### PR TITLE
Fix code coverage setup with proper test isolation

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: "en-US"
+language: en-US
 early_access: true
 reviews:
-  profile: "chill"
+  profile: chill
   request_changes_workflow: false
   high_level_summary: true
   poem: true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,34 @@
+[run]
+source = src/mmrelay
+omit = 
+    */tests/*
+    */test_*
+    */__pycache__/*
+    */venv/*
+    */env/*
+    */.venv/*
+    */build/*
+    */dist/*
+    */setup.py
+    */conftest.py
+branch = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod
+ignore_errors = True
+
+[html]
+directory = htmlcov
+
+[xml]
+output = coverage.xml

--- a/.github/workflows/build-armv7-builder-image.yml
+++ b/.github/workflows/build-armv7-builder-image.yml
@@ -4,17 +4,20 @@ on:
   workflow_dispatch:
     inputs:
       push_image:
-        description: "Push image to registry"
+        description: Push image to registry
         required: false
         default: true
         type: boolean
   schedule:
     # Rebuild monthly to keep dependencies fresh
-    - cron: "0 2 1 * *"
+    - cron: 0 2 1 * *
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: jeremiah-k/mmrelay-builder-armv7
+
+permissions:
+  contents: read
 
 jobs:
   build-armv7-builder:

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          python -m pytest tests/ -v --junitxml=junit.xml
+          python -m pytest tests/ -v --cov --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.11'

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -1,0 +1,49 @@
+name: Tests and Coverage
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run tests with coverage
+      run: |
+        python -m pytest tests/ -v
+
+    - name: Upload coverage reports to Codecov
+      if: matrix.python-version == '3.11'
+      uses: codecov/codecov-action@v5
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -2,10 +2,13 @@ name: Tests and Coverage
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -15,35 +18,39 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache pip dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-    - name: Run tests with coverage
-      run: |
-        python -m pytest tests/ -v
+      - name: Run tests with coverage
+        run: |
+          python -m pytest tests/ -v
 
-    - name: Upload coverage reports to Codecov
-      if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v5
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
+      - name: Upload coverage reports to Codecov
+        if: matrix.python-version == '3.11'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: jeremiah-k/meshtastic-matrix-relay
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          python -m pytest tests/ -v
+          python -m pytest tests/ -v --junitxml=junit.xml
 
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.11'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ src/mmrelay.egg-info
 # Docker files (use samples from src/mmrelay/tools/)
 docker-compose.yaml
 .env
+
+# Coverage files
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+.pytest_cache/

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -22,7 +22,7 @@ If you want to contribute or modify the code:
 
 ```bash
 # Clone the repository
-git clone https://github.com/geoffwhittington/meshtastic-matrix-relay.git
+git clone https://github.com/jeremiah-k/meshtastic-matrix-relay.git
 cd meshtastic-matrix-relay
 
 # Install in development mode using pipx (recommended)
@@ -165,7 +165,7 @@ MMRelay includes official Docker support for easy deployment and management. Doc
 
 ```bash
 # Clone the repository (if you haven't already)
-git clone https://github.com/geoffwhittington/meshtastic-matrix-relay.git
+git clone https://github.com/jeremiah-k/meshtastic-matrix-relay.git
 cd meshtastic-matrix-relay
 
 # Set up configuration and start

--- a/docs/UPGRADE_TO_V1.md
+++ b/docs/UPGRADE_TO_V1.md
@@ -56,7 +56,7 @@ If you want to contribute or modify the code:
 
 ```bash
 # Clone the repository (or pull latest changes)
-git clone https://github.com/geoffwhittington/meshtastic-matrix-relay.git
+git clone https://github.com/jeremiah-k/meshtastic-matrix-relay.git
 cd meshtastic-matrix-relay
 
 # Install in editable mode for development
@@ -210,5 +210,5 @@ Your existing configuration will continue to work without changes. The applicati
 ### Getting Help
 
 - Join our Matrix room: [#mmrelay:meshnet.club](https://matrix.to/#/#mmrelay:meshnet.club)
-- Open an issue on GitHub: [meshtastic-matrix-relay](https://github.com/geoffwhittington/meshtastic-matrix-relay/issues)
+- Open an issue on GitHub: [meshtastic-matrix-relay](https://github.com/jeremiah-k/meshtastic-matrix-relay/issues)
 - Check the wiki for additional documentation

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,19 @@
+[tool:pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = 
+    --cov=src/mmrelay
+    --cov-report=xml
+    --cov-report=html
+    --cov-report=term-missing
+    --cov-branch
+    --strict-markers
+    --disable-warnings
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    integration: marks tests as integration tests
+    unit: marks tests as unit tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,9 +10,10 @@ addopts =
     --cov-report=term-missing
     --cov-branch
     --strict-markers
-    --disable-warnings
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
+env =
+    MMRELAY_TESTING=1
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,9 @@ platformdirs==4.3.8
 py-staticmaps>=0.4.0
 rich==14.1.0
 setuptools==80.9.0
+
+# Testing and coverage
+coverage==7.6.9
+pytest==8.3.4
+pytest-cov==6.0.0
+pytest-asyncio==0.25.0

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
     description="Bridge between Meshtastic mesh networks and Matrix chat rooms",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/geoffwhittington/meshtastic-matrix-relay",
+    url="https://github.com/jeremiah-k/meshtastic-matrix-relay",
     project_urls={
-        "Bug Tracker": "https://github.com/geoffwhittington/meshtastic-matrix-relay/issues"
+        "Bug Tracker": "https://github.com/jeremiah-k/meshtastic-matrix-relay/issues"
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -69,12 +69,12 @@ def configure_component_debug_logging():
 def get_logger(name):
     """
     Create and configure a logger with console and optional rotating file output, using global configuration and command-line arguments.
-
-    The logger supports colorized console output via Rich if enabled, and writes logs to a rotating file if configured or requested via command-line arguments. Log file location and rotation parameters are determined by priority: command-line argument, configuration file, or a default directory. The function ensures the log directory exists and stores the log file path globally if the logger name is "M<>M Relay".
-
+    
+    The logger supports colorized console output if enabled, and writes logs to a rotating file if configured or requested via command-line arguments. Log file location and rotation parameters are determined by priority: command-line argument, configuration file, or a default directory. The log directory is created if it does not exist, and the log file path is stored globally if the logger name is "M<>M Relay".
+    
     Parameters:
         name (str): The name of the logger to create and configure.
-
+    
     Returns:
         logging.Logger: The configured logger instance.
     """

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -126,7 +126,8 @@ def get_logger(name):
     try:
         # Only parse arguments if we're not in a test environment
         import sys
-        if 'pytest' not in sys.modules and 'unittest' not in sys.modules:
+        import os
+        if not os.environ.get("MMRELAY_TESTING"):
             from mmrelay.cli import parse_arguments
             args = parse_arguments()
     except (SystemExit, ImportError):

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from logging.handlers import RotatingFileHandler
 
 from rich.console import Console
@@ -69,12 +68,12 @@ def configure_component_debug_logging():
 def get_logger(name):
     """
     Create and configure a logger with console and optional rotating file output, using global configuration and command-line arguments.
-    
+
     The logger supports colorized console output if enabled, and writes logs to a rotating file if configured or requested via command-line arguments. Log file location and rotation parameters are determined by priority: command-line argument, configuration file, or a default directory. The log directory is created if it does not exist, and the log file path is stored globally if the logger name is "M<>M Relay".
-    
+
     Parameters:
         name (str): The name of the logger to create and configure.
-    
+
     Returns:
         logging.Logger: The configured logger instance.
     """
@@ -125,7 +124,6 @@ def get_logger(name):
     args = None
     try:
         # Only parse arguments if we're not in a test environment
-        import sys
         import os
         if not os.environ.get("MMRELAY_TESTING"):
             from mmrelay.cli import parse_arguments

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,11 @@ _BUILTIN_MODULES = {
 }
 
 def ensure_builtins_not_mocked():
-    """Ensure that Python built-in modules are not accidentally mocked."""
+    """
+    Restores original Python built-in modules if they have been accidentally mocked during testing.
+    
+    This function checks for mocked versions of critical built-in modules and replaces them with their original references. It also reloads the logging module if it was mocked to ensure proper logging functionality is maintained.
+    """
     for name, module in _BUILTIN_MODULES.items():
         if name in sys.modules and hasattr(sys.modules[name], '_mock_name'):
             # Restore the original module if it was mocked

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,66 +5,71 @@ This file sets up comprehensive mocking for external dependencies
 to ensure tests can run without requiring actual hardware or network connections.
 """
 
+import asyncio
+import logging
+
+# Preserve references to built-in modules that should NOT be mocked
+import queue
 import sys
+import threading
+import time
 from unittest.mock import MagicMock
 
 # Mock all external dependencies before any imports
 # This prevents ImportError and allows tests to run in isolation
 
-# Preserve references to built-in modules that should NOT be mocked
-import queue
-import logging
-import asyncio
-import threading
-import time
 
 # Store references to prevent accidental mocking
 _BUILTIN_MODULES = {
-    'queue': queue,
-    'logging': logging,
-    'asyncio': asyncio,
-    'threading': threading,
-    'time': time,
+    "queue": queue,
+    "logging": logging,
+    "asyncio": asyncio,
+    "threading": threading,
+    "time": time,
 }
+
 
 def ensure_builtins_not_mocked():
     """
     Restores original Python built-in modules if they have been accidentally mocked during testing.
-    
+
     This function checks for mocked versions of critical built-in modules and replaces them with their original references. It also reloads the logging module if it was mocked to ensure proper logging functionality is maintained.
     """
     for name, module in _BUILTIN_MODULES.items():
-        if name in sys.modules and hasattr(sys.modules[name], '_mock_name'):
+        if name in sys.modules and hasattr(sys.modules[name], "_mock_name"):
             # Restore the original module if it was mocked
             sys.modules[name] = module
 
     # Extra protection for logging system
     import logging
-    if hasattr(logging, '_mock_name'):
+
+    if hasattr(logging, "_mock_name"):
         # If logging itself got mocked, restore it
         import importlib
+
         importlib.reload(logging)
+
 
 # Mock Meshtastic modules comprehensively
 meshtastic_mock = MagicMock()
-sys.modules['meshtastic'] = meshtastic_mock
-sys.modules['meshtastic.protobuf'] = MagicMock()
-sys.modules['meshtastic.protobuf.portnums_pb2'] = MagicMock()
-sys.modules['meshtastic.protobuf.portnums_pb2'].PortNum = MagicMock()
-sys.modules['meshtastic.protobuf.portnums_pb2'].PortNum.DETECTION_SENSOR_APP = 1
-sys.modules['meshtastic.protobuf.mesh_pb2'] = MagicMock()
-sys.modules['meshtastic.ble_interface'] = MagicMock()
-sys.modules['meshtastic.serial_interface'] = MagicMock()
-sys.modules['meshtastic.tcp_interface'] = MagicMock()
+sys.modules["meshtastic"] = meshtastic_mock
+sys.modules["meshtastic.protobuf"] = MagicMock()
+sys.modules["meshtastic.protobuf.portnums_pb2"] = MagicMock()
+sys.modules["meshtastic.protobuf.portnums_pb2"].PortNum = MagicMock()
+sys.modules["meshtastic.protobuf.portnums_pb2"].PortNum.DETECTION_SENSOR_APP = 1
+sys.modules["meshtastic.protobuf.mesh_pb2"] = MagicMock()
+sys.modules["meshtastic.ble_interface"] = MagicMock()
+sys.modules["meshtastic.serial_interface"] = MagicMock()
+sys.modules["meshtastic.tcp_interface"] = MagicMock()
 
 # Set up meshtastic constants
 meshtastic_mock.BROADCAST_ADDR = "^all"
 
 # Mock Matrix-nio modules comprehensively
 nio_mock = MagicMock()
-sys.modules['nio'] = nio_mock
-sys.modules['nio.events'] = MagicMock()
-sys.modules['nio.events.room_events'] = MagicMock()
+sys.modules["nio"] = nio_mock
+sys.modules["nio.events"] = MagicMock()
+sys.modules["nio.events.room_events"] = MagicMock()
 
 # Mock specific nio classes that are imported directly
 nio_mock.AsyncClient = MagicMock()
@@ -78,48 +83,49 @@ nio_mock.UploadResponse = MagicMock()
 nio_mock.WhoamiError = MagicMock()
 
 # Mock RoomMemberEvent from nio.events.room_events
-sys.modules['nio.events.room_events'].RoomMemberEvent = MagicMock()
+sys.modules["nio.events.room_events"].RoomMemberEvent = MagicMock()
 
 # Mock PIL/Pillow
-sys.modules['PIL'] = MagicMock()
-sys.modules['PIL.Image'] = MagicMock()
+sys.modules["PIL"] = MagicMock()
+sys.modules["PIL.Image"] = MagicMock()
 
 # Mock other external dependencies (but avoid Python built-ins)
-sys.modules['certifi'] = MagicMock()
-sys.modules['serial'] = MagicMock()
-sys.modules['serial.tools'] = MagicMock()
-sys.modules['serial.tools.list_ports'] = MagicMock()
-sys.modules['bleak'] = MagicMock()
-sys.modules['bleak.exc'] = MagicMock()
-sys.modules['pubsub'] = MagicMock()
-sys.modules['matplotlib'] = MagicMock()
-sys.modules['matplotlib.pyplot'] = MagicMock()
-sys.modules['requests'] = MagicMock()
-sys.modules['markdown'] = MagicMock()
-sys.modules['haversine'] = MagicMock()
-sys.modules['schedule'] = MagicMock()
-sys.modules['platformdirs'] = MagicMock()
-sys.modules['py_staticmaps'] = MagicMock()
+sys.modules["certifi"] = MagicMock()
+sys.modules["serial"] = MagicMock()
+sys.modules["serial.tools"] = MagicMock()
+sys.modules["serial.tools.list_ports"] = MagicMock()
+sys.modules["bleak"] = MagicMock()
+sys.modules["bleak.exc"] = MagicMock()
+sys.modules["pubsub"] = MagicMock()
+sys.modules["matplotlib"] = MagicMock()
+sys.modules["matplotlib.pyplot"] = MagicMock()
+sys.modules["requests"] = MagicMock()
+sys.modules["markdown"] = MagicMock()
+sys.modules["haversine"] = MagicMock()
+sys.modules["schedule"] = MagicMock()
+sys.modules["platformdirs"] = MagicMock()
+sys.modules["py_staticmaps"] = MagicMock()
 
 # Mock Rich modules but preserve rich.logging for proper logging functionality
 # Import the real rich module first to preserve its structure
 try:
     import rich
-    import rich.logging
     import rich.console
+    import rich.logging
+
     # Keep the real rich module but mock specific components
     rich_mock = rich
     rich_mock.Console = MagicMock
-    sys.modules['rich.console'] = MagicMock()
+    sys.modules["rich.console"] = MagicMock()
 except ImportError:
     # If rich is not available, create a minimal mock that won't interfere with logging
     rich_mock = MagicMock()
-    sys.modules['rich'] = rich_mock
-    sys.modules['rich.console'] = MagicMock()
+    sys.modules["rich"] = rich_mock
+    sys.modules["rich.console"] = MagicMock()
     # Create a minimal rich.logging mock that won't break the logging system
     rich_logging_mock = MagicMock()
     rich_logging_mock.RichHandler = MagicMock
-    sys.modules['rich.logging'] = rich_logging_mock
+    sys.modules["rich.logging"] = rich_logging_mock
 
 # Ensure built-in modules are not accidentally mocked
 ensure_builtins_not_mocked()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,13 @@ def ensure_builtins_not_mocked():
             # Restore the original module if it was mocked
             sys.modules[name] = module
 
+    # Extra protection for logging system
+    import logging
+    if hasattr(logging, '_mock_name'):
+        # If logging itself got mocked, restore it
+        import importlib
+        importlib.reload(logging)
+
 # Mock Meshtastic modules comprehensively
 meshtastic_mock = MagicMock()
 sys.modules['meshtastic'] = meshtastic_mock
@@ -90,16 +97,14 @@ sys.modules['schedule'] = MagicMock()
 sys.modules['platformdirs'] = MagicMock()
 sys.modules['py_staticmaps'] = MagicMock()
 
-# Mock Rich modules with more specific behavior
+# Mock Rich modules but avoid interfering with logging system
 rich_mock = MagicMock()
 sys.modules['rich'] = rich_mock
 sys.modules['rich.console'] = MagicMock()
-sys.modules['rich.logging'] = MagicMock()
 
-# Set up Rich console mock to avoid logging issues
+# Don't mock rich.logging at all - let it use the real logging system
+# This prevents interference with Python's logging handlers
 rich_mock.Console = MagicMock
-rich_mock.logging = MagicMock()
-rich_mock.logging.RichHandler = MagicMock
 
 # Ensure built-in modules are not accidentally mocked
 ensure_builtins_not_mocked()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+"""
+Pytest configuration and fixtures for MMRelay tests.
+
+This file sets up comprehensive mocking for external dependencies
+to ensure tests can run without requiring actual hardware or network connections.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# Mock all external dependencies before any imports
+# This prevents ImportError and allows tests to run in isolation
+
+# Mock Meshtastic modules comprehensively
+meshtastic_mock = MagicMock()
+sys.modules['meshtastic'] = meshtastic_mock
+sys.modules['meshtastic.protobuf'] = MagicMock()
+sys.modules['meshtastic.protobuf.portnums_pb2'] = MagicMock()
+sys.modules['meshtastic.protobuf.portnums_pb2'].PortNum = MagicMock()
+sys.modules['meshtastic.protobuf.portnums_pb2'].PortNum.DETECTION_SENSOR_APP = 1
+sys.modules['meshtastic.protobuf.mesh_pb2'] = MagicMock()
+sys.modules['meshtastic.ble_interface'] = MagicMock()
+sys.modules['meshtastic.serial_interface'] = MagicMock()
+sys.modules['meshtastic.tcp_interface'] = MagicMock()
+
+# Set up meshtastic constants
+meshtastic_mock.BROADCAST_ADDR = "^all"
+
+# Mock Matrix-nio modules comprehensively
+nio_mock = MagicMock()
+sys.modules['nio'] = nio_mock
+sys.modules['nio.events'] = MagicMock()
+sys.modules['nio.events.room_events'] = MagicMock()
+
+# Mock specific nio classes that are imported directly
+nio_mock.AsyncClient = MagicMock()
+nio_mock.AsyncClientConfig = MagicMock()
+nio_mock.MatrixRoom = MagicMock()
+nio_mock.ReactionEvent = MagicMock()
+nio_mock.RoomMessageEmote = MagicMock()
+nio_mock.RoomMessageNotice = MagicMock()
+nio_mock.RoomMessageText = MagicMock()
+nio_mock.UploadResponse = MagicMock()
+nio_mock.WhoamiError = MagicMock()
+
+# Mock RoomMemberEvent from nio.events.room_events
+sys.modules['nio.events.room_events'].RoomMemberEvent = MagicMock()
+
+# Mock PIL/Pillow
+sys.modules['PIL'] = MagicMock()
+sys.modules['PIL.Image'] = MagicMock()
+
+# Mock other external dependencies
+sys.modules['certifi'] = MagicMock()
+sys.modules['serial'] = MagicMock()
+sys.modules['serial.tools'] = MagicMock()
+sys.modules['serial.tools.list_ports'] = MagicMock()
+sys.modules['bleak'] = MagicMock()
+sys.modules['bleak.exc'] = MagicMock()
+sys.modules['pubsub'] = MagicMock()
+sys.modules['matplotlib'] = MagicMock()
+sys.modules['matplotlib.pyplot'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+sys.modules['markdown'] = MagicMock()
+sys.modules['haversine'] = MagicMock()
+sys.modules['schedule'] = MagicMock()
+sys.modules['platformdirs'] = MagicMock()
+sys.modules['py_staticmaps'] = MagicMock()
+sys.modules['rich'] = MagicMock()
+sys.modules['rich.console'] = MagicMock()
+sys.modules['rich.logging'] = MagicMock()

--- a/tests/test_detection_sensor.py
+++ b/tests/test_detection_sensor.py
@@ -30,6 +30,7 @@ class TestDetectionSensor(unittest.TestCase):
         """
         # Set up a real event loop for asyncio operations
         import asyncio
+
         real_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(real_loop)
 
@@ -39,14 +40,14 @@ class TestDetectionSensor(unittest.TestCase):
         def sync_run_in_executor(executor, func, *args, **kwargs):
             """
             Synchronously executes a function, bypassing the executor, for use in testing environments.
-            
+
             Parameters:
-            	func (callable): The function to execute.
-            	*args: Positional arguments to pass to the function.
-            	**kwargs: Keyword arguments to pass to the function.
-            
+                func (callable): The function to execute.
+                *args: Positional arguments to pass to the function.
+                **kwargs: Keyword arguments to pass to the function.
+
             Returns:
-            	The result of the executed function.
+                The result of the executed function.
             """
             return func(*args, **kwargs)
 
@@ -72,9 +73,10 @@ class TestDetectionSensor(unittest.TestCase):
 
         # Restore original run_in_executor and clean up event loop
         import asyncio
+
         try:
             current_loop = asyncio.get_event_loop()
-            if hasattr(self, 'original_run_in_executor'):
+            if hasattr(self, "original_run_in_executor"):
                 current_loop.run_in_executor = self.original_run_in_executor
         except RuntimeError:
             # No current event loop, which is fine

--- a/tests/test_detection_sensor.py
+++ b/tests/test_detection_sensor.py
@@ -58,9 +58,13 @@ class TestDetectionSensor(unittest.TestCase):
 
         # Restore original run_in_executor and clean up event loop
         import asyncio
-        current_loop = asyncio.get_event_loop()
-        if hasattr(self, 'original_run_in_executor'):
-            current_loop.run_in_executor = self.original_run_in_executor
+        try:
+            current_loop = asyncio.get_event_loop()
+            if hasattr(self, 'original_run_in_executor'):
+                current_loop.run_in_executor = self.original_run_in_executor
+        except RuntimeError:
+            # No current event loop, which is fine
+            pass
         asyncio.set_event_loop(None)
 
     def test_detection_sensor_config_enabled(self):

--- a/tests/test_detection_sensor.py
+++ b/tests/test_detection_sensor.py
@@ -15,18 +15,7 @@ from unittest.mock import MagicMock
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-# Mock all external dependencies
-sys.modules["meshtastic"] = MagicMock()
-sys.modules["meshtastic.protobuf"] = MagicMock()
-sys.modules["meshtastic.protobuf.portnums_pb2"] = MagicMock()
-sys.modules["meshtastic.protobuf.portnums_pb2"].PortNum = MagicMock()
-sys.modules["meshtastic.protobuf.portnums_pb2"].PortNum.DETECTION_SENSOR_APP = 1
-sys.modules["nio"] = MagicMock()
-sys.modules["nio.MatrixRoom"] = MagicMock()
-sys.modules["nio.RoomMessageText"] = MagicMock()
-sys.modules["nio.RoomMessageNotice"] = MagicMock()
-sys.modules["nio.ReactionEvent"] = MagicMock()
-sys.modules["nio.RoomMessageEmote"] = MagicMock()
+# External dependencies are mocked in conftest.py
 
 # Import after mocking
 from mmrelay.message_queue import MessageQueue  # noqa: E402

--- a/tests/test_detection_sensor.py
+++ b/tests/test_detection_sensor.py
@@ -25,7 +25,9 @@ class TestDetectionSensor(unittest.TestCase):
     """Test detection sensor functionality."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Prepare the test environment by creating a real asyncio event loop with synchronous executor behavior, initializing a mock message queue, and setting up a mock sendData function to record message calls.
+        """
         # Set up a real event loop for asyncio operations
         import asyncio
         real_loop = asyncio.new_event_loop()
@@ -35,7 +37,17 @@ class TestDetectionSensor(unittest.TestCase):
         self.original_run_in_executor = real_loop.run_in_executor
 
         def sync_run_in_executor(executor, func, *args, **kwargs):
-            """Execute function synchronously for testing."""
+            """
+            Synchronously executes a function, bypassing the executor, for use in testing environments.
+            
+            Parameters:
+            	func (callable): The function to execute.
+            	*args: Positional arguments to pass to the function.
+            	**kwargs: Keyword arguments to pass to the function.
+            
+            Returns:
+            	The result of the executed function.
+            """
             return func(*args, **kwargs)
 
         real_loop.run_in_executor = sync_run_in_executor
@@ -52,7 +64,9 @@ class TestDetectionSensor(unittest.TestCase):
         self.mock_send_data = mock_send_data
 
     def tearDown(self):
-        """Clean up after tests."""
+        """
+        Cleans up test resources by stopping the message queue, restoring the original event loop executor, and resetting the asyncio event loop.
+        """
         if self.queue.is_running():
             self.queue.stop()
 
@@ -68,7 +82,9 @@ class TestDetectionSensor(unittest.TestCase):
         asyncio.set_event_loop(None)
 
     def test_detection_sensor_config_enabled(self):
-        """Test detection sensor configuration parsing when enabled."""
+        """
+        Test that the detection sensor configuration flag is correctly parsed as enabled when set to True in the configuration dictionary.
+        """
         config_enabled = {
             "meshtastic": {
                 "detection_sensor": True,

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -13,7 +13,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 
 def test_basic_imports():
-    """Test that basic modules can be imported without errors."""
+    """
+    Verify that core project modules and functions can be imported and are accessible under the mocking setup.
+    """
     # These should work with the mocking setup
     from mmrelay.message_queue import MessageQueue
     from mmrelay.matrix_utils import get_matrix_prefix, get_meshtastic_prefix
@@ -25,7 +27,11 @@ def test_basic_imports():
 
 
 def test_external_dependencies_mocked():
-    """Test that external dependencies are properly mocked."""
+    """
+    Verify that external dependencies are mocked and expose expected attributes.
+    
+    Asserts that the `meshtastic` and `nio` modules provide specific attributes and that `PIL.Image` is available, confirming the mocking setup is effective.
+    """
     import meshtastic
     import nio
     from PIL import Image
@@ -37,7 +43,9 @@ def test_external_dependencies_mocked():
 
 
 def test_prefix_functions():
-    """Test the prefix functions with basic inputs."""
+    """
+    Verify that the prefix-generating functions return strings when called with sample configuration dictionaries and user identifiers.
+    """
     from mmrelay.matrix_utils import get_matrix_prefix, get_meshtastic_prefix
     
     # Test meshtastic prefix

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,8 +5,8 @@ This test verifies that the mocking setup in conftest.py properly handles
 all external dependencies and allows modules to be imported without errors.
 """
 
-import sys
 import os
+import sys
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -17,9 +17,9 @@ def test_basic_imports():
     Verify that core project modules and functions can be imported and are accessible under the mocking setup.
     """
     # These should work with the mocking setup
-    from mmrelay.message_queue import MessageQueue
     from mmrelay.matrix_utils import get_matrix_prefix, get_meshtastic_prefix
-    
+    from mmrelay.message_queue import MessageQueue
+
     # Test that the functions exist and are callable
     assert callable(get_matrix_prefix)
     assert callable(get_meshtastic_prefix)
@@ -29,16 +29,16 @@ def test_basic_imports():
 def test_external_dependencies_mocked():
     """
     Verify that external dependencies are mocked and expose expected attributes.
-    
+
     Asserts that the `meshtastic` and `nio` modules provide specific attributes and that `PIL.Image` is available, confirming the mocking setup is effective.
     """
     import meshtastic
     import nio
     from PIL import Image
-    
+
     # These should be MagicMock objects
-    assert hasattr(meshtastic, 'BROADCAST_ADDR')
-    assert hasattr(nio, 'AsyncClient')
+    assert hasattr(meshtastic, "BROADCAST_ADDR")
+    assert hasattr(nio, "AsyncClient")
     assert Image is not None
 
 
@@ -47,13 +47,15 @@ def test_prefix_functions():
     Verify that the prefix-generating functions return strings when called with sample configuration dictionaries and user identifiers.
     """
     from mmrelay.matrix_utils import get_matrix_prefix, get_meshtastic_prefix
-    
+
     # Test meshtastic prefix
     config = {"meshtastic": {"prefix_enabled": True}}
     prefix = get_meshtastic_prefix(config, "TestUser")
     assert isinstance(prefix, str)
-    
-    # Test matrix prefix  
+
+    # Test matrix prefix
     matrix_config = {"matrix": {"prefix_enabled": True}}
-    matrix_prefix = get_matrix_prefix(matrix_config, "TestLong", "TestShort", "TestMesh")
+    matrix_prefix = get_matrix_prefix(
+        matrix_config, "TestLong", "TestShort", "TestMesh"
+    )
     assert isinstance(matrix_prefix, str)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,51 @@
+"""
+Test that all imports work correctly with mocking.
+
+This test verifies that the mocking setup in conftest.py properly handles
+all external dependencies and allows modules to be imported without errors.
+"""
+
+import sys
+import os
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+
+def test_basic_imports():
+    """Test that basic modules can be imported without errors."""
+    # These should work with the mocking setup
+    from mmrelay.message_queue import MessageQueue
+    from mmrelay.matrix_utils import get_matrix_prefix, get_meshtastic_prefix
+    
+    # Test that the functions exist and are callable
+    assert callable(get_matrix_prefix)
+    assert callable(get_meshtastic_prefix)
+    assert MessageQueue is not None
+
+
+def test_external_dependencies_mocked():
+    """Test that external dependencies are properly mocked."""
+    import meshtastic
+    import nio
+    from PIL import Image
+    
+    # These should be MagicMock objects
+    assert hasattr(meshtastic, 'BROADCAST_ADDR')
+    assert hasattr(nio, 'AsyncClient')
+    assert Image is not None
+
+
+def test_prefix_functions():
+    """Test the prefix functions with basic inputs."""
+    from mmrelay.matrix_utils import get_matrix_prefix, get_meshtastic_prefix
+    
+    # Test meshtastic prefix
+    config = {"meshtastic": {"prefix_enabled": True}}
+    prefix = get_meshtastic_prefix(config, "TestUser")
+    assert isinstance(prefix, str)
+    
+    # Test matrix prefix  
+    matrix_config = {"matrix": {"prefix_enabled": True}}
+    matrix_prefix = get_matrix_prefix(matrix_config, "TestLong", "TestShort", "TestMesh")
+    assert isinstance(matrix_prefix, str)

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -54,7 +54,7 @@ class TestMessageQueue(unittest.TestCase):
 
     def setUp(self):
         """
-        Initializes the test environment for each test case by setting up a fresh MessageQueue instance, clearing mock send function calls, and patching asyncio to run executor functions synchronously.
+        Prepare the test environment by initializing a new MessageQueue, clearing previous mock send function calls, and configuring the asyncio event loop to execute executor functions synchronously for deterministic testing.
         """
         self.queue = MessageQueue()
         # Clear mock function calls for each test
@@ -71,16 +71,15 @@ class TestMessageQueue(unittest.TestCase):
 
         def sync_run_in_executor(executor, func, *args, **kwargs):
             """
-            Executes a function synchronously, bypassing the executor.
-
+            Execute a function synchronously, ignoring the provided executor.
+            
             Parameters:
-                executor: The executor (ignored in sync mode).
                 func (callable): The function to execute.
-                *args: Positional arguments to pass to the function.
-                **kwargs: Keyword arguments to pass to the function.
-
+                *args: Positional arguments for the function.
+                **kwargs: Keyword arguments for the function.
+            
             Returns:
-                The result of the executed function.
+                The result returned by the executed function.
             """
             return func(*args, **kwargs)
 
@@ -88,7 +87,7 @@ class TestMessageQueue(unittest.TestCase):
 
     def tearDown(self):
         """
-        Stops the message queue and restores the original asyncio event loop behavior after each test.
+        Clean up after each test by stopping the message queue and restoring the original event loop executor behavior.
         """
         if self.queue.is_running():
             # Wait a bit for any in-flight messages to complete
@@ -110,7 +109,7 @@ class TestMessageQueue(unittest.TestCase):
     @property
     def sent_messages(self):
         """
-        Returns the list of messages sent via the mock send function during testing.
+        Returns the list of messages sent by the mock send function during the test run.
         """
         return mock_send_function.calls
 

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -98,9 +98,13 @@ class TestMessageQueue(unittest.TestCase):
             self.queue.stop()
 
         # Restore original run_in_executor and clean up event loop
-        current_loop = asyncio.get_event_loop()
-        if hasattr(self, 'original_run_in_executor'):
-            current_loop.run_in_executor = self.original_run_in_executor
+        try:
+            current_loop = asyncio.get_event_loop()
+            if hasattr(self, 'original_run_in_executor'):
+                current_loop.run_in_executor = self.original_run_in_executor
+        except RuntimeError:
+            # No current event loop, which is fine
+            pass
         asyncio.set_event_loop(None)
 
     @property

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -15,7 +15,6 @@ import os
 import sys
 import time
 import unittest
-from unittest.mock import MagicMock, patch
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -72,12 +71,12 @@ class TestMessageQueue(unittest.TestCase):
         def sync_run_in_executor(executor, func, *args, **kwargs):
             """
             Execute a function synchronously, ignoring the provided executor.
-            
+
             Parameters:
                 func (callable): The function to execute.
                 *args: Positional arguments for the function.
                 **kwargs: Keyword arguments for the function.
-            
+
             Returns:
                 The result returned by the executed function.
             """
@@ -99,7 +98,7 @@ class TestMessageQueue(unittest.TestCase):
         # Restore original run_in_executor and clean up event loop
         try:
             current_loop = asyncio.get_event_loop()
-            if hasattr(self, 'original_run_in_executor'):
+            if hasattr(self, "original_run_in_executor"):
                 current_loop.run_in_executor = self.original_run_in_executor
         except RuntimeError:
             # No current event loop, which is fine


### PR DESCRIPTION
Key fixes:
- Fix CLI argument parsing conflict with pytest by making parse_arguments() conditional
- Only parse CLI arguments when not in test environment (pytest/unittest)
- Handle None args gracefully in log_utils.py
- Add asyncio_default_fixture_loop_scope to fix pytest-asyncio warning
- Proper test isolation to prevent SystemExit during module imports

This resolves the SystemExit error that occurred when pytest tried to import modules that called parse_arguments() at import time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test and coverage configuration files to streamline testing and coverage reporting.
  * Introduced a GitHub Actions workflow for automated testing and coverage reporting across multiple Python versions.

* **Chores**
  * Updated dependencies to include testing and coverage tools.
  * Enhanced .gitignore to exclude test and coverage artifacts.
  * Improved mocking of external dependencies for isolated and reliable test execution.
  * Refined test setup and teardown to better manage asyncio event loops and executor behavior.

* **Tests**
  * Added new tests to verify importability and correct mocking of external dependencies.
  * Improved test reliability and maintainability by centralizing mocking logic and adjusting event loop handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->