### PR TITLE
Feature/replies support Add bidirectional reply message support between Matrix and Meshtastic

### DIFF
--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -45,14 +45,13 @@ def get_db_path():
     if config is not None:
         # Hash only the database-related config sections
         db_config = {
-            'database': config.get('database', {}),
-            'db': config.get('db', {})  # Legacy format
+            "database": config.get("database", {}),
+            "db": config.get("db", {}),  # Legacy format
         }
         current_config_hash = hash(str(sorted(db_config.items())))
 
     # Check if cache is valid (path exists and config hasn't changed)
-    if (_cached_db_path is not None and
-        current_config_hash == _cached_config_hash):
+    if _cached_db_path is not None and current_config_hash == _cached_config_hash:
         return _cached_db_path
 
     # Config changed or first call - clear cache and re-resolve

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -466,7 +466,7 @@ def format_reply_message(full_display_name, text):
     return truncate_message(reply_message)
 
 
-async def send_reply_to_meshtastic(reply_message, full_display_name, room_config, event, text, storage_enabled, local_meshnet_name):
+async def send_reply_to_meshtastic(reply_message, full_display_name, room_config, room, event, text, storage_enabled, local_meshnet_name):
     """
     Send a reply message to Meshtastic and handle storage.
 
@@ -474,6 +474,7 @@ async def send_reply_to_meshtastic(reply_message, full_display_name, room_config
         reply_message (str): The formatted reply message
         full_display_name (str): The user's display name
         room_config (dict): Room configuration
+        room: The Matrix room object
         event: The Matrix event
         text (str): Original reply text
         storage_enabled (bool): Whether message storage is enabled
@@ -500,7 +501,7 @@ async def send_reply_to_meshtastic(reply_message, full_display_name, room_config
                 store_message_map(
                     sent_packet.id,
                     event.event_id,
-                    event.room_id,
+                    room.room_id,
                     cleaned_text,
                     meshtastic_meshnet=local_meshnet_name,
                 )
@@ -543,7 +544,7 @@ async def handle_matrix_reply(room, event, reply_to_event_id, text, room_config,
 
     # Send the reply to Meshtastic
     await send_reply_to_meshtastic(
-        reply_message, full_display_name, room_config, event, text, storage_enabled, local_meshnet_name
+        reply_message, full_display_name, room_config, room, event, text, storage_enabled, local_meshnet_name
     )
 
     return True  # Reply was handled, stop further processing

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -274,17 +274,25 @@ async def matrix_relay(
             # For Matrix replies, we need to format the body with quoted content
             # Get the original message details for proper quoting
             try:
-                from mmrelay.db_utils import get_message_map_by_matrix_event_id
                 orig = get_message_map_by_matrix_event_id(reply_to_event_id)
                 if orig:
                     # orig = (meshtastic_id, matrix_room_id, meshtastic_text, meshtastic_meshnet)
                     _, _, original_text, original_meshnet = orig
+
+                    # Use the relay bot's user ID for attribution (this is correct for relay messages)
+                    bot_user_id = matrix_client.user_id
+                    original_sender_display = f"{longname}/{original_meshnet}"
+
                     # Create the quoted reply format
-                    quoted_text = f"> <@{matrix_client.user_id}> [{longname}/{original_meshnet}]: {original_text}"
+                    quoted_text = f"> <@{bot_user_id}> [{original_sender_display}]: {original_text}"
                     content["body"] = f"{quoted_text}\n\n{message}"
                     content["format"] = "org.matrix.custom.html"
-                    # Create formatted HTML version
-                    content["formatted_body"] = f'<mx-reply><blockquote><a href="https://matrix.to/#/{room_id}/{reply_to_event_id}">In reply to</a> <a href="https://matrix.to/#/@{matrix_client.user_id}">@{matrix_client.user_id}</a><br>[{longname}/{original_meshnet}]: {original_text}</blockquote></mx-reply>{message}'
+
+                    # Create formatted HTML version with better readability
+                    reply_link = f"https://matrix.to/#/{room_id}/{reply_to_event_id}"
+                    bot_link = f"https://matrix.to/#/@{bot_user_id}"
+                    blockquote_content = f'<a href="{reply_link}">In reply to</a> <a href="{bot_link}">@{bot_user_id}</a><br>[{original_sender_display}]: {original_text}'
+                    content["formatted_body"] = f'<mx-reply><blockquote>{blockquote_content}</blockquote></mx-reply>{message}'
                 else:
                     logger.warning(f"Could not find original message for reply_to_event_id: {reply_to_event_id}")
             except Exception as e:
@@ -370,6 +378,85 @@ def strip_quoted_lines(text: str) -> str:
     lines = text.splitlines()
     filtered = [line for line in lines if not line.strip().startswith(">")]
     return " ".join(filtered).strip()
+
+
+async def handle_matrix_reply(room, event, reply_to_event_id, text, room_config, relay_reactions, local_meshnet_name):
+    """
+    Handle Matrix replies to Meshtastic messages.
+
+    Returns:
+        bool: True if the reply was handled and processing should stop, False otherwise.
+    """
+    # Look up the original message in the message map
+    orig = get_message_map_by_matrix_event_id(reply_to_event_id)
+    if not orig:
+        logger.debug(f"Original message for Matrix reply not found in DB: {reply_to_event_id}")
+        return False  # Continue processing as normal message if original not found
+
+    # orig = (meshtastic_id, matrix_room_id, meshtastic_text, meshtastic_meshnet)
+    original_meshtastic_id, _, _, _ = orig
+
+    # Get user display name
+    room_display_name = room.user_name(event.sender)
+    if room_display_name:
+        full_display_name = room_display_name
+    else:
+        display_name_response = await matrix_client.get_displayname(event.sender)
+        full_display_name = display_name_response.displayname or event.sender
+
+    short_display_name = full_display_name[:5]
+    prefix = f"{short_display_name}[M]: "
+
+    # Strip quoted content from the reply text
+    clean_text = strip_quoted_lines(text)
+    reply_message = f"{prefix}{clean_text}"
+    reply_message = truncate_message(reply_message)
+
+    logger.info(f"Relaying Matrix reply from {full_display_name} to Meshtastic")
+
+    # Send the reply to Meshtastic with replyId
+    meshtastic_interface = connect_meshtastic()
+    from mmrelay.meshtastic_utils import logger as meshtastic_logger
+
+    meshtastic_channel = room_config["meshtastic_channel"]
+
+    if config["meshtastic"]["broadcast_enabled"]:
+        try:
+            # Send as a reply with the original meshtastic_id as replyId
+            sent_packet = meshtastic_interface.sendText(
+                text=reply_message,
+                channelIndex=meshtastic_channel,
+                replyId=original_meshtastic_id
+            )
+            meshtastic_logger.info(f"Relaying Matrix reply from {full_display_name} to radio broadcast")
+
+            # Store the reply in message map if relay_reactions is enabled
+            if relay_reactions and sent_packet and hasattr(sent_packet, "id"):
+                # Strip quoted lines from text before storing to prevent issues with reactions to replies
+                cleaned_text = strip_quoted_lines(text)
+                store_message_map(
+                    sent_packet.id,
+                    event.event_id,
+                    room.room_id,
+                    cleaned_text,
+                    meshtastic_meshnet=local_meshnet_name,
+                )
+                # Prune old messages if configured
+                database_config = config.get("database", {})
+                msg_map_config = database_config.get("msg_map", {})
+                if not msg_map_config:
+                    db_config = config.get("db", {})
+                    legacy_msg_map_config = db_config.get("msg_map", {})
+                    if legacy_msg_map_config:
+                        msg_map_config = legacy_msg_map_config
+                msgs_to_keep = msg_map_config.get("msgs_to_keep", 500)
+                if msgs_to_keep > 0:
+                    prune_message_map(msgs_to_keep)
+
+        except Exception as e:
+            meshtastic_logger.error(f"Error sending Matrix reply to Meshtastic: {e}")
+
+    return True  # Reply was handled, stop further processing
 
 
 # Callback for new messages in Matrix room
@@ -604,75 +691,11 @@ async def on_room_message(
 
     # Handle Matrix replies to Meshtastic messages
     if is_reply and reply_to_event_id:
-        # Look up the original message in the message map
-        orig = get_message_map_by_matrix_event_id(reply_to_event_id)
-        if orig:
-            # orig = (meshtastic_id, matrix_room_id, meshtastic_text, meshtastic_meshnet)
-            original_meshtastic_id, _, _, _ = orig
-
-            # Get user display name
-            room_display_name = room.user_name(event.sender)
-            if room_display_name:
-                full_display_name = room_display_name
-            else:
-                display_name_response = await matrix_client.get_displayname(event.sender)
-                full_display_name = display_name_response.displayname or event.sender
-
-            short_display_name = full_display_name[:5]
-            prefix = f"{short_display_name}[M]: "
-
-            # Strip quoted content from the reply text
-            clean_text = strip_quoted_lines(text)
-            reply_message = f"{prefix}{clean_text}"
-            reply_message = truncate_message(reply_message)
-
-            logger.info(f"Relaying Matrix reply from {full_display_name} to Meshtastic")
-
-            # Send the reply to Meshtastic with replyId
-            meshtastic_interface = connect_meshtastic()
-            from mmrelay.meshtastic_utils import logger as meshtastic_logger
-
-            meshtastic_channel = room_config["meshtastic_channel"]
-
-            if config["meshtastic"]["broadcast_enabled"]:
-                try:
-                    # Send as a reply with the original meshtastic_id as replyId
-                    sent_packet = meshtastic_interface.sendText(
-                        text=reply_message,
-                        channelIndex=meshtastic_channel,
-                        replyId=original_meshtastic_id
-                    )
-                    meshtastic_logger.info(f"Relaying Matrix reply from {full_display_name} to radio broadcast")
-
-                    # Store the reply in message map if relay_reactions is enabled
-                    if relay_reactions and sent_packet and hasattr(sent_packet, "id"):
-                        # Strip quoted lines from text before storing to prevent issues with reactions to replies
-                        cleaned_text = strip_quoted_lines(text)
-                        store_message_map(
-                            sent_packet.id,
-                            event.event_id,
-                            room.room_id,
-                            cleaned_text,
-                            meshtastic_meshnet=local_meshnet_name,
-                        )
-                        # Prune old messages if configured
-                        database_config = config.get("database", {})
-                        msg_map_config = database_config.get("msg_map", {})
-                        if not msg_map_config:
-                            db_config = config.get("db", {})
-                            legacy_msg_map_config = db_config.get("msg_map", {})
-                            if legacy_msg_map_config:
-                                msg_map_config = legacy_msg_map_config
-                        msgs_to_keep = msg_map_config.get("msgs_to_keep", 500)
-                        if msgs_to_keep > 0:
-                            prune_message_map(msgs_to_keep)
-
-                except Exception as e:
-                    meshtastic_logger.error(f"Error sending Matrix reply to Meshtastic: {e}")
+        reply_handled = await handle_matrix_reply(
+            room, event, reply_to_event_id, text, room_config, relay_reactions, local_meshnet_name
+        )
+        if reply_handled:
             return
-        else:
-            logger.debug(f"Original message for Matrix reply not found in DB: {reply_to_event_id}")
-            # Continue processing as normal message if original not found
 
     # For Matrix->Mesh messages from a remote meshnet, rewrite the message format
     if longname and meshnet_name:

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -55,15 +55,6 @@ def get_interaction_settings(config):
             'replies': interactions.get('replies', False)
         }
 
-    # Check for enable_message_interactions (previous implementation)
-    if "enable_message_interactions" in meshtastic_config:
-        enabled = meshtastic_config["enable_message_interactions"]
-        logger.warning(
-            "Configuration setting 'enable_message_interactions' is deprecated. "
-            "Please use 'message_interactions: {reactions: bool, replies: bool}' instead."
-        )
-        return {'reactions': enabled, 'replies': enabled}
-
     # Fall back to legacy relay_reactions setting
     if "relay_reactions" in meshtastic_config:
         enabled = meshtastic_config["relay_reactions"]

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -12,6 +12,7 @@ import meshtastic.tcp_interface
 import serial  # For serial port exceptions
 import serial.tools.list_ports  # Import serial tools for port listing
 from bleak.exc import BleakDBusError, BleakError
+from meshtastic.protobuf import mesh_pb2, portnums_pb2
 from pubsub import pub
 
 from mmrelay.db_utils import (
@@ -323,7 +324,7 @@ async def reconnect():
 def on_meshtastic_message(packet, interface):
     """
     Processes incoming Meshtastic messages and relays them to Matrix rooms or plugins based on message type and interaction settings.
-    
+
     Handles reactions and replies by relaying them to Matrix if enabled in the interaction settings. Normal text messages are relayed to all mapped Matrix rooms unless handled by a plugin or directed to the relay node. Non-text messages are passed to plugins for processing. Filters out messages from unmapped channels or disabled detection sensors, and ensures sender information is retrieved or stored as needed.
     """
     global config, matrix_rooms
@@ -346,13 +347,17 @@ def on_meshtastic_message(packet, interface):
 
     # Get interaction settings
     interactions = get_interaction_settings(config)
-    storage_enabled = message_storage_enabled(interactions)
+    message_storage_enabled(interactions)
 
     # Filter packets based on interaction settings
     if packet.get("decoded", {}).get("portnum") == "TEXT_MESSAGE_APP":
         decoded = packet.get("decoded", {})
         # Filter out reactions if reactions are disabled
-        if not interactions['reactions'] and "emoji" in decoded and decoded.get("emoji") == 1:
+        if (
+            not interactions["reactions"]
+            and "emoji" in decoded
+            and decoded.get("emoji") == 1
+        ):
             logger.debug(
                 "Filtered out reaction packet due to reactions being disabled."
             )
@@ -397,7 +402,7 @@ def on_meshtastic_message(packet, interface):
 
     # Reaction handling (Meshtastic -> Matrix)
     # If replyId and emoji_flag are present and reactions are enabled, we relay as text reactions in Matrix
-    if replyId and emoji_flag and interactions['reactions']:
+    if replyId and emoji_flag and interactions["reactions"]:
         longname = get_longname(sender) or str(sender)
         shortname = get_shortname(sender) or str(sender)
         orig = get_message_map_by_meshtastic_id(replyId)
@@ -439,7 +444,7 @@ def on_meshtastic_message(packet, interface):
 
     # Reply handling (Meshtastic -> Matrix)
     # If replyId is present but emoji is not (or not 1), this is a reply
-    if replyId and not emoji_flag and interactions['replies']:
+    if replyId and not emoji_flag and interactions["replies"]:
         longname = get_longname(sender) or str(sender)
         shortname = get_shortname(sender) or str(sender)
         orig = get_message_map_by_meshtastic_id(replyId)
@@ -654,6 +659,51 @@ async def check_connection():
                 logger.error(f"{connection_type.capitalize()} connection lost: {e}")
                 on_lost_meshtastic_connection(meshtastic_client)
         await asyncio.sleep(30)  # Check connection every 30 seconds
+
+
+def sendTextReply(
+    interface,
+    text: str,
+    reply_id: int,
+    destinationId=meshtastic.BROADCAST_ADDR,
+    wantAck: bool = False,
+    channelIndex: int = 0,
+):
+    """
+    Send a text message as a reply to a previous message.
+
+    This function creates a proper Meshtastic reply by setting the reply_id field
+    in the Data protobuf message, which the standard sendText() method doesn't support.
+
+    Args:
+        interface: The Meshtastic interface to send through
+        text: The text message to send
+        reply_id: The ID of the message this is replying to
+        destinationId: Where to send the message (default: broadcast)
+        wantAck: Whether to request acknowledgment
+        channelIndex: Which channel to send on
+
+    Returns:
+        The sent packet with populated ID field
+    """
+    logger.debug(f"Sending text reply: '{text}' replying to message ID {reply_id}")
+
+    # Create the Data protobuf message with reply_id set
+    data_msg = mesh_pb2.Data()
+    data_msg.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+    data_msg.payload = text.encode("utf-8")
+    data_msg.reply_id = reply_id
+
+    # Create the MeshPacket
+    mesh_packet = mesh_pb2.MeshPacket()
+    mesh_packet.channel = channelIndex
+    mesh_packet.decoded.CopyFrom(data_msg)
+    mesh_packet.id = interface._generatePacketId()
+
+    # Send the packet using the existing infrastructure
+    return interface._sendPacket(
+        mesh_packet, destinationId=destinationId, wantAck=wantAck
+    )
 
 
 if __name__ == "__main__":

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -322,9 +322,9 @@ async def reconnect():
 
 def on_meshtastic_message(packet, interface):
     """
-    Handle incoming Meshtastic messages. For reaction messages, if relay_reactions is False,
-    we do not store message maps and thus won't be able to relay reactions back to Matrix.
-    If relay_reactions is True, message maps are stored inside matrix_relay().
+    Processes incoming Meshtastic messages and relays them to Matrix rooms or plugins based on message type and interaction settings.
+    
+    Handles reactions and replies by relaying them to Matrix if enabled in the interaction settings. Normal text messages are relayed to all mapped Matrix rooms unless handled by a plugin or directed to the relay node. Non-text messages are passed to plugins for processing. Filters out messages from unmapped channels or disabled detection sensors, and ensures sender information is retrieved or stored as needed.
     """
     global config, matrix_rooms
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -341,17 +341,20 @@ def on_meshtastic_message(packet, interface):
         logger.error("No configuration available. Cannot process Meshtastic message.")
         return
 
-    # Apply reaction filtering based on config
-    relay_reactions = config["meshtastic"].get("relay_reactions", False)
+    # Import the configuration helper
+    from mmrelay.matrix_utils import get_message_interactions_enabled
 
-    # If relay_reactions is False, filter out reaction packets to avoid complexity
-    # Note: We allow replies even when relay_reactions is False, but filter reactions
+    # Check if message interactions (reactions/replies) are enabled
+    message_interactions_enabled = get_message_interactions_enabled(config)
+
+    # Filter packets based on message interactions setting
     if packet.get("decoded", {}).get("portnum") == "TEXT_MESSAGE_APP":
         decoded = packet.get("decoded", {})
-        # Only filter out reactions (emoji=1), not replies (replyId without emoji)
-        if not relay_reactions and "emoji" in decoded and decoded.get("emoji") == 1:
+        # Filter out reactions if message interactions are disabled
+        # Note: We allow replies to pass through for basic functionality, but they won't be stored
+        if not message_interactions_enabled and "emoji" in decoded and decoded.get("emoji") == 1:
             logger.debug(
-                "Filtered out reaction packet due to relay_reactions=false."
+                "Filtered out reaction packet due to message interactions being disabled."
             )
             return
 
@@ -393,8 +396,8 @@ def on_meshtastic_message(packet, interface):
     meshnet_name = config["meshtastic"]["meshnet_name"]
 
     # Reaction handling (Meshtastic -> Matrix)
-    # If replyId and emoji_flag are present and relay_reactions is True, we relay as text reactions in Matrix
-    if replyId and emoji_flag and relay_reactions:
+    # If replyId and emoji_flag are present and message interactions are enabled, we relay as text reactions in Matrix
+    if replyId and emoji_flag and message_interactions_enabled:
         longname = get_longname(sender) or str(sender)
         shortname = get_shortname(sender) or str(sender)
         orig = get_message_map_by_meshtastic_id(replyId)

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -18,8 +18,10 @@ meshtastic:
   broadcast_enabled: true # Must be set to true to enable Matrix to Meshtastic messages
   detection_sensor: true # Must be set to true to forward messages of Meshtastic's detection sensor module
   plugin_response_delay: 3 # Default response delay in seconds for plugins that respond on the mesh;
-  enable_message_interactions: false # Enable reactions and replies (requires message storage in database)
-  # relay_reactions: false # DEPRECATED: Use enable_message_interactions instead
+  message_interactions: # Configure reactions and replies (both require message storage in database)
+    reactions: false # Enable reaction relaying between platforms
+    replies: false   # Enable reply relaying between platforms
+  # Note: Legacy 'relay_reactions' setting is deprecated but still supported
 
 logging:
   level: info

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -18,7 +18,8 @@ meshtastic:
   broadcast_enabled: true # Must be set to true to enable Matrix to Meshtastic messages
   detection_sensor: true # Must be set to true to forward messages of Meshtastic's detection sensor module
   plugin_response_delay: 3 # Default response delay in seconds for plugins that respond on the mesh;
-  relay_reactions: true # Defaults to false, set to true to enable relay reactions between platforms
+  enable_message_interactions: false # Enable reactions and replies (requires message storage in database)
+  # relay_reactions: false # DEPRECATED: Use enable_message_interactions instead
 
 logging:
   level: info


### PR DESCRIPTION
@coderabbitai update summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for relaying reply messages between Matrix and Meshtastic, preserving conversational context across both platforms.
  - Introduced separate controls for enabling reactions and replies in message interactions.
  - Enabled sending Meshtastic text messages as replies with proper linking to original messages.
- **Bug Fixes**
  - Improved handling to ensure reactions and replies are correctly differentiated and processed according to user settings.
- **Chores**
  - Updated configuration to replace a single reaction flag with distinct reaction and reply settings, maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->