### PR TITLE
Improve Test Coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,35 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 55%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+component_management:
+  default_rules:
+    rules:
+      - paths:
+          - "src/mmrelay/plugins/**"
+        name: "Plugins"
+      - paths:
+          - "src/mmrelay/config_checker.py"
+        name: "Configuration"
+      - paths:
+          - "src/mmrelay/meshtastic_utils.py"
+          - "src/mmrelay/matrix_utils.py"
+        name: "Core Utils"
+      - paths:
+          - "src/mmrelay/main.py"
+          - "src/mmrelay/cli.py"
+        name: "CLI & Main"
+      - paths:
+          - "tests/**"
+        name: "Tests"
+
+comment:
+  layout: "reach,diff,flags,tree,component"
+  behavior: default
+  require_changes: false

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay base plugin class.
+
+Tests the core plugin functionality including:
+- Plugin initialization and name validation
+- Configuration management and validation
+- Database operations (store, get, delete plugin data)
+- Channel enablement checking
+- Matrix message sending capabilities
+- Response delay calculation
+- Command matching and routing
+- Scheduling support
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.base_plugin import BasePlugin
+
+
+class MockPlugin(BasePlugin):
+    """Mock plugin implementation for testing BasePlugin functionality."""
+    plugin_name = "test_plugin"
+
+    async def handle_meshtastic_message(self, packet, formatted_message, longname, meshnet_name):
+        return False
+
+    async def handle_room_message(self, room, event, full_message):
+        return False
+
+
+class TestBasePlugin(unittest.TestCase):
+    """Test cases for the BasePlugin class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Mock the global config
+        self.mock_config = {
+            "plugins": {
+                "test_plugin": {
+                    "active": True,
+                    "channels": [0, 1]
+                }
+            },
+            "meshtastic": {
+                "message_delay": 3.0
+            },
+            "matrix": {
+                "rooms": [
+                    {"id": "!room1:matrix.org", "meshtastic_channel": 0},
+                    {"id": "!room2:matrix.org", "meshtastic_channel": 1}
+                ]
+            }
+        }
+        
+        # Patch the global config
+        patcher = patch('mmrelay.plugins.base_plugin.config', self.mock_config)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        
+        # Mock database functions
+        self.mock_store_plugin_data = patch('mmrelay.plugins.base_plugin.store_plugin_data').start()
+        self.mock_get_plugin_data = patch('mmrelay.plugins.base_plugin.get_plugin_data').start()
+        self.mock_get_plugin_data_for_node = patch('mmrelay.plugins.base_plugin.get_plugin_data_for_node').start()
+        self.mock_delete_plugin_data = patch('mmrelay.plugins.base_plugin.delete_plugin_data').start()
+        
+        self.addCleanup(patch.stopall)
+
+    def test_plugin_initialization_with_class_name(self):
+        """Test plugin initialization using class-level plugin_name."""
+        plugin = MockPlugin()
+
+        self.assertEqual(plugin.plugin_name, "test_plugin")
+        self.assertEqual(plugin.max_data_rows_per_node, 100)
+        self.assertEqual(plugin.priority, 10)
+        self.assertTrue(plugin.config["active"])
+
+    def test_plugin_initialization_with_parameter_name(self):
+        """Test plugin initialization with plugin_name parameter."""
+        plugin = MockPlugin(plugin_name="custom_name")
+
+        self.assertEqual(plugin.plugin_name, "custom_name")
+
+    def test_plugin_initialization_no_name_raises_error(self):
+        """Test that plugin initialization without name raises ValueError."""
+        class NoNamePlugin(BasePlugin):
+            async def handle_meshtastic_message(self, packet, formatted_message, longname, meshnet_name):
+                return False
+            async def handle_room_message(self, room, event, full_message):
+                return False
+        
+        with self.assertRaises(ValueError) as context:
+            NoNamePlugin()
+        
+        self.assertIn("missing plugin_name definition", str(context.exception))
+
+    def test_description_property_default(self):
+        """Test that description property returns empty string by default."""
+        plugin = MockPlugin()
+        self.assertEqual(plugin.description, "")
+
+    def test_config_loading_with_plugin_config(self):
+        """Test configuration loading when plugin config exists."""
+        plugin = MockPlugin()
+
+        self.assertTrue(plugin.config["active"])
+        self.assertEqual(plugin.response_delay, 3.0)
+        self.assertEqual(plugin.channels, [0, 1])
+
+    def test_config_loading_without_plugin_config(self):
+        """Test configuration loading when plugin config doesn't exist."""
+        # Remove plugin config
+        config_without_plugin = {"plugins": {}}
+
+        with patch('mmrelay.plugins.base_plugin.config', config_without_plugin):
+            plugin = MockPlugin()
+
+            self.assertFalse(plugin.config["active"])
+            self.assertEqual(plugin.response_delay, 2.2)  # DEFAULT_MESSAGE_DELAY
+            self.assertEqual(plugin.channels, [])
+
+    def test_response_delay_minimum_enforcement(self):
+        """Test that response delay is enforced to minimum 2.0 seconds."""
+        config_low_delay = {
+            "plugins": {
+                "test_plugin": {
+                    "active": True
+                }
+            },
+            "meshtastic": {
+                "message_delay": 0.5  # Below minimum
+            }
+        }
+
+        with patch('mmrelay.plugins.base_plugin.config', config_low_delay):
+            plugin = MockPlugin()
+            self.assertEqual(plugin.response_delay, 2.0)  # Should be enforced to minimum
+
+    def test_get_response_delay(self):
+        """Test get_response_delay method."""
+        plugin = MockPlugin()
+        self.assertEqual(plugin.get_response_delay(), 3.0)
+
+    def test_store_node_data(self):
+        """Test store_node_data method."""
+        plugin = MockPlugin()
+        test_data = {"key": "value", "timestamp": 1234567890}
+
+        plugin.store_node_data("!node123", test_data)
+
+        # store_node_data appends to existing data, so it calls get first
+        self.mock_get_plugin_data_for_node.assert_called_once_with("test_plugin", "!node123")
+
+    def test_get_node_data(self):
+        """Test get_node_data method."""
+        plugin = MockPlugin()
+        expected_data = [{"key": "value"}]
+        self.mock_get_plugin_data_for_node.return_value = expected_data
+
+        result = plugin.get_node_data("!node123")
+
+        self.assertEqual(result, expected_data)
+        self.mock_get_plugin_data_for_node.assert_called_once_with("test_plugin", "!node123")
+
+    def test_set_node_data(self):
+        """Test set_node_data method (replaces existing data)."""
+        plugin = MockPlugin()
+        test_data = [{"key": "value"}]
+
+        plugin.set_node_data("!node123", test_data)
+
+        self.mock_store_plugin_data.assert_called_once_with(
+            "test_plugin", "!node123", test_data
+        )
+
+    def test_get_data(self):
+        """Test get_data method."""
+        plugin = MockPlugin()
+        expected_data = [{"node": "!node123", "data": {"key": "value"}}]
+        self.mock_get_plugin_data.return_value = expected_data
+
+        result = plugin.get_data()
+
+        self.assertEqual(result, expected_data)
+        self.mock_get_plugin_data.assert_called_once_with("test_plugin")
+
+    def test_delete_node_data(self):
+        """Test delete_node_data method."""
+        plugin = MockPlugin()
+
+        plugin.delete_node_data("!node123")
+
+        self.mock_delete_plugin_data.assert_called_once_with("test_plugin", "!node123")
+
+    def test_is_channel_enabled_with_enabled_channel(self):
+        """Test is_channel_enabled with enabled channel."""
+        plugin = MockPlugin()
+
+        result = plugin.is_channel_enabled(0)
+        self.assertTrue(result)
+
+    def test_is_channel_enabled_with_disabled_channel(self):
+        """Test is_channel_enabled with disabled channel."""
+        plugin = MockPlugin()
+
+        result = plugin.is_channel_enabled(2)  # Not in channels list
+        self.assertFalse(result)
+
+    def test_is_channel_enabled_with_direct_message(self):
+        """Test is_channel_enabled with direct message override."""
+        plugin = MockPlugin()
+
+        # Even disabled channel should be enabled for direct messages
+        result = plugin.is_channel_enabled(2, is_direct_message=True)
+        self.assertTrue(result)
+
+    def test_is_channel_enabled_no_channels_configured(self):
+        """Test is_channel_enabled when no channels are configured."""
+        config_no_channels = {
+            "plugins": {
+                "test_plugin": {
+                    "active": True
+                    # No channels configured
+                }
+            }
+        }
+
+        with patch('mmrelay.plugins.base_plugin.config', config_no_channels):
+            plugin = MockPlugin()
+
+            # Should return False for any channel when none configured
+            result = plugin.is_channel_enabled(0)
+            self.assertFalse(result)
+
+            # But should still allow direct messages
+            result = plugin.is_channel_enabled(0, is_direct_message=True)
+            self.assertTrue(result)
+
+    @patch('mmrelay.matrix_utils.bot_command')
+    def test_matches_method(self, mock_bot_command):
+        """Test matches method for Matrix event matching."""
+        plugin = MockPlugin()
+        event = MagicMock()
+
+        mock_bot_command.return_value = True
+        result = plugin.matches(event)
+        self.assertTrue(result)
+
+        mock_bot_command.return_value = False
+        result = plugin.matches(event)
+        self.assertFalse(result)
+
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_send_matrix_message(self, mock_connect_matrix):
+        """Test send_matrix_message method."""
+        plugin = MockPlugin()
+        mock_matrix_client = AsyncMock()
+        mock_connect_matrix.return_value = mock_matrix_client
+
+        async def run_test():
+            await plugin.send_matrix_message(
+                "!room:matrix.org",
+                "Test message",
+                formatted=True
+            )
+
+            # Should call room_send on the matrix client
+            mock_matrix_client.room_send.assert_called_once()
+            call_args = mock_matrix_client.room_send.call_args
+            self.assertEqual(call_args.kwargs['room_id'], "!room:matrix.org")
+            self.assertEqual(call_args.kwargs['message_type'], "m.room.message")
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_strip_raw_method(self):
+        """Test strip_raw method for removing raw packet data."""
+        plugin = MockPlugin()
+
+        # Test with packet containing raw data
+        packet_with_raw = {
+            "decoded": {"text": "hello"},
+            "raw": "binary_data_here"
+        }
+
+        result = plugin.strip_raw(packet_with_raw)
+
+        expected = {"decoded": {"text": "hello"}}
+        self.assertEqual(result, expected)
+
+    def test_strip_raw_method_no_raw_data(self):
+        """Test strip_raw method with packet without raw data."""
+        plugin = MockPlugin()
+
+        packet_without_raw = {"decoded": {"text": "hello"}}
+        result = plugin.strip_raw(packet_without_raw)
+
+        # Should return unchanged
+        self.assertEqual(result, packet_without_raw)
+
+    @patch('mmrelay.plugins.base_plugin.queue_message')
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_send_message(self, mock_connect_meshtastic, mock_queue_message):
+        """Test send_message method."""
+        plugin = MockPlugin()
+
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_connect_meshtastic.return_value = mock_client
+        mock_queue_message.return_value = True
+
+        result = plugin.send_message("Test message", channel=1, destination_id="!node123")
+
+        # Should queue the message (result depends on queue state, but call should happen)
+        mock_queue_message.assert_called_once()
+        call_args = mock_queue_message.call_args
+        self.assertEqual(call_args[0][0], mock_client.sendText)  # First arg is the function
+        self.assertIn("text", call_args[1])  # kwargs should contain text
+        self.assertEqual(call_args[1]["text"], "Test message")
+
+    def test_get_matrix_commands_default(self):
+        """Test get_matrix_commands returns plugin name by default."""
+        plugin = MockPlugin()
+        self.assertEqual(plugin.get_matrix_commands(), ["test_plugin"])
+
+    def test_get_mesh_commands_default(self):
+        """Test get_mesh_commands returns empty list by default."""
+        plugin = MockPlugin()
+        self.assertEqual(plugin.get_mesh_commands(), [])
+
+    def test_get_plugin_data_dir(self):
+        """Test get_plugin_data_dir method."""
+        plugin = MockPlugin()
+
+        with patch('mmrelay.plugins.base_plugin.get_plugin_data_dir') as mock_get_dir:
+            mock_get_dir.return_value = "/path/to/plugin/data"
+
+            result = plugin.get_plugin_data_dir()
+
+            self.assertEqual(result, "/path/to/plugin/data")
+            mock_get_dir.assert_called_once_with("test_plugin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -29,9 +29,26 @@ class MockPlugin(BasePlugin):
     plugin_name = "test_plugin"
 
     async def handle_meshtastic_message(self, packet, formatted_message, longname, meshnet_name):
+        """
+        Handle an incoming Meshtastic message.
+        
+        Returns:
+            bool: Always returns False, indicating the message was not handled.
+        """
         return False
 
     async def handle_room_message(self, room, event, full_message):
+        """
+        Handle a Matrix room message event.
+        
+        Parameters:
+            room: The Matrix room where the event occurred.
+            event: The Matrix event object.
+            full_message: The full message content.
+        
+        Returns:
+            bool: Always returns False, indicating the message was not handled.
+        """
         return False
 
 
@@ -39,7 +56,9 @@ class TestBasePlugin(unittest.TestCase):
     """Test cases for the BasePlugin class."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Prepare the test environment by mocking configuration and database functions for plugin tests.
+        """
         # Mock the global config
         self.mock_config = {
             "plugins": {
@@ -82,17 +101,42 @@ class TestBasePlugin(unittest.TestCase):
         self.assertTrue(plugin.config["active"])
 
     def test_plugin_initialization_with_parameter_name(self):
-        """Test plugin initialization with plugin_name parameter."""
+        """
+        Test that a plugin can be initialized with a custom plugin_name parameter.
+        
+        Verifies that the plugin_name attribute is set to the provided value during initialization.
+        """
         plugin = MockPlugin(plugin_name="custom_name")
 
         self.assertEqual(plugin.plugin_name, "custom_name")
 
     def test_plugin_initialization_no_name_raises_error(self):
-        """Test that plugin initialization without name raises ValueError."""
+        """
+        Test that initializing a plugin without a plugin name raises a ValueError.
+        
+        Ensures that a subclass of BasePlugin without a defined plugin_name triggers a ValueError during instantiation.
+        """
         class NoNamePlugin(BasePlugin):
             async def handle_meshtastic_message(self, packet, formatted_message, longname, meshnet_name):
+                """
+                Handle an incoming Meshtastic message.
+                
+                Returns:
+                    bool: Always returns False, indicating the message was not handled.
+                """
                 return False
             async def handle_room_message(self, room, event, full_message):
+                """
+                Handle a Matrix room message event.
+                
+                Parameters:
+                	room: The Matrix room where the event occurred.
+                	event: The Matrix event object.
+                	full_message: The full message content.
+                
+                Returns:
+                	bool: Always returns False, indicating the message was not handled.
+                """
                 return False
         
         with self.assertRaises(ValueError) as context:
@@ -106,7 +150,11 @@ class TestBasePlugin(unittest.TestCase):
         self.assertEqual(plugin.description, "")
 
     def test_config_loading_with_plugin_config(self):
-        """Test configuration loading when plugin config exists."""
+        """
+        Test that the plugin loads configuration values correctly when a plugin config is present.
+        
+        Verifies that the plugin is active, the response delay is set to 3.0 seconds, and the enabled channels are [0, 1] when these values are provided in the configuration.
+        """
         plugin = MockPlugin()
 
         self.assertTrue(plugin.config["active"])
@@ -114,7 +162,11 @@ class TestBasePlugin(unittest.TestCase):
         self.assertEqual(plugin.channels, [0, 1])
 
     def test_config_loading_without_plugin_config(self):
-        """Test configuration loading when plugin config doesn't exist."""
+        """
+        Test that the plugin loads default configuration values when no plugin-specific config is present.
+        
+        Verifies that the plugin is inactive, uses the default response delay, and has no enabled channels if its configuration is missing.
+        """
         # Remove plugin config
         config_without_plugin = {"plugins": {}}
 
@@ -126,7 +178,9 @@ class TestBasePlugin(unittest.TestCase):
             self.assertEqual(plugin.channels, [])
 
     def test_response_delay_minimum_enforcement(self):
-        """Test that response delay is enforced to minimum 2.0 seconds."""
+        """
+        Test that the plugin enforces a minimum response delay of 2.0 seconds when configured with a lower value.
+        """
         config_low_delay = {
             "plugins": {
                 "test_plugin": {
@@ -143,12 +197,16 @@ class TestBasePlugin(unittest.TestCase):
             self.assertEqual(plugin.response_delay, 2.0)  # Should be enforced to minimum
 
     def test_get_response_delay(self):
-        """Test get_response_delay method."""
+        """
+        Test that the get_response_delay method returns the configured response delay value.
+        """
         plugin = MockPlugin()
         self.assertEqual(plugin.get_response_delay(), 3.0)
 
     def test_store_node_data(self):
-        """Test store_node_data method."""
+        """
+        Tests that the store_node_data method appends new data to a node's existing plugin data by first retrieving current data.
+        """
         plugin = MockPlugin()
         test_data = {"key": "value", "timestamp": 1234567890}
 
@@ -158,7 +216,9 @@ class TestBasePlugin(unittest.TestCase):
         self.mock_get_plugin_data_for_node.assert_called_once_with("test_plugin", "!node123")
 
     def test_get_node_data(self):
-        """Test get_node_data method."""
+        """
+        Tests that the get_node_data method retrieves the correct data for a given node from the plugin database.
+        """
         plugin = MockPlugin()
         expected_data = [{"key": "value"}]
         self.mock_get_plugin_data_for_node.return_value = expected_data
@@ -169,7 +229,11 @@ class TestBasePlugin(unittest.TestCase):
         self.mock_get_plugin_data_for_node.assert_called_once_with("test_plugin", "!node123")
 
     def test_set_node_data(self):
-        """Test set_node_data method (replaces existing data)."""
+        """
+        Test that set_node_data correctly replaces the data for a specific node.
+        
+        Verifies that calling set_node_data stores the provided data for the given node, replacing any existing data.
+        """
         plugin = MockPlugin()
         test_data = [{"key": "value"}]
 
@@ -180,7 +244,9 @@ class TestBasePlugin(unittest.TestCase):
         )
 
     def test_get_data(self):
-        """Test get_data method."""
+        """
+        Tests that the get_data method retrieves all plugin data using the correct plugin name.
+        """
         plugin = MockPlugin()
         expected_data = [{"node": "!node123", "data": {"key": "value"}}]
         self.mock_get_plugin_data.return_value = expected_data
@@ -191,7 +257,9 @@ class TestBasePlugin(unittest.TestCase):
         self.mock_get_plugin_data.assert_called_once_with("test_plugin")
 
     def test_delete_node_data(self):
-        """Test delete_node_data method."""
+        """
+        Tests that the delete_node_data method removes plugin data for a specific node by calling the appropriate database function.
+        """
         plugin = MockPlugin()
 
         plugin.delete_node_data("!node123")
@@ -199,21 +267,27 @@ class TestBasePlugin(unittest.TestCase):
         self.mock_delete_plugin_data.assert_called_once_with("test_plugin", "!node123")
 
     def test_is_channel_enabled_with_enabled_channel(self):
-        """Test is_channel_enabled with enabled channel."""
+        """
+        Test that is_channel_enabled returns True for a channel that is enabled in the plugin configuration.
+        """
         plugin = MockPlugin()
 
         result = plugin.is_channel_enabled(0)
         self.assertTrue(result)
 
     def test_is_channel_enabled_with_disabled_channel(self):
-        """Test is_channel_enabled with disabled channel."""
+        """
+        Test that is_channel_enabled returns False for a channel not listed as enabled in the plugin configuration.
+        """
         plugin = MockPlugin()
 
         result = plugin.is_channel_enabled(2)  # Not in channels list
         self.assertFalse(result)
 
     def test_is_channel_enabled_with_direct_message(self):
-        """Test is_channel_enabled with direct message override."""
+        """
+        Test that is_channel_enabled returns True for direct messages, regardless of channel configuration.
+        """
         plugin = MockPlugin()
 
         # Even disabled channel should be enabled for direct messages
@@ -221,7 +295,9 @@ class TestBasePlugin(unittest.TestCase):
         self.assertTrue(result)
 
     def test_is_channel_enabled_no_channels_configured(self):
-        """Test is_channel_enabled when no channels are configured."""
+        """
+        Verifies that is_channel_enabled returns False for all channels when no channels are configured, except for direct messages which remain enabled.
+        """
         config_no_channels = {
             "plugins": {
                 "test_plugin": {
@@ -244,7 +320,11 @@ class TestBasePlugin(unittest.TestCase):
 
     @patch('mmrelay.matrix_utils.bot_command')
     def test_matches_method(self, mock_bot_command):
-        """Test matches method for Matrix event matching."""
+        """
+        Test that the plugin's matches method correctly identifies Matrix events as matching or not based on the bot_command utility.
+        
+        Verifies that the matches method returns True when the event matches a command and False otherwise.
+        """
         plugin = MockPlugin()
         event = MagicMock()
 
@@ -258,12 +338,19 @@ class TestBasePlugin(unittest.TestCase):
 
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_send_matrix_message(self, mock_connect_matrix):
-        """Test send_matrix_message method."""
+        """
+        Test that the send_matrix_message method sends a message to the specified Matrix room using the Matrix client.
+        
+        Verifies that the Matrix client's room_send method is called with the correct room ID and message type.
+        """
         plugin = MockPlugin()
         mock_matrix_client = AsyncMock()
         mock_connect_matrix.return_value = mock_matrix_client
 
         async def run_test():
+            """
+            Asynchronously tests that sending a Matrix message via the plugin calls the Matrix client's room_send method with the correct parameters.
+            """
             await plugin.send_matrix_message(
                 "!room:matrix.org",
                 "Test message",
@@ -280,7 +367,9 @@ class TestBasePlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_strip_raw_method(self):
-        """Test strip_raw method for removing raw packet data."""
+        """
+        Test that the strip_raw method removes the 'raw' field from a packet dictionary if present.
+        """
         plugin = MockPlugin()
 
         # Test with packet containing raw data
@@ -295,7 +384,9 @@ class TestBasePlugin(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_strip_raw_method_no_raw_data(self):
-        """Test strip_raw method with packet without raw data."""
+        """
+        Test that the strip_raw method returns the packet unchanged when no raw data is present.
+        """
         plugin = MockPlugin()
 
         packet_without_raw = {"decoded": {"text": "hello"}}
@@ -307,7 +398,11 @@ class TestBasePlugin(unittest.TestCase):
     @patch('mmrelay.plugins.base_plugin.queue_message')
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_send_message(self, mock_connect_meshtastic, mock_queue_message):
-        """Test send_message method."""
+        """
+        Test that the plugin's send_message method queues a Meshtastic message with the correct parameters.
+        
+        Verifies that the message is sent using the mocked Meshtastic client and that the queue_message function is called with the expected arguments.
+        """
         plugin = MockPlugin()
 
         # Mock meshtastic client
@@ -325,17 +420,23 @@ class TestBasePlugin(unittest.TestCase):
         self.assertEqual(call_args[1]["text"], "Test message")
 
     def test_get_matrix_commands_default(self):
-        """Test get_matrix_commands returns plugin name by default."""
+        """
+        Test that get_matrix_commands returns a list containing the plugin name by default.
+        """
         plugin = MockPlugin()
         self.assertEqual(plugin.get_matrix_commands(), ["test_plugin"])
 
     def test_get_mesh_commands_default(self):
-        """Test get_mesh_commands returns empty list by default."""
+        """
+        Test that the default get_mesh_commands method returns an empty list.
+        """
         plugin = MockPlugin()
         self.assertEqual(plugin.get_mesh_commands(), [])
 
     def test_get_plugin_data_dir(self):
-        """Test get_plugin_data_dir method."""
+        """
+        Tests that the get_plugin_data_dir method returns the correct plugin data directory path using the patched utility function.
+        """
         plugin = MockPlugin()
 
         with patch('mmrelay.plugins.base_plugin.get_plugin_data_dir') as mock_get_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,7 @@ class TestCLI(unittest.TestCase):
     ):
         # Mock an invalid config (invalid connection type)
         """
-        Test that check_config returns False when the configuration contains an invalid meshtastic connection type.
+        Test that check_config() returns False when the configuration specifies an invalid Meshtastic connection type.
         """
         mock_yaml_load.return_value = {
             "matrix": {
@@ -157,14 +157,18 @@ class TestCLI(unittest.TestCase):
             self.assertFalse(check_config())
 
     def test_get_version(self):
-        """Test get_version function."""
+        """
+        Test that get_version returns a non-empty string representing the version.
+        """
         version = get_version()
         self.assertIsInstance(version, str)
         self.assertGreater(len(version), 0)
 
     @patch('builtins.print')
     def test_print_version(self, mock_print):
-        """Test print_version function."""
+        """
+        Test that print_version outputs the MMRelay version information using the print function.
+        """
         print_version()
         mock_print.assert_called_once()
         # Check that the printed message contains version info
@@ -174,14 +178,18 @@ class TestCLI(unittest.TestCase):
 
     @patch('sys.platform', 'win32')
     def test_parse_arguments_windows_positional(self):
-        """Test Windows-specific positional argument handling."""
+        """
+        Test that on Windows, a positional argument is interpreted as the config file path.
+        """
         with patch("sys.argv", ["mmrelay", "config.yaml"]):
             args = parse_arguments()
             self.assertEqual(args.config, "config.yaml")
 
     @patch('sys.platform', 'win32')
     def test_parse_arguments_windows_both_args(self):
-        """Test Windows handling when both positional and --config are provided."""
+        """
+        Test that on Windows, the --config option takes precedence over a positional config file argument when both are provided.
+        """
         with patch("sys.argv", ["mmrelay", "--config", "explicit.yaml", "positional.yaml"]):
             args = parse_arguments()
             # --config should take precedence
@@ -189,7 +197,11 @@ class TestCLI(unittest.TestCase):
 
     @patch('builtins.print')
     def test_parse_arguments_unknown_args_warning(self, mock_print):
-        """Test warning for unknown arguments outside test environment."""
+        """
+        Test that a warning is printed when unknown CLI arguments are provided outside a test environment.
+        
+        Verifies that `parse_arguments()` triggers a warning message containing the unknown argument name when an unrecognized CLI argument is passed and the environment is not a test context.
+        """
         with patch("sys.argv", ["mmrelay", "--unknown-arg", "value"]):
             args = parse_arguments()
             # Should print warning about unknown arguments
@@ -199,7 +211,9 @@ class TestCLI(unittest.TestCase):
             self.assertIn("unknown-arg", warning_msg)
 
     def test_parse_arguments_test_environment(self):
-        """Test that unknown arguments don't trigger warnings in test environment."""
+        """
+        Verify that unknown CLI arguments do not produce warnings when running in a test environment.
+        """
         with patch("sys.argv", ["pytest", "mmrelay", "--unknown-arg"]):
             with patch('builtins.print') as mock_print:
                 args = parse_arguments()
@@ -213,7 +227,9 @@ class TestGenerateSampleConfig(unittest.TestCase):
     @patch('mmrelay.config.get_config_paths')
     @patch('os.path.isfile')
     def test_generate_sample_config_existing_file(self, mock_isfile, mock_get_paths):
-        """Test generate_sample_config when config file already exists."""
+        """
+        Test that generate_sample_config returns False and prints a message when the config file already exists.
+        """
         mock_get_paths.return_value = ["/home/user/.mmrelay/config.yaml"]
         mock_isfile.return_value = True
 
@@ -234,7 +250,9 @@ class TestGenerateSampleConfig(unittest.TestCase):
     @patch('shutil.copy2')
     def test_generate_sample_config_success(self, mock_copy, mock_exists, mock_get_sample,
                                           mock_makedirs, mock_isfile, mock_get_paths):
-        """Test successful sample config generation."""
+        """
+                                          Test that generate_sample_config creates a sample config file when none exists and the sample file is available, ensuring correct file operations and success message output.
+                                          """
         mock_get_paths.return_value = ["/home/user/.mmrelay/config.yaml"]
         mock_isfile.return_value = False  # No existing config
         mock_get_sample.return_value = "/path/to/sample_config.yaml"
@@ -259,7 +277,11 @@ class TestGenerateSampleConfig(unittest.TestCase):
     def test_generate_sample_config_importlib_fallback(self, mock_files, mock_exists,
                                                      mock_get_sample, mock_makedirs,
                                                      mock_isfile, mock_get_paths):
-        """Test sample config generation using importlib.resources fallback."""
+        """
+                                                     Test that generate_sample_config() uses importlib.resources to create the config file when the sample config is not found at the helper path.
+                                                     
+                                                     Simulates the absence of the sample config file at the expected location, mocks importlib.resources to provide sample content, and verifies that the config file is created with the correct content.
+                                                     """
         mock_get_paths.return_value = ["/home/user/.mmrelay/config.yaml"]
         mock_isfile.return_value = False
         mock_get_sample.return_value = "/nonexistent/path"
@@ -284,7 +306,9 @@ class TestHandleCLICommands(unittest.TestCase):
     """Test cases for handle_cli_commands function."""
 
     def test_handle_version_command(self):
-        """Test handling --version command."""
+        """
+        Test that handle_cli_commands processes the --version flag by calling print_version and returning True.
+        """
         args = MagicMock()
         args.version = True
         args.install_service = False
@@ -300,7 +324,9 @@ class TestHandleCLICommands(unittest.TestCase):
     @patch('mmrelay.setup_utils.install_service')
     @patch('sys.exit')
     def test_handle_install_service_success(self, mock_exit, mock_install):
-        """Test handling --install-service command with success."""
+        """
+        Test that the --install-service command triggers service installation and exits with code 0 on success.
+        """
         args = MagicMock()
         args.version = False
         args.install_service = True
@@ -316,7 +342,9 @@ class TestHandleCLICommands(unittest.TestCase):
     @patch('mmrelay.setup_utils.install_service')
     @patch('sys.exit')
     def test_handle_install_service_failure(self, mock_exit, mock_install):
-        """Test handling --install-service command with failure."""
+        """
+        Test that handle_cli_commands exits with code 1 when service installation fails using the --install-service flag.
+        """
         args = MagicMock()
         args.version = False
         args.install_service = True
@@ -331,7 +359,9 @@ class TestHandleCLICommands(unittest.TestCase):
 
     @patch('mmrelay.cli.generate_sample_config')
     def test_handle_generate_config_success(self, mock_generate):
-        """Test handling --generate-config command with success."""
+        """
+        Test that handle_cli_commands returns True when the --generate-config command is specified and sample config generation succeeds.
+        """
         args = MagicMock()
         args.version = False
         args.install_service = False
@@ -347,7 +377,9 @@ class TestHandleCLICommands(unittest.TestCase):
     @patch('mmrelay.cli.generate_sample_config')
     @patch('sys.exit')
     def test_handle_generate_config_failure(self, mock_exit, mock_generate):
-        """Test handling --generate-config command with failure."""
+        """
+        Test that handle_cli_commands exits with code 1 when --generate-config is specified and config generation fails.
+        """
         args = MagicMock()
         args.version = False
         args.install_service = False
@@ -363,7 +395,9 @@ class TestHandleCLICommands(unittest.TestCase):
     @patch('mmrelay.cli.check_config')
     @patch('sys.exit')
     def test_handle_check_config_success(self, mock_exit, mock_check):
-        """Test handling --check-config command with success."""
+        """
+        Test that handle_cli_commands exits with code 0 when --check-config is specified and the config check succeeds.
+        """
         args = MagicMock()
         args.version = False
         args.install_service = False
@@ -379,7 +413,9 @@ class TestHandleCLICommands(unittest.TestCase):
     @patch('mmrelay.cli.check_config')
     @patch('sys.exit')
     def test_handle_check_config_failure(self, mock_exit, mock_check):
-        """Test handling --check-config command with failure."""
+        """
+        Test that handle_cli_commands exits with code 1 when --check-config is specified and the config check fails.
+        """
         args = MagicMock()
         args.version = False
         args.install_service = False
@@ -393,7 +429,9 @@ class TestHandleCLICommands(unittest.TestCase):
         mock_exit.assert_called_once_with(1)
 
     def test_handle_no_commands(self):
-        """Test when no CLI commands are specified."""
+        """
+        Test that handle_cli_commands returns False when no CLI command flags are set.
+        """
         args = MagicMock()
         args.version = False
         args.install_service = False
@@ -411,7 +449,9 @@ class TestMainFunction(unittest.TestCase):
     @patch('mmrelay.cli.parse_arguments')
     @patch('mmrelay.cli.check_config')
     def test_main_check_config_success(self, mock_check, mock_parse):
-        """Test main function with --check-config success."""
+        """
+        Tests that the main function returns exit code 0 when the --check-config flag is set and the configuration check succeeds.
+        """
         args = MagicMock()
         args.check_config = True
         args.install_service = False
@@ -428,7 +468,9 @@ class TestMainFunction(unittest.TestCase):
     @patch('mmrelay.cli.parse_arguments')
     @patch('mmrelay.cli.check_config')
     def test_main_check_config_failure(self, mock_check, mock_parse):
-        """Test main function with --check-config failure."""
+        """
+        Test that the main function returns exit code 1 when configuration check fails with --check-config.
+        """
         args = MagicMock()
         args.check_config = True
         args.install_service = False
@@ -444,7 +486,9 @@ class TestMainFunction(unittest.TestCase):
     @patch('mmrelay.cli.parse_arguments')
     @patch('mmrelay.setup_utils.install_service')
     def test_main_install_service_success(self, mock_install, mock_parse):
-        """Test main function with --install-service success."""
+        """
+        Test that the main function returns exit code 0 when the --install-service flag is set and service installation succeeds.
+        """
         args = MagicMock()
         args.check_config = False
         args.install_service = True
@@ -461,7 +505,9 @@ class TestMainFunction(unittest.TestCase):
     @patch('mmrelay.cli.parse_arguments')
     @patch('mmrelay.cli.generate_sample_config')
     def test_main_generate_config_success(self, mock_generate, mock_parse):
-        """Test main function with --generate-config success."""
+        """
+        Test that the main function returns exit code 0 when --generate-config is specified and sample config generation succeeds.
+        """
         args = MagicMock()
         args.check_config = False
         args.install_service = False
@@ -478,7 +524,9 @@ class TestMainFunction(unittest.TestCase):
     @patch('mmrelay.cli.parse_arguments')
     @patch('mmrelay.cli.print_version')
     def test_main_version(self, mock_print_version, mock_parse):
-        """Test main function with --version."""
+        """
+        Tests that the main function handles the --version flag by printing version information and returning exit code 0.
+        """
         args = MagicMock()
         args.check_config = False
         args.install_service = False
@@ -494,7 +542,9 @@ class TestMainFunction(unittest.TestCase):
     @patch('mmrelay.cli.parse_arguments')
     @patch('mmrelay.main.run_main')
     def test_main_run_main(self, mock_run_main, mock_parse):
-        """Test main function running normal functionality."""
+        """
+        Tests that the main function calls run_main with parsed arguments and returns its exit code when no special CLI commands are specified.
+        """
         args = MagicMock()
         args.check_config = False
         args.install_service = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,21 @@
 import os
 import sys
+import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from mmrelay.cli import check_config, parse_arguments
+from mmrelay.cli import (
+    check_config,
+    generate_sample_config,
+    get_version,
+    handle_cli_commands,
+    main,
+    parse_arguments,
+    print_version,
+)
 
 
 class TestCLI(unittest.TestCase):
@@ -146,6 +155,358 @@ class TestCLI(unittest.TestCase):
 
         with patch("sys.argv", ["mmrelay", "--config", "invalid_config.yaml"]):
             self.assertFalse(check_config())
+
+    def test_get_version(self):
+        """Test get_version function."""
+        version = get_version()
+        self.assertIsInstance(version, str)
+        self.assertGreater(len(version), 0)
+
+    @patch('builtins.print')
+    def test_print_version(self, mock_print):
+        """Test print_version function."""
+        print_version()
+        mock_print.assert_called_once()
+        # Check that the printed message contains version info
+        call_args = mock_print.call_args[0][0]
+        self.assertIn("MMRelay", call_args)
+        self.assertIn("v", call_args)
+
+    @patch('sys.platform', 'win32')
+    def test_parse_arguments_windows_positional(self):
+        """Test Windows-specific positional argument handling."""
+        with patch("sys.argv", ["mmrelay", "config.yaml"]):
+            args = parse_arguments()
+            self.assertEqual(args.config, "config.yaml")
+
+    @patch('sys.platform', 'win32')
+    def test_parse_arguments_windows_both_args(self):
+        """Test Windows handling when both positional and --config are provided."""
+        with patch("sys.argv", ["mmrelay", "--config", "explicit.yaml", "positional.yaml"]):
+            args = parse_arguments()
+            # --config should take precedence
+            self.assertEqual(args.config, "explicit.yaml")
+
+    @patch('builtins.print')
+    def test_parse_arguments_unknown_args_warning(self, mock_print):
+        """Test warning for unknown arguments outside test environment."""
+        with patch("sys.argv", ["mmrelay", "--unknown-arg", "value"]):
+            args = parse_arguments()
+            # Should print warning about unknown arguments
+            mock_print.assert_called()
+            warning_msg = mock_print.call_args[0][0]
+            self.assertIn("Warning", warning_msg)
+            self.assertIn("unknown-arg", warning_msg)
+
+    def test_parse_arguments_test_environment(self):
+        """Test that unknown arguments don't trigger warnings in test environment."""
+        with patch("sys.argv", ["pytest", "mmrelay", "--unknown-arg"]):
+            with patch('builtins.print') as mock_print:
+                args = parse_arguments()
+                # Should not print warning in test environment
+                mock_print.assert_not_called()
+
+
+class TestGenerateSampleConfig(unittest.TestCase):
+    """Test cases for generate_sample_config function."""
+
+    @patch('mmrelay.config.get_config_paths')
+    @patch('os.path.isfile')
+    def test_generate_sample_config_existing_file(self, mock_isfile, mock_get_paths):
+        """Test generate_sample_config when config file already exists."""
+        mock_get_paths.return_value = ["/home/user/.mmrelay/config.yaml"]
+        mock_isfile.return_value = True
+
+        with patch('builtins.print') as mock_print:
+            result = generate_sample_config()
+
+        self.assertFalse(result)
+        mock_print.assert_called()
+        # Check that it mentions existing config
+        print_calls = [call[0][0] for call in mock_print.call_args_list]
+        self.assertTrue(any("already exists" in call for call in print_calls))
+
+    @patch('mmrelay.config.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('os.makedirs')
+    @patch('mmrelay.tools.get_sample_config_path')
+    @patch('os.path.exists')
+    @patch('shutil.copy2')
+    def test_generate_sample_config_success(self, mock_copy, mock_exists, mock_get_sample,
+                                          mock_makedirs, mock_isfile, mock_get_paths):
+        """Test successful sample config generation."""
+        mock_get_paths.return_value = ["/home/user/.mmrelay/config.yaml"]
+        mock_isfile.return_value = False  # No existing config
+        mock_get_sample.return_value = "/path/to/sample_config.yaml"
+        mock_exists.return_value = True  # Sample config exists
+
+        with patch('builtins.print') as mock_print:
+            result = generate_sample_config()
+
+        self.assertTrue(result)
+        mock_copy.assert_called_once()
+        mock_makedirs.assert_called_once()
+        # Check success message
+        print_calls = [call[0][0] for call in mock_print.call_args_list]
+        self.assertTrue(any("Generated sample config" in call for call in print_calls))
+
+    @patch('mmrelay.config.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('os.makedirs')
+    @patch('mmrelay.tools.get_sample_config_path')
+    @patch('os.path.exists')
+    @patch('importlib.resources.files')
+    def test_generate_sample_config_importlib_fallback(self, mock_files, mock_exists,
+                                                     mock_get_sample, mock_makedirs,
+                                                     mock_isfile, mock_get_paths):
+        """Test sample config generation using importlib.resources fallback."""
+        mock_get_paths.return_value = ["/home/user/.mmrelay/config.yaml"]
+        mock_isfile.return_value = False
+        mock_get_sample.return_value = "/nonexistent/path"
+        mock_exists.return_value = False  # Sample config doesn't exist at helper path
+
+        # Mock importlib.resources
+        mock_resource = MagicMock()
+        mock_resource.read_text.return_value = "sample config content"
+        mock_files.return_value.joinpath.return_value = mock_resource
+
+        with patch('builtins.open', mock_open()) as mock_file:
+            with patch('builtins.print') as mock_print:
+                result = generate_sample_config()
+
+        self.assertTrue(result)
+        mock_file.assert_called_once()
+        # Check that content was written
+        mock_file().write.assert_called_once_with("sample config content")
+
+
+class TestHandleCLICommands(unittest.TestCase):
+    """Test cases for handle_cli_commands function."""
+
+    def test_handle_version_command(self):
+        """Test handling --version command."""
+        args = MagicMock()
+        args.version = True
+        args.install_service = False
+        args.generate_config = False
+        args.check_config = False
+
+        with patch('mmrelay.cli.print_version') as mock_print_version:
+            result = handle_cli_commands(args)
+
+        self.assertTrue(result)
+        mock_print_version.assert_called_once()
+
+    @patch('mmrelay.setup_utils.install_service')
+    @patch('sys.exit')
+    def test_handle_install_service_success(self, mock_exit, mock_install):
+        """Test handling --install-service command with success."""
+        args = MagicMock()
+        args.version = False
+        args.install_service = True
+        args.generate_config = False
+        args.check_config = False
+        mock_install.return_value = True
+
+        handle_cli_commands(args)
+
+        mock_install.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mmrelay.setup_utils.install_service')
+    @patch('sys.exit')
+    def test_handle_install_service_failure(self, mock_exit, mock_install):
+        """Test handling --install-service command with failure."""
+        args = MagicMock()
+        args.version = False
+        args.install_service = True
+        args.generate_config = False
+        args.check_config = False
+        mock_install.return_value = False
+
+        handle_cli_commands(args)
+
+        mock_install.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+
+    @patch('mmrelay.cli.generate_sample_config')
+    def test_handle_generate_config_success(self, mock_generate):
+        """Test handling --generate-config command with success."""
+        args = MagicMock()
+        args.version = False
+        args.install_service = False
+        args.generate_config = True
+        args.check_config = False
+        mock_generate.return_value = True
+
+        result = handle_cli_commands(args)
+
+        self.assertTrue(result)
+        mock_generate.assert_called_once()
+
+    @patch('mmrelay.cli.generate_sample_config')
+    @patch('sys.exit')
+    def test_handle_generate_config_failure(self, mock_exit, mock_generate):
+        """Test handling --generate-config command with failure."""
+        args = MagicMock()
+        args.version = False
+        args.install_service = False
+        args.generate_config = True
+        args.check_config = False
+        mock_generate.return_value = False
+
+        handle_cli_commands(args)
+
+        mock_generate.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+
+    @patch('mmrelay.cli.check_config')
+    @patch('sys.exit')
+    def test_handle_check_config_success(self, mock_exit, mock_check):
+        """Test handling --check-config command with success."""
+        args = MagicMock()
+        args.version = False
+        args.install_service = False
+        args.generate_config = False
+        args.check_config = True
+        mock_check.return_value = True
+
+        handle_cli_commands(args)
+
+        mock_check.assert_called_once()
+        mock_exit.assert_called_once_with(0)
+
+    @patch('mmrelay.cli.check_config')
+    @patch('sys.exit')
+    def test_handle_check_config_failure(self, mock_exit, mock_check):
+        """Test handling --check-config command with failure."""
+        args = MagicMock()
+        args.version = False
+        args.install_service = False
+        args.generate_config = False
+        args.check_config = True
+        mock_check.return_value = False
+
+        handle_cli_commands(args)
+
+        mock_check.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+
+    def test_handle_no_commands(self):
+        """Test when no CLI commands are specified."""
+        args = MagicMock()
+        args.version = False
+        args.install_service = False
+        args.generate_config = False
+        args.check_config = False
+
+        result = handle_cli_commands(args)
+
+        self.assertFalse(result)
+
+
+class TestMainFunction(unittest.TestCase):
+    """Test cases for main function."""
+
+    @patch('mmrelay.cli.parse_arguments')
+    @patch('mmrelay.cli.check_config')
+    def test_main_check_config_success(self, mock_check, mock_parse):
+        """Test main function with --check-config success."""
+        args = MagicMock()
+        args.check_config = True
+        args.install_service = False
+        args.generate_config = False
+        args.version = False
+        mock_parse.return_value = args
+        mock_check.return_value = True
+
+        result = main()
+
+        self.assertEqual(result, 0)
+        mock_check.assert_called_once_with(args)
+
+    @patch('mmrelay.cli.parse_arguments')
+    @patch('mmrelay.cli.check_config')
+    def test_main_check_config_failure(self, mock_check, mock_parse):
+        """Test main function with --check-config failure."""
+        args = MagicMock()
+        args.check_config = True
+        args.install_service = False
+        args.generate_config = False
+        args.version = False
+        mock_parse.return_value = args
+        mock_check.return_value = False
+
+        result = main()
+
+        self.assertEqual(result, 1)
+
+    @patch('mmrelay.cli.parse_arguments')
+    @patch('mmrelay.setup_utils.install_service')
+    def test_main_install_service_success(self, mock_install, mock_parse):
+        """Test main function with --install-service success."""
+        args = MagicMock()
+        args.check_config = False
+        args.install_service = True
+        args.generate_config = False
+        args.version = False
+        mock_parse.return_value = args
+        mock_install.return_value = True
+
+        result = main()
+
+        self.assertEqual(result, 0)
+        mock_install.assert_called_once()
+
+    @patch('mmrelay.cli.parse_arguments')
+    @patch('mmrelay.cli.generate_sample_config')
+    def test_main_generate_config_success(self, mock_generate, mock_parse):
+        """Test main function with --generate-config success."""
+        args = MagicMock()
+        args.check_config = False
+        args.install_service = False
+        args.generate_config = True
+        args.version = False
+        mock_parse.return_value = args
+        mock_generate.return_value = True
+
+        result = main()
+
+        self.assertEqual(result, 0)
+        mock_generate.assert_called_once()
+
+    @patch('mmrelay.cli.parse_arguments')
+    @patch('mmrelay.cli.print_version')
+    def test_main_version(self, mock_print_version, mock_parse):
+        """Test main function with --version."""
+        args = MagicMock()
+        args.check_config = False
+        args.install_service = False
+        args.generate_config = False
+        args.version = True
+        mock_parse.return_value = args
+
+        result = main()
+
+        self.assertEqual(result, 0)
+        mock_print_version.assert_called_once()
+
+    @patch('mmrelay.cli.parse_arguments')
+    @patch('mmrelay.main.run_main')
+    def test_main_run_main(self, mock_run_main, mock_parse):
+        """Test main function running normal functionality."""
+        args = MagicMock()
+        args.check_config = False
+        args.install_service = False
+        args.generate_config = False
+        args.version = False
+        mock_parse.return_value = args
+        mock_run_main.return_value = 0
+
+        result = main()
+
+        self.assertEqual(result, 0)
+        mock_run_main.assert_called_once_with(args)
 
 
 if __name__ == "__main__":

--- a/tests/test_config_checker.py
+++ b/tests/test_config_checker.py
@@ -26,7 +26,9 @@ class TestConfigChecker(unittest.TestCase):
     """Test cases for the configuration checker."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initializes a valid configuration dictionary for use in test cases.
+        """
         self.valid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -43,7 +45,11 @@ class TestConfigChecker(unittest.TestCase):
         }
 
     def test_get_config_paths(self):
-        """Test that get_config_paths returns a list of paths."""
+        """
+        Test that get_config_paths returns a list of configuration file paths.
+        
+        Asserts that the returned value is a list of the expected length and that the function is called exactly once.
+        """
         with patch('mmrelay.config.get_config_paths') as mock_get_paths:
             mock_get_paths.return_value = ['/path1/config.yaml', '/path2/config.yaml']
             
@@ -59,7 +65,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_valid_tcp(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test configuration validation with valid TCP configuration."""
+        """
+        Test that `check_config` returns True and prints success messages when provided with a valid TCP configuration.
+        """
         mock_get_paths.return_value = ['/test/config.yaml']
         mock_isfile.return_value = True
         mock_yaml_load.return_value = self.valid_config
@@ -76,7 +84,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_valid_serial(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test configuration validation with valid serial configuration."""
+        """
+        Test that `check_config` returns True and prints a success message when provided with a valid serial meshtastic configuration.
+        """
         serial_config = self.valid_config.copy()
         serial_config["meshtastic"] = {
             "connection_type": "serial",
@@ -98,7 +108,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_valid_ble(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test configuration validation with valid BLE configuration."""
+        """
+        Test that `check_config` successfully validates a configuration with a valid BLE connection type.
+        
+        Simulates a configuration file specifying a BLE connection and asserts that validation passes and the correct success message is printed.
+        """
         ble_config = self.valid_config.copy()
         ble_config["meshtastic"] = {
             "connection_type": "ble",
@@ -118,7 +132,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('os.path.isfile')
     @patch('builtins.print')
     def test_check_config_no_file_found(self, mock_print, mock_isfile, mock_get_paths):
-        """Test behavior when no configuration file is found."""
+        """
+        Test that check_config returns False and prints appropriate error messages when no configuration file is found at any of the discovered paths.
+        """
         mock_get_paths.return_value = ['/test/config.yaml', '/test2/config.yaml']
         mock_isfile.return_value = False
         
@@ -135,7 +151,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_empty_config(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with empty configuration."""
+        """
+        Test that check_config returns False and prints an error when the configuration file is empty or invalid.
+        """
         mock_get_paths.return_value = ['/test/config.yaml']
         mock_isfile.return_value = True
         mock_yaml_load.return_value = None
@@ -151,7 +169,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_matrix_section(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing matrix section."""
+        """
+        Test that check_config fails when the 'matrix' section is missing from the configuration.
+        
+        Asserts that the function returns False and prints the appropriate error message.
+        """
         invalid_config = {"meshtastic": {"connection_type": "tcp"}}
 
         mock_get_paths.return_value = ['/test/config.yaml']
@@ -169,7 +191,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_matrix_fields(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing required matrix fields."""
+        """
+        Test that check_config fails when required fields are missing from the 'matrix' section.
+        
+        Simulates a configuration missing 'access_token' and 'bot_user_id' in the 'matrix' section and asserts that validation fails with the appropriate error message.
+        """
         invalid_config = {
             "matrix": {"homeserver": "https://matrix.org"},  # Missing access_token and bot_user_id
             "matrix_rooms": [{"id": "!room1:matrix.org"}],
@@ -191,7 +217,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_matrix_rooms(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing matrix_rooms section."""
+        """
+        Test that `check_config` fails when the 'matrix_rooms' section is missing from the configuration.
+        
+        Asserts that the function returns False and prints an appropriate error message.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -216,7 +246,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_invalid_matrix_rooms_type(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with invalid matrix_rooms type."""
+        """
+        Test that check_config fails when the 'matrix_rooms' field is not a list.
+        
+        Asserts that the function returns False and prints an appropriate error message when 'matrix_rooms' is of an invalid type.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -242,7 +276,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_invalid_room_format(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with invalid room format in matrix_rooms."""
+        """
+        Test that check_config fails when an entry in 'matrix_rooms' is not a dictionary.
+        
+        Asserts that the function returns False and prints an appropriate error message when a non-dictionary object is present in the 'matrix_rooms' list.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -268,7 +306,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_room_id(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing room id in matrix_rooms."""
+        """
+        Test that check_config fails when a room in 'matrix_rooms' lacks the required 'id' field.
+        
+        Simulates a configuration where a room dictionary in 'matrix_rooms' is missing the 'id' key and asserts that check_config returns False and prints the appropriate error message.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -294,7 +336,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_meshtastic_section(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing meshtastic section."""
+        """
+        Test that `check_config` fails and prints an error when the 'meshtastic' section is missing from the configuration.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -319,7 +363,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_connection_type(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing connection_type in meshtastic section."""
+        """
+        Test that check_config fails when the 'connection_type' field is missing from the 'meshtastic' section of the configuration.
+        
+        Asserts that the function returns False and prints the appropriate error message.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -345,7 +393,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_invalid_connection_type(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with invalid connection_type."""
+        """
+        Test that check_config returns False and prints an error when the meshtastic connection_type is invalid.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -371,7 +421,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_serial_port(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing serial_port for serial connection."""
+        """
+        Test that check_config fails when 'serial_port' is missing for a serial connection type in the configuration.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -397,7 +449,11 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_tcp_host(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing host for TCP connection."""
+        """
+        Test that `check_config` fails when the 'host' field is missing for a TCP meshtastic connection.
+        
+        Asserts that the function returns False and prints the appropriate error message.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -423,7 +479,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_missing_ble_address(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with missing ble_address for BLE connection."""
+        """
+        Test that check_config fails when the 'ble_address' field is missing for a BLE connection type in the configuration.
+        """
         invalid_config = {
             "matrix": {
                 "homeserver": "https://matrix.org",
@@ -449,7 +507,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_yaml_error(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with YAML parsing error."""
+        """
+        Test that check_config returns False and prints an error message when a YAML parsing error occurs.
+        """
         from yaml import YAMLError
 
         mock_get_paths.return_value = ['/test/config.yaml']
@@ -467,7 +527,9 @@ class TestConfigChecker(unittest.TestCase):
     @patch('yaml.load')
     @patch('builtins.print')
     def test_check_config_general_exception(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
-        """Test behavior with general exception during config checking."""
+        """
+        Test that check_config returns False and prints an error message when a general exception occurs during configuration checking.
+        """
         mock_get_paths.return_value = ['/test/config.yaml']
         mock_isfile.return_value = True
         mock_yaml_load.side_effect = Exception("General error")

--- a/tests/test_config_checker.py
+++ b/tests/test_config_checker.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay configuration checker.
+
+Tests the configuration validation functionality including:
+- Configuration file discovery
+- YAML parsing and validation
+- Required field validation
+- Connection type validation
+- Error handling and reporting
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, mock_open
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.config_checker import check_config, get_config_paths
+
+
+class TestConfigChecker(unittest.TestCase):
+    """Test cases for the configuration checker."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.valid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [
+                {"id": "!room1:matrix.org", "meshtastic_channel": 0}
+            ],
+            "meshtastic": {
+                "connection_type": "tcp",
+                "host": "192.168.1.100"
+            }
+        }
+
+    def test_get_config_paths(self):
+        """Test that get_config_paths returns a list of paths."""
+        with patch('mmrelay.config.get_config_paths') as mock_get_paths:
+            mock_get_paths.return_value = ['/path1/config.yaml', '/path2/config.yaml']
+            
+            paths = get_config_paths()
+            
+            self.assertIsInstance(paths, list)
+            self.assertEqual(len(paths), 2)
+            mock_get_paths.assert_called_once()
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_valid_tcp(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test configuration validation with valid TCP configuration."""
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = self.valid_config
+        
+        result = check_config()
+        
+        self.assertTrue(result)
+        mock_print.assert_any_call("Found configuration file at: /test/config.yaml")
+        mock_print.assert_any_call("Configuration file is valid!")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_valid_serial(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test configuration validation with valid serial configuration."""
+        serial_config = self.valid_config.copy()
+        serial_config["meshtastic"] = {
+            "connection_type": "serial",
+            "serial_port": "/dev/ttyUSB0"
+        }
+        
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = serial_config
+        
+        result = check_config()
+        
+        self.assertTrue(result)
+        mock_print.assert_any_call("Configuration file is valid!")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_valid_ble(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test configuration validation with valid BLE configuration."""
+        ble_config = self.valid_config.copy()
+        ble_config["meshtastic"] = {
+            "connection_type": "ble",
+            "ble_address": "AA:BB:CC:DD:EE:FF"
+        }
+        
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = ble_config
+        
+        result = check_config()
+        
+        self.assertTrue(result)
+        mock_print.assert_any_call("Configuration file is valid!")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.print')
+    def test_check_config_no_file_found(self, mock_print, mock_isfile, mock_get_paths):
+        """Test behavior when no configuration file is found."""
+        mock_get_paths.return_value = ['/test/config.yaml', '/test2/config.yaml']
+        mock_isfile.return_value = False
+        
+        result = check_config()
+        
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: No configuration file found in any of the following locations:")
+        mock_print.assert_any_call("  - /test/config.yaml")
+        mock_print.assert_any_call("  - /test2/config.yaml")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_empty_config(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with empty configuration."""
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = None
+        
+        result = check_config()
+        
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Configuration file is empty or invalid")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_matrix_section(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing matrix section."""
+        invalid_config = {"meshtastic": {"connection_type": "tcp"}}
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing 'matrix' section in config")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_matrix_fields(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing required matrix fields."""
+        invalid_config = {
+            "matrix": {"homeserver": "https://matrix.org"},  # Missing access_token and bot_user_id
+            "matrix_rooms": [{"id": "!room1:matrix.org"}],
+            "meshtastic": {"connection_type": "tcp", "host": "192.168.1.100"}
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing required fields in 'matrix' section: access_token, bot_user_id")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_matrix_rooms(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing matrix_rooms section."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "meshtastic": {"connection_type": "tcp", "host": "192.168.1.100"}
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing or empty 'matrix_rooms' section in config")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_invalid_matrix_rooms_type(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with invalid matrix_rooms type."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": "not_a_list",  # Should be a list
+            "meshtastic": {"connection_type": "tcp", "host": "192.168.1.100"}
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: 'matrix_rooms' must be a list")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_invalid_room_format(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with invalid room format in matrix_rooms."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": ["not_a_dict"],  # Should be dict objects
+            "meshtastic": {"connection_type": "tcp", "host": "192.168.1.100"}
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Room 1 in 'matrix_rooms' must be a dictionary")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_room_id(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing room id in matrix_rooms."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [{"meshtastic_channel": 0}],  # Missing 'id' field
+            "meshtastic": {"connection_type": "tcp", "host": "192.168.1.100"}
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Room 1 in 'matrix_rooms' is missing the 'id' field")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_meshtastic_section(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing meshtastic section."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [{"id": "!room1:matrix.org"}]
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing 'meshtastic' section in config")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_connection_type(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing connection_type in meshtastic section."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [{"id": "!room1:matrix.org"}],
+            "meshtastic": {"host": "192.168.1.100"}  # Missing connection_type
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing 'connection_type' in 'meshtastic' section")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_invalid_connection_type(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with invalid connection_type."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [{"id": "!room1:matrix.org"}],
+            "meshtastic": {"connection_type": "invalid_type"}
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Invalid 'connection_type': invalid_type. Must be 'tcp', 'serial', or 'ble'")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_serial_port(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing serial_port for serial connection."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [{"id": "!room1:matrix.org"}],
+            "meshtastic": {"connection_type": "serial"}  # Missing serial_port
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing 'serial_port' for 'serial' connection type")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_tcp_host(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing host for TCP connection."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [{"id": "!room1:matrix.org"}],
+            "meshtastic": {"connection_type": "tcp"}  # Missing host
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing 'host' for 'tcp' connection type")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_missing_ble_address(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with missing ble_address for BLE connection."""
+        invalid_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [{"id": "!room1:matrix.org"}],
+            "meshtastic": {"connection_type": "ble"}  # Missing ble_address
+        }
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.return_value = invalid_config
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error: Missing 'ble_address' for 'ble' connection type")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_yaml_error(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with YAML parsing error."""
+        from yaml import YAMLError
+
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.side_effect = YAMLError("Invalid YAML syntax")
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error parsing YAML in /test/config.yaml: Invalid YAML syntax")
+
+    @patch('mmrelay.config_checker.get_config_paths')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.load')
+    @patch('builtins.print')
+    def test_check_config_general_exception(self, mock_print, mock_yaml_load, mock_file, mock_isfile, mock_get_paths):
+        """Test behavior with general exception during config checking."""
+        mock_get_paths.return_value = ['/test/config.yaml']
+        mock_isfile.return_value = True
+        mock_yaml_load.side_effect = Exception("General error")
+
+        result = check_config()
+
+        self.assertFalse(result)
+        mock_print.assert_any_call("Error checking configuration: General error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -112,9 +112,14 @@ class TestDbUtils(unittest.TestCase):
         mmrelay.db_utils.config = None
         clear_db_path_cache()
         
-        mock_get_data_dir.return_value = "/test/data"
-        path = get_db_path()
-        self.assertEqual(path, "/test/data/meshtastic.sqlite")
+        import tempfile
+        import os
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_get_data_dir.return_value = temp_dir
+            path = get_db_path()
+            expected_path = os.path.join(temp_dir, "meshtastic.sqlite")
+            self.assertEqual(path, expected_path)
 
     def test_get_db_path_legacy_config(self):
         """

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -103,9 +103,9 @@ class TestDbUtils(unittest.TestCase):
     @patch('mmrelay.db_utils.get_data_dir')
     def test_get_db_path_default(self, mock_get_data_dir):
         """
-        Test that the database path defaults to the data directory when no configuration is set.
+        Test that `get_db_path()` returns the default database path in the absence of configuration.
         
-        Verifies that `get_db_path()` returns the expected default path using a mocked data directory when configuration is absent.
+        Mocks the data directory to verify that the default path is constructed correctly when no configuration is set.
         """
         # Clear config to test default behavior
         import mmrelay.db_utils
@@ -123,7 +123,7 @@ class TestDbUtils(unittest.TestCase):
 
     def test_get_db_path_legacy_config(self):
         """
-        Test that the database path is correctly resolved when using a legacy configuration format with the 'db.path' key.
+        Test that get_db_path() returns the correct database path when using a legacy configuration with the 'db.path' key.
         """
         # Use legacy db.path format
         legacy_config = {

--- a/tests/test_drop_plugin.py
+++ b/tests/test_drop_plugin.py
@@ -29,6 +29,11 @@ class TestDropPlugin(unittest.TestCase):
         self.plugin = Plugin()
         self.plugin.config = {"radius_km": 5}
         self.plugin.logger = MagicMock()
+
+        # Mock database operations
+        self.plugin.store_node_data = MagicMock()
+        self.plugin.get_node_data = MagicMock(return_value=[])
+        self.plugin.set_node_data = MagicMock()
         
         # Mock meshtastic client
         self.mock_meshtastic_client = MagicMock()
@@ -74,9 +79,6 @@ class TestDropPlugin(unittest.TestCase):
     def test_handle_meshtastic_message_drop_valid(self, mock_connect):
         """Test dropping a message with valid position data."""
         mock_connect.return_value = self.mock_meshtastic_client
-
-        # Mock plugin methods
-        self.plugin.store_node_data = MagicMock()
 
         packet = {
             "fromId": "!12345678",
@@ -189,8 +191,7 @@ class TestDropPlugin(unittest.TestCase):
             }
         ]
 
-        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
-        self.plugin.set_node_data = MagicMock()
+        self.plugin.get_node_data.return_value = stored_messages
 
         packet = {
             "fromId": "!12345678",  # Node1 with position
@@ -232,8 +233,7 @@ class TestDropPlugin(unittest.TestCase):
             }
         ]
 
-        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
-        self.plugin.set_node_data = MagicMock()
+        self.plugin.get_node_data.return_value = stored_messages
 
         packet = {
             "fromId": "!12345678",  # Node1 with position
@@ -273,8 +273,7 @@ class TestDropPlugin(unittest.TestCase):
             }
         ]
 
-        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
-        self.plugin.set_node_data = MagicMock()
+        self.plugin.get_node_data.return_value = stored_messages
 
         packet = {
             "fromId": "!12345678",  # Same as originator
@@ -314,8 +313,7 @@ class TestDropPlugin(unittest.TestCase):
             }
         ]
 
-        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
-        self.plugin.set_node_data = MagicMock()
+        self.plugin.get_node_data.return_value = stored_messages
 
         packet = {
             "fromId": "!12345678",

--- a/tests/test_drop_plugin.py
+++ b/tests/test_drop_plugin.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay drop plugin.
+
+Tests the message drop and pickup functionality including:
+- Message dropping with location validation
+- Message pickup based on proximity
+- Location-based filtering
+- Node data storage and retrieval
+- Error handling for invalid positions
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.drop_plugin import Plugin
+
+
+class TestDropPlugin(unittest.TestCase):
+    """Test cases for the drop plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.config = {"radius_km": 5}
+        self.plugin.logger = MagicMock()
+        
+        # Mock meshtastic client
+        self.mock_meshtastic_client = MagicMock()
+        self.mock_meshtastic_client.nodes = {
+            "node1": {
+                "user": {"id": "!12345678"},
+                "position": {"latitude": 40.7128, "longitude": -74.0060}
+            },
+            "node2": {
+                "user": {"id": "!87654321"},
+                "position": {"latitude": 40.7589, "longitude": -73.9851}
+            },
+            "node3": {
+                "user": {"id": "!11111111"}
+                # No position data
+            }
+        }
+        self.mock_meshtastic_client.getMyNodeInfo.return_value = {
+            "user": {"id": "!relay123"}
+        }
+
+    def test_get_position_with_valid_node(self):
+        """Test getting position for a node that exists with position data."""
+        position = self.plugin.get_position(self.mock_meshtastic_client, "!12345678")
+        
+        self.assertIsNotNone(position)
+        self.assertEqual(position["latitude"], 40.7128)
+        self.assertEqual(position["longitude"], -74.0060)
+
+    def test_get_position_with_node_no_position(self):
+        """Test getting position for a node that exists but has no position data."""
+        position = self.plugin.get_position(self.mock_meshtastic_client, "!11111111")
+        
+        self.assertIsNone(position)
+
+    def test_get_position_with_nonexistent_node(self):
+        """Test getting position for a node that doesn't exist."""
+        position = self.plugin.get_position(self.mock_meshtastic_client, "!99999999")
+        
+        self.assertIsNone(position)
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_drop_valid(self, mock_connect):
+        """Test dropping a message with valid position data."""
+        mock_connect.return_value = self.mock_meshtastic_client
+        
+        # Mock plugin methods
+        self.plugin.store_node_data = MagicMock()
+        
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!drop This is a test message"
+            }
+        }
+        
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+        
+        self.assertTrue(result)
+        self.plugin.store_node_data.assert_called_once()
+        call_args = self.plugin.store_node_data.call_args
+        self.assertEqual(call_args[0][0], "!NODE_MSGS!")
+        stored_data = call_args[0][1]
+        self.assertEqual(stored_data["text"], "This is a test message")
+        self.assertEqual(stored_data["originator"], "!12345678")
+        self.assertEqual(stored_data["location"], (40.7128, -74.0060))
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_drop_no_position(self, mock_connect):
+        """Test dropping a message when node has no position data."""
+        mock_connect.return_value = self.mock_meshtastic_client
+        
+        packet = {
+            "fromId": "!11111111",  # Node without position
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!drop This should fail"
+            }
+        }
+        
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+        
+        self.assertTrue(result)  # Returns True but doesn't store
+        self.plugin.logger.debug.assert_called_with(
+            "Position of dropping node is not known. Skipping ..."
+        )
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_not_drop_command(self, mock_connect):
+        """Test handling a message that's not a drop command."""
+        mock_connect.return_value = self.mock_meshtastic_client
+        
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Just a regular message"
+            }
+        }
+        
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+        
+        self.assertFalse(result)
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_invalid_drop_format(self, mock_connect):
+        """Test handling a drop command with invalid format."""
+        mock_connect.return_value = self.mock_meshtastic_client
+        
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!drop"  # No message content
+            }
+        }
+        
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+        
+        self.assertFalse(result)
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_pickup_in_range(self, mock_connect):
+        """Test picking up messages when in range."""
+        mock_connect.return_value = self.mock_meshtastic_client
+        
+        # Mock stored messages
+        stored_messages = [
+            {
+                "location": (40.7128, -74.0060),  # Same as node1 location
+                "text": "Pickup this message",
+                "originator": "!99999999"  # Different from packet sender
+            }
+        ]
+        
+        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
+        self.plugin.set_node_data = MagicMock()
+        
+        packet = {
+            "fromId": "!12345678",  # Node1 with position
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Some message"
+            }
+        }
+        
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+        
+        # Should send the message to the node
+        self.mock_meshtastic_client.sendText.assert_called_once_with(
+            text="Pickup this message", destinationId="!12345678"
+        )
+        
+        # Should clear the messages (empty list)
+        self.plugin.set_node_data.assert_called_once_with("!NODE_MSGS!", [])
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_pickup_out_of_range(self, mock_connect):
+        """Test that messages out of range are not picked up."""
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        # Mock stored messages at a distant location
+        stored_messages = [
+            {
+                "location": (41.0000, -75.0000),  # Far from node1 location
+                "text": "Distant message",
+                "originator": "!99999999"
+            }
+        ]
+
+        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
+        self.plugin.set_node_data = MagicMock()
+
+        packet = {
+            "fromId": "!12345678",  # Node1 with position
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Some message"
+            }
+        }
+
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+
+        # Should not send the message
+        self.mock_meshtastic_client.sendText.assert_not_called()
+
+        # Should keep the message in storage
+        self.plugin.set_node_data.assert_called_once_with("!NODE_MSGS!", stored_messages)
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_skip_own_messages(self, mock_connect):
+        """Test that nodes cannot pickup their own dropped messages."""
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        # Mock stored messages from the same originator
+        stored_messages = [
+            {
+                "location": (40.7128, -74.0060),
+                "text": "Own message",
+                "originator": "!12345678"  # Same as packet sender
+            }
+        ]
+
+        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
+        self.plugin.set_node_data = MagicMock()
+
+        packet = {
+            "fromId": "!12345678",  # Same as originator
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Some message"
+            }
+        }
+
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+
+        # Should not send the message
+        self.mock_meshtastic_client.sendText.assert_not_called()
+
+        # Should keep the message in storage (can't pickup own messages)
+        self.plugin.set_node_data.assert_called_once_with("!NODE_MSGS!", stored_messages)
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_distance_calculation_error(self, mock_connect):
+        """Test handling of distance calculation errors."""
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        # Mock stored messages with invalid location data
+        stored_messages = [
+            {
+                "location": "invalid_location",  # Invalid location format
+                "text": "Message with bad location",
+                "originator": "!99999999"
+            }
+        ]
+
+        self.plugin.get_node_data = MagicMock(return_value=stored_messages)
+        self.plugin.set_node_data = MagicMock()
+
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Some message"
+            }
+        }
+
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+
+        # Should not send the message (distance defaults to 1000km, out of range)
+        self.mock_meshtastic_client.sendText.assert_not_called()
+
+        # Should keep the message in storage
+        self.plugin.set_node_data.assert_called_once_with("!NODE_MSGS!", stored_messages)
+
+    @patch('mmrelay.plugins.drop_plugin.connect_meshtastic')
+    async def test_handle_meshtastic_message_from_relay_node(self, mock_connect):
+        """Test that messages from the relay node itself are ignored for pickup."""
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        packet = {
+            "fromId": "!relay123",  # Same as relay node ID
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Message from relay"
+            }
+        }
+
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+
+        # Should not process pickup for relay's own messages
+        self.assertIsNone(result)
+
+    def test_handle_room_message_with_matching_command(self):
+        """Test handling Matrix room messages with matching commands."""
+        # Mock the matches method to return True
+        self.plugin.matches = MagicMock(return_value=True)
+
+        room = MagicMock()
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertTrue(result)
+            self.plugin.matches.assert_called_once_with(event)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_without_matching_command(self):
+        """Test handling Matrix room messages without matching commands."""
+        # Mock the matches method to return False
+        self.plugin.matches = MagicMock(return_value=False)
+
+        room = MagicMock()
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertIsNone(result)  # Returns None when no match
+            self.plugin.matches.assert_called_once_with(event)
+
+        import asyncio
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_health_plugin.py
+++ b/tests/test_health_plugin.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay health plugin.
+
+Tests the mesh health statistics functionality including:
+- Battery level statistics (average, median, low battery count)
+- Air utilization statistics
+- SNR (Signal-to-Noise Ratio) statistics
+- Node counting and health reporting
+- Matrix room message handling
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.health_plugin import Plugin
+
+
+class TestHealthPlugin(unittest.TestCase):
+    """Test cases for the health plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        
+        # Mock Matrix client methods
+        self.plugin.send_matrix_message = AsyncMock()
+        
+        # Create sample node data for testing
+        self.sample_nodes = {
+            "node1": {
+                "deviceMetrics": {
+                    "batteryLevel": 85,
+                    "airUtilTx": 12.5
+                },
+                "snr": 10.2
+            },
+            "node2": {
+                "deviceMetrics": {
+                    "batteryLevel": 45,
+                    "airUtilTx": 8.3
+                },
+                "snr": -5.1
+            },
+            "node3": {
+                "deviceMetrics": {
+                    "batteryLevel": 5,  # Low battery
+                    "airUtilTx": 15.7
+                },
+                "snr": 2.8
+            },
+            "node4": {
+                # Node with missing deviceMetrics
+                "snr": 7.5
+            },
+            "node5": {
+                "deviceMetrics": {
+                    "batteryLevel": 92
+                    # Missing airUtilTx
+                },
+                "snr": None  # None SNR value
+            }
+        }
+
+    def test_plugin_name(self):
+        """Test that plugin name is correctly set."""
+        self.assertEqual(self.plugin.plugin_name, "health")
+
+    def test_description_property(self):
+        """Test that description property returns expected string."""
+        description = self.plugin.description
+        self.assertEqual(description, "Show mesh health using avg battery, SNR, AirUtil")
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_with_full_data(self, mock_connect):
+        """Test response generation with complete node data."""
+        mock_meshtastic_client = MagicMock()
+        mock_meshtastic_client.nodes = self.sample_nodes
+        mock_connect.return_value = mock_meshtastic_client
+        
+        response = self.plugin.generate_response()
+        
+        # Should contain node count
+        self.assertIn("Nodes: 5", response)
+        
+        # Should contain battery statistics
+        # Battery levels: [85, 45, 5, 92] -> avg=56.75, median=65.0
+        self.assertIn("Battery: 56.8%", response)  # Rounded to 1 decimal
+        self.assertIn("65.0%", response)  # Median
+        
+        # Should contain low battery count (< 10%)
+        self.assertIn("Nodes with Low Battery (< 10): 1", response)
+        
+        # Should contain air util statistics
+        # Air util: [12.5, 8.3, 15.7] -> avg=12.17, median=12.5
+        self.assertIn("Air Util: 12.17", response)
+        self.assertIn("12.50", response)
+        
+        # Should contain SNR statistics
+        # SNR: [10.2, -5.1, 2.8, 7.5] (None filtered out) -> avg=3.85, median=5.15
+        self.assertIn("SNR: 3.85", response)
+        self.assertIn("5.15", response)
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_with_empty_nodes(self, mock_connect):
+        """Test response generation with no nodes (exposes bug in plugin)."""
+        mock_meshtastic_client = MagicMock()
+        mock_meshtastic_client.nodes = {}
+        mock_connect.return_value = mock_meshtastic_client
+
+        # The plugin has a bug - it doesn't check for empty lists before calling median()
+        with self.assertRaises(Exception):  # Will raise StatisticsError
+            self.plugin.generate_response()
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_with_minimal_data(self, mock_connect):
+        """Test response generation with minimal node data (exposes bug)."""
+        minimal_nodes = {
+            "node1": {
+                "deviceMetrics": {
+                    "batteryLevel": 50
+                }
+                # No SNR or airUtilTx
+            }
+        }
+
+        mock_meshtastic_client = MagicMock()
+        mock_meshtastic_client.nodes = minimal_nodes
+        mock_connect.return_value = mock_meshtastic_client
+
+        # The plugin has a bug - it tries to calculate median on empty air_util_tx and snr lists
+        with self.assertRaises(Exception):  # Will raise StatisticsError
+            self.plugin.generate_response()
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_with_all_low_battery(self, mock_connect):
+        """Test response generation with all nodes having low battery (exposes bug)."""
+        low_battery_nodes = {
+            "node1": {
+                "deviceMetrics": {
+                    "batteryLevel": 5
+                },
+                "snr": 10.0
+            },
+            "node2": {
+                "deviceMetrics": {
+                    "batteryLevel": 8
+                },
+                "snr": 5.0
+            }
+        }
+
+        mock_meshtastic_client = MagicMock()
+        mock_meshtastic_client.nodes = low_battery_nodes
+        mock_connect.return_value = mock_meshtastic_client
+
+        # The plugin has a bug - it tries to calculate median on empty air_util_tx list
+        with self.assertRaises(Exception):  # Will raise StatisticsError
+            self.plugin.generate_response()
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_filters_none_values(self, mock_connect):
+        """Test that None values are properly filtered from statistics."""
+        nodes_with_none = {
+            "node1": {
+                "deviceMetrics": {
+                    "batteryLevel": 75,
+                    "airUtilTx": None  # None value should be filtered
+                },
+                "snr": None  # None value should be filtered
+            },
+            "node2": {
+                "deviceMetrics": {
+                    "batteryLevel": 25,
+                    "airUtilTx": 10.0
+                },
+                "snr": 5.0
+            }
+        }
+        
+        mock_meshtastic_client = MagicMock()
+        mock_meshtastic_client.nodes = nodes_with_none
+        mock_connect.return_value = mock_meshtastic_client
+        
+        response = self.plugin.generate_response()
+        
+        # Should only use non-None values for statistics
+        self.assertIn("Nodes: 2", response)
+        self.assertIn("Battery: 50.0%", response)  # Average of 75 and 25
+        self.assertIn("Air Util: 10.00", response)  # Only one valid value
+        self.assertIn("10.00", response)  # Median same as single value
+        self.assertIn("SNR: 5.00", response)  # Only one valid value
+
+    def test_handle_meshtastic_message_always_false(self):
+        """Test that handle_meshtastic_message always returns False."""
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                {}, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_no_match(self):
+        """Test handle_room_message when event doesn't match."""
+        self.plugin.matches = MagicMock(return_value=False)
+        
+        room = MagicMock()
+        event = MagicMock()
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_not_called()
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_room_message_with_match(self, mock_connect):
+        """Test handle_room_message when event matches."""
+        mock_meshtastic_client = MagicMock()
+        mock_meshtastic_client.nodes = self.sample_nodes
+        mock_connect.return_value = mock_meshtastic_client
+        
+        self.plugin.matches = MagicMock(return_value=True)
+        
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            
+            self.assertTrue(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_called_once()
+            
+            # Check the call arguments
+            call_args = self.plugin.send_matrix_message.call_args
+            self.assertEqual(call_args[0][0], "!test:matrix.org")  # room_id
+            self.assertIn("Nodes: 5", call_args[0][1])  # message content
+            self.assertEqual(call_args.kwargs['formatted'], False)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_health_plugin.py
+++ b/tests/test_health_plugin.py
@@ -25,7 +25,11 @@ class TestHealthPlugin(unittest.TestCase):
     """Test cases for the health plugin."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initializes the Plugin instance and prepares sample node data for health statistics tests.
+        
+        Sets up mocked logger and Matrix message sending methods, and defines a variety of node data scenarios including normal, low battery, missing metrics, and None values.
+        """
         self.plugin = Plugin()
         self.plugin.logger = MagicMock()
         
@@ -69,17 +73,25 @@ class TestHealthPlugin(unittest.TestCase):
         }
 
     def test_plugin_name(self):
-        """Test that plugin name is correctly set."""
+        """
+        Test that the plugin's name attribute is set to "health".
+        """
         self.assertEqual(self.plugin.plugin_name, "health")
 
     def test_description_property(self):
-        """Test that description property returns expected string."""
+        """
+        Test that the plugin's description property returns the expected summary string.
+        """
         description = self.plugin.description
         self.assertEqual(description, "Show mesh health using avg battery, SNR, AirUtil")
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_with_full_data(self, mock_connect):
-        """Test response generation with complete node data."""
+        """
+        Verifies that the plugin generates a correct health summary response when provided with complete node data.
+        
+        Checks that the response includes accurate node count, battery statistics (average, median, low battery count), air utilization statistics (average, median), and SNR statistics (average, median), with values rounded as expected.
+        """
         mock_meshtastic_client = MagicMock()
         mock_meshtastic_client.nodes = self.sample_nodes
         mock_connect.return_value = mock_meshtastic_client
@@ -109,7 +121,11 @@ class TestHealthPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_with_empty_nodes(self, mock_connect):
-        """Test response generation with no nodes (exposes bug in plugin)."""
+        """
+        Test that generating a response with no nodes raises an exception due to empty data lists.
+        
+        Verifies that the plugin does not handle empty node data and raises an exception (such as StatisticsError) when attempting to compute statistics.
+        """
         mock_meshtastic_client = MagicMock()
         mock_meshtastic_client.nodes = {}
         mock_connect.return_value = mock_meshtastic_client
@@ -120,7 +136,11 @@ class TestHealthPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_with_minimal_data(self, mock_connect):
-        """Test response generation with minimal node data (exposes bug)."""
+        """
+        Test that generating a response with minimal node data raises an exception due to missing metrics.
+        
+        This test verifies that the plugin raises an exception (such as StatisticsError) when attempting to compute statistics on empty air utilization and SNR lists, exposing a bug in the response generation logic.
+        """
         minimal_nodes = {
             "node1": {
                 "deviceMetrics": {
@@ -140,7 +160,11 @@ class TestHealthPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_with_all_low_battery(self, mock_connect):
-        """Test response generation with all nodes having low battery (exposes bug)."""
+        """
+        Test that response generation raises an exception when all nodes have low battery and air utilization data is missing.
+        
+        This verifies that the plugin attempts to compute statistics on empty air utilization data, exposing a known bug.
+        """
         low_battery_nodes = {
             "node1": {
                 "deviceMetrics": {
@@ -166,7 +190,9 @@ class TestHealthPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_filters_none_values(self, mock_connect):
-        """Test that None values are properly filtered from statistics."""
+        """
+        Verify that the health plugin correctly filters out None values from node statistics before calculating and reporting mesh health metrics.
+        """
         nodes_with_none = {
             "node1": {
                 "deviceMetrics": {
@@ -198,8 +224,13 @@ class TestHealthPlugin(unittest.TestCase):
         self.assertIn("SNR: 5.00", response)  # Only one valid value
 
     def test_handle_meshtastic_message_always_false(self):
-        """Test that handle_meshtastic_message always returns False."""
+        """
+        Test that handle_meshtastic_message consistently returns False regardless of input.
+        """
         async def run_test():
+            """
+            Asynchronously tests that the plugin's handle_meshtastic_message method returns False when called with sample input.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 {}, "formatted_message", "longname", "meshnet_name"
             )
@@ -209,13 +240,18 @@ class TestHealthPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_no_match(self):
-        """Test handle_room_message when event doesn't match."""
+        """
+        Test that handle_room_message returns False and does not send a message when the event does not match the plugin criteria.
+        """
         self.plugin.matches = MagicMock(return_value=False)
         
         room = MagicMock()
         event = MagicMock()
         
         async def run_test():
+            """
+            Asynchronously tests that `handle_room_message` returns False when the event does not match and ensures no Matrix message is sent.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -226,7 +262,11 @@ class TestHealthPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_handle_room_message_with_match(self, mock_connect):
-        """Test handle_room_message when event matches."""
+        """
+        Tests that handle_room_message sends a health summary message to the Matrix room when the event matches.
+        
+        Verifies that the message contains the correct node count, is sent to the expected room, and the formatted flag is set to False.
+        """
         mock_meshtastic_client = MagicMock()
         mock_meshtastic_client.nodes = self.sample_nodes
         mock_connect.return_value = mock_meshtastic_client
@@ -238,6 +278,11 @@ class TestHealthPlugin(unittest.TestCase):
         event = MagicMock()
         
         async def run_test():
+            """
+            Asynchronously tests that a Matrix room message event matching the plugin triggers a health summary message to be sent.
+            
+            Verifies that `handle_room_message` returns True, the event matcher is called once, and the Matrix message is sent with the correct room ID, message content, and formatting flag.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
             
             self.assertTrue(result)

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -25,7 +25,9 @@ class TestHelpPlugin(unittest.TestCase):
     """Test cases for the help plugin."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initialize the test environment by creating a Plugin instance, mocking its logger and message sending method, and setting up mock plugins with predefined commands and descriptions.
+        """
         self.plugin = Plugin()
         self.plugin.logger = MagicMock()
         
@@ -46,27 +48,40 @@ class TestHelpPlugin(unittest.TestCase):
         self.mock_plugin3.description = "List supported relay commands"
 
     def test_plugin_name(self):
-        """Test that plugin name is correctly set."""
+        """
+        Verify that the plugin's name is set to "help".
+        """
         self.assertEqual(self.plugin.plugin_name, "help")
 
     def test_description_property(self):
-        """Test that description property returns expected string."""
+        """
+        Test that the help plugin's description property returns the expected string.
+        """
         description = self.plugin.description
         self.assertEqual(description, "List supported relay commands")
 
     def test_get_matrix_commands(self):
-        """Test that get_matrix_commands returns help command."""
+        """
+        Test that the help plugin reports 'help' as its supported Matrix command.
+        """
         commands = self.plugin.get_matrix_commands()
         self.assertEqual(commands, ["help"])
 
     def test_get_mesh_commands(self):
-        """Test that get_mesh_commands returns empty list."""
+        """
+        Test that the help plugin reports no supported Meshtastic commands.
+        """
         commands = self.plugin.get_mesh_commands()
         self.assertEqual(commands, [])
 
     def test_handle_meshtastic_message_always_false(self):
-        """Test that handle_meshtastic_message always returns False."""
+        """
+        Test that handle_meshtastic_message always returns False, regardless of input.
+        """
         async def run_test():
+            """
+            Asynchronously tests that handle_meshtastic_message always returns False for the help plugin.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 {}, "formatted_message", "longname", "meshnet_name"
             )
@@ -76,13 +91,18 @@ class TestHelpPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_no_match(self):
-        """Test handle_room_message when event doesn't match."""
+        """
+        Test that handle_room_message returns False and does not send a message when the event does not match the help command.
+        """
         self.plugin.matches = MagicMock(return_value=False)
         
         room = MagicMock()
         event = MagicMock()
         
         async def run_test():
+            """
+            Asynchronously tests that handle_room_message returns False and does not send a message when the event does not match the help command.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -93,7 +113,11 @@ class TestHelpPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.help_plugin.load_plugins')
     def test_handle_room_message_general_help(self, mock_load_plugins):
-        """Test handle_room_message with general help command."""
+        """
+        Test that a general help command triggers a message listing all available commands from loaded plugins.
+        
+        Verifies that when the help command is invoked, the plugin responds with a message containing all supported commands, and that the message is sent to the correct Matrix room.
+        """
         mock_load_plugins.return_value = [self.mock_plugin1, self.mock_plugin2, self.mock_plugin3]
         self.plugin.matches = MagicMock(return_value=True)
         
@@ -103,6 +127,11 @@ class TestHelpPlugin(unittest.TestCase):
         full_message = "bot: !help"
         
         async def run_test():
+            """
+            Asynchronously tests that the help plugin sends a message listing all available commands when handling a general help request.
+            
+            Verifies that the plugin's `handle_room_message` method returns True, calls the `matches` and `send_matrix_message` methods once, and that the sent message includes all expected command names.
+            """
             result = await self.plugin.handle_room_message(room, event, full_message)
             
             self.assertTrue(result)
@@ -126,7 +155,11 @@ class TestHelpPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.help_plugin.load_plugins')
     def test_handle_room_message_specific_help_found(self, mock_load_plugins):
-        """Test handle_room_message with specific help command for existing command."""
+        """
+        Test that handle_room_message sends specific help information when a known command is requested.
+        
+        Verifies that when a help request for an existing command is received, the plugin responds with the correct command description.
+        """
         mock_load_plugins.return_value = [self.mock_plugin1, self.mock_plugin2, self.mock_plugin3]
         self.plugin.matches = MagicMock(return_value=True)
         
@@ -136,6 +169,11 @@ class TestHelpPlugin(unittest.TestCase):
         full_message = "bot: !help weather"
         
         async def run_test():
+            """
+            Asynchronously tests that requesting help for a specific command sends the correct help message.
+            
+            Verifies that invoking the help plugin with a specific command triggers sending a message containing the command and its description.
+            """
             result = await self.plugin.handle_room_message(room, event, full_message)
             
             self.assertTrue(result)
@@ -154,7 +192,11 @@ class TestHelpPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.help_plugin.load_plugins')
     def test_handle_room_message_specific_help_not_found(self, mock_load_plugins):
-        """Test handle_room_message with specific help command for non-existing command."""
+        """
+        Test that requesting help for a nonexistent command results in an appropriate error message.
+        
+        Verifies that when a specific help command is issued for a command that does not exist, the plugin responds with an error message indicating the command was not found.
+        """
         mock_load_plugins.return_value = [self.mock_plugin1, self.mock_plugin2, self.mock_plugin3]
         self.plugin.matches = MagicMock(return_value=True)
         
@@ -164,6 +206,11 @@ class TestHelpPlugin(unittest.TestCase):
         full_message = "bot: !help nonexistent"
         
         async def run_test():
+            """
+            Asynchronously tests that requesting help for a nonexistent command returns an appropriate error message.
+            
+            Verifies that the help plugin responds with "No such command: nonexistent" and sends a Matrix message when a nonexistent command is queried.
+            """
             result = await self.plugin.handle_room_message(room, event, full_message)
             
             self.assertTrue(result)
@@ -181,7 +228,11 @@ class TestHelpPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.help_plugin.load_plugins')
     def test_handle_room_message_multiple_commands_per_plugin(self, mock_load_plugins):
-        """Test handle_room_message with plugins that have multiple commands."""
+        """
+        Test that handle_room_message lists all commands from plugins with multiple commands.
+        
+        Verifies that when the help command is invoked and plugins provide multiple commands, the help message includes all commands from all loaded plugins.
+        """
         # Plugin with multiple commands
         multi_command_plugin = MagicMock()
         multi_command_plugin.get_matrix_commands.return_value = ["cmd1", "cmd2", "cmd3"]
@@ -196,6 +247,9 @@ class TestHelpPlugin(unittest.TestCase):
         full_message = "bot: !help"
         
         async def run_test():
+            """
+            Asynchronously tests that the help plugin's room message handler returns True and sends a message containing all available commands from loaded plugins.
+            """
             result = await self.plugin.handle_room_message(room, event, full_message)
             
             self.assertTrue(result)
@@ -213,7 +267,11 @@ class TestHelpPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.help_plugin.load_plugins')
     def test_handle_room_message_specific_help_multi_command_plugin(self, mock_load_plugins):
-        """Test specific help for a command from a multi-command plugin."""
+        """
+        Test that requesting help for a specific command from a plugin with multiple commands returns the correct help message.
+        
+        Verifies that the help message includes the requested command and the plugin's description when a multi-command plugin is loaded.
+        """
         # Plugin with multiple commands
         multi_command_plugin = MagicMock()
         multi_command_plugin.get_matrix_commands.return_value = ["cmd1", "cmd2", "cmd3"]
@@ -228,6 +286,9 @@ class TestHelpPlugin(unittest.TestCase):
         full_message = "bot: !help cmd2"
         
         async def run_test():
+            """
+            Runs an asynchronous test to verify that requesting help for a specific command returns the correct help message, including the command and its plugin description.
+            """
             result = await self.plugin.handle_room_message(room, event, full_message)
             
             self.assertTrue(result)
@@ -243,7 +304,11 @@ class TestHelpPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.help_plugin.load_plugins')
     def test_handle_room_message_no_plugins(self, mock_load_plugins):
-        """Test handle_room_message when no plugins are loaded."""
+        """
+        Test that handle_room_message sends an empty command list message when no plugins are loaded.
+        
+        Verifies that when the help command is invoked and no plugins are available, the plugin responds with a message indicating no commands are present.
+        """
         mock_load_plugins.return_value = []
         self.plugin.matches = MagicMock(return_value=True)
         
@@ -253,6 +318,12 @@ class TestHelpPlugin(unittest.TestCase):
         full_message = "bot: !help"
         
         async def run_test():
+            """
+            Asynchronously tests that the help plugin returns an empty command list message when no plugins are loaded.
+            
+            Returns:
+                None
+            """
             result = await self.plugin.handle_room_message(room, event, full_message)
             
             self.assertTrue(result)

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay help plugin.
+
+Tests the help command functionality including:
+- General help command listing all available commands
+- Specific help command for individual plugins
+- Command discovery from loaded plugins
+- Matrix room message handling
+- Plugin description retrieval
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.help_plugin import Plugin
+
+
+class TestHelpPlugin(unittest.TestCase):
+    """Test cases for the help plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        
+        # Mock Matrix client methods
+        self.plugin.send_matrix_message = AsyncMock()
+        
+        # Create mock plugins for testing
+        self.mock_plugin1 = MagicMock()
+        self.mock_plugin1.get_matrix_commands.return_value = ["nodes", "health"]
+        self.mock_plugin1.description = "Show mesh nodes and health"
+        
+        self.mock_plugin2 = MagicMock()
+        self.mock_plugin2.get_matrix_commands.return_value = ["weather"]
+        self.mock_plugin2.description = "Show weather forecast"
+        
+        self.mock_plugin3 = MagicMock()
+        self.mock_plugin3.get_matrix_commands.return_value = ["help"]
+        self.mock_plugin3.description = "List supported relay commands"
+
+    def test_plugin_name(self):
+        """Test that plugin name is correctly set."""
+        self.assertEqual(self.plugin.plugin_name, "help")
+
+    def test_description_property(self):
+        """Test that description property returns expected string."""
+        description = self.plugin.description
+        self.assertEqual(description, "List supported relay commands")
+
+    def test_get_matrix_commands(self):
+        """Test that get_matrix_commands returns help command."""
+        commands = self.plugin.get_matrix_commands()
+        self.assertEqual(commands, ["help"])
+
+    def test_get_mesh_commands(self):
+        """Test that get_mesh_commands returns empty list."""
+        commands = self.plugin.get_mesh_commands()
+        self.assertEqual(commands, [])
+
+    def test_handle_meshtastic_message_always_false(self):
+        """Test that handle_meshtastic_message always returns False."""
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                {}, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_no_match(self):
+        """Test handle_room_message when event doesn't match."""
+        self.plugin.matches = MagicMock(return_value=False)
+        
+        room = MagicMock()
+        event = MagicMock()
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_not_called()
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.help_plugin.load_plugins')
+    def test_handle_room_message_general_help(self, mock_load_plugins):
+        """Test handle_room_message with general help command."""
+        mock_load_plugins.return_value = [self.mock_plugin1, self.mock_plugin2, self.mock_plugin3]
+        self.plugin.matches = MagicMock(return_value=True)
+        
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        full_message = "bot: !help"
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+            
+            self.assertTrue(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_called_once()
+            
+            # Check the call arguments
+            call_args = self.plugin.send_matrix_message.call_args
+            self.assertEqual(call_args[0][0], "!test:matrix.org")  # room_id
+            
+            # Should contain all available commands
+            message = call_args[0][1]
+            self.assertIn("Available commands:", message)
+            self.assertIn("nodes", message)
+            self.assertIn("health", message)
+            self.assertIn("weather", message)
+            self.assertIn("help", message)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.help_plugin.load_plugins')
+    def test_handle_room_message_specific_help_found(self, mock_load_plugins):
+        """Test handle_room_message with specific help command for existing command."""
+        mock_load_plugins.return_value = [self.mock_plugin1, self.mock_plugin2, self.mock_plugin3]
+        self.plugin.matches = MagicMock(return_value=True)
+        
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        full_message = "bot: !help weather"
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+            
+            self.assertTrue(result)
+            self.plugin.send_matrix_message.assert_called_once()
+            
+            # Check the call arguments
+            call_args = self.plugin.send_matrix_message.call_args
+            message = call_args[0][1]
+            
+            # Should contain specific help for weather command
+            self.assertIn("`!weather`:", message)
+            self.assertIn("Show weather forecast", message)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.help_plugin.load_plugins')
+    def test_handle_room_message_specific_help_not_found(self, mock_load_plugins):
+        """Test handle_room_message with specific help command for non-existing command."""
+        mock_load_plugins.return_value = [self.mock_plugin1, self.mock_plugin2, self.mock_plugin3]
+        self.plugin.matches = MagicMock(return_value=True)
+        
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        full_message = "bot: !help nonexistent"
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+            
+            self.assertTrue(result)
+            self.plugin.send_matrix_message.assert_called_once()
+            
+            # Check the call arguments
+            call_args = self.plugin.send_matrix_message.call_args
+            message = call_args[0][1]
+            
+            # Should contain error message
+            self.assertEqual(message, "No such command: nonexistent")
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.help_plugin.load_plugins')
+    def test_handle_room_message_multiple_commands_per_plugin(self, mock_load_plugins):
+        """Test handle_room_message with plugins that have multiple commands."""
+        # Plugin with multiple commands
+        multi_command_plugin = MagicMock()
+        multi_command_plugin.get_matrix_commands.return_value = ["cmd1", "cmd2", "cmd3"]
+        multi_command_plugin.description = "Multi-command plugin"
+        
+        mock_load_plugins.return_value = [multi_command_plugin, self.mock_plugin2]
+        self.plugin.matches = MagicMock(return_value=True)
+        
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        full_message = "bot: !help"
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+            
+            self.assertTrue(result)
+            call_args = self.plugin.send_matrix_message.call_args
+            message = call_args[0][1]
+            
+            # Should contain all commands from all plugins
+            self.assertIn("cmd1", message)
+            self.assertIn("cmd2", message)
+            self.assertIn("cmd3", message)
+            self.assertIn("weather", message)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.help_plugin.load_plugins')
+    def test_handle_room_message_specific_help_multi_command_plugin(self, mock_load_plugins):
+        """Test specific help for a command from a multi-command plugin."""
+        # Plugin with multiple commands
+        multi_command_plugin = MagicMock()
+        multi_command_plugin.get_matrix_commands.return_value = ["cmd1", "cmd2", "cmd3"]
+        multi_command_plugin.description = "Multi-command plugin"
+        
+        mock_load_plugins.return_value = [multi_command_plugin]
+        self.plugin.matches = MagicMock(return_value=True)
+        
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        full_message = "bot: !help cmd2"
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+            
+            self.assertTrue(result)
+            call_args = self.plugin.send_matrix_message.call_args
+            message = call_args[0][1]
+            
+            # Should show help for cmd2
+            self.assertIn("`!cmd2`:", message)
+            self.assertIn("Multi-command plugin", message)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.help_plugin.load_plugins')
+    def test_handle_room_message_no_plugins(self, mock_load_plugins):
+        """Test handle_room_message when no plugins are loaded."""
+        mock_load_plugins.return_value = []
+        self.plugin.matches = MagicMock(return_value=True)
+        
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        full_message = "bot: !help"
+        
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+            
+            self.assertTrue(result)
+            call_args = self.plugin.send_matrix_message.call_args
+            message = call_args[0][1]
+            
+            # Should show empty command list
+            self.assertEqual(message, "Available commands: ")
+        
+        import asyncio
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -377,23 +377,30 @@ class TestLogUtils(unittest.TestCase):
         
         Verifies that logger creation does not raise unexpected exceptions when file logging is enabled with an invalid path, and that either a valid Logger is returned or a PermissionError is raised.
         """
-        config = {
-            "logging": {
-                "log_to_file": True,
-                "filename": "/invalid/path/test.log"  # Invalid path
+        import tempfile
+        import os
+
+        # Use a path in a non-existent subdirectory of temp directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            invalid_path = os.path.join(temp_dir, "nonexistent", "test.log")
+
+            config = {
+                "logging": {
+                    "log_to_file": True,
+                    "filename": invalid_path  # Invalid path (parent dir doesn't exist)
+                }
             }
-        }
 
-        import mmrelay.log_utils
-        mmrelay.log_utils.config = config
+            import mmrelay.log_utils
+            mmrelay.log_utils.config = config
 
-        # Should not raise exception, just return logger
-        try:
-            logger = get_logger("test_logger")
-            self.assertIsInstance(logger, logging.Logger)
-        except PermissionError:
-            # This is expected behavior - the test passes if we get a permission error
-            pass
+            # Should not raise exception, just return logger
+            try:
+                logger = get_logger("test_logger")
+                self.assertIsInstance(logger, logging.Logger)
+            except PermissionError:
+                # This is expected behavior - the test passes if we get a permission error
+                pass
 
 
 if __name__ == "__main__":

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -373,9 +373,9 @@ class TestLogUtils(unittest.TestCase):
 
     def test_get_logger_file_creation_error(self):
         """
-        Test that get_logger handles file creation errors gracefully when an invalid log file path is provided.
+        Test that `get_logger` handles file creation errors gracefully when given an invalid log file path.
         
-        Verifies that logger creation does not raise unexpected exceptions when file logging is enabled with an invalid path, and that either a valid Logger is returned or a PermissionError is raised.
+        Ensures that enabling file logging with a non-existent directory does not raise unexpected exceptions, and that either a valid `Logger` is returned or a `PermissionError` is raised.
         """
         import tempfile
         import os

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -539,8 +539,8 @@ class TestMainFunctionEdgeCases(unittest.TestCase):
         except KeyboardInterrupt:
             pass
 
-        # Should call wipe_message_map
-        mock_wipe_db.assert_called_once()
+        # Should call wipe_message_map (may be called multiple times - startup and shutdown)
+        self.assertGreaterEqual(mock_wipe_db.call_count, 1)
 
     @patch('mmrelay.main.wipe_message_map')
     @patch('mmrelay.main.initialize_database')
@@ -575,8 +575,8 @@ class TestMainFunctionEdgeCases(unittest.TestCase):
         except KeyboardInterrupt:
             pass
 
-        # Should call wipe_message_map
-        mock_wipe_db.assert_called_once()
+        # Should call wipe_message_map (may be called multiple times - startup and shutdown)
+        self.assertGreaterEqual(mock_wipe_db.call_count, 1)
 
     @patch('mmrelay.main.initialize_database')
     @patch('mmrelay.main.load_plugins')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -293,5 +293,346 @@ class TestMain(unittest.TestCase):
             asyncio.run(main(self.mock_config))
 
 
+class TestPrintBanner(unittest.TestCase):
+    """Test cases for banner printing functionality."""
+
+    def setUp(self):
+        """Reset banner state before each test."""
+        import mmrelay.main
+        mmrelay.main._banner_printed = False
+
+    @patch('mmrelay.main.logger')
+    def test_print_banner_first_time(self, mock_logger):
+        """Test that banner is printed on first call."""
+        print_banner()
+        mock_logger.info.assert_called_once()
+        # Check that the message contains version info
+        call_args = mock_logger.info.call_args[0][0]
+        self.assertIn("Starting MMRelay", call_args)
+
+    @patch('mmrelay.main.logger')
+    def test_print_banner_subsequent_calls(self, mock_logger):
+        """Test that banner is only printed once."""
+        print_banner()
+        print_banner()  # Second call
+        # Should only be called once
+        mock_logger.info.assert_called_once()
+
+
+class TestRunMain(unittest.TestCase):
+    """Test cases for run_main function."""
+
+    def setUp(self):
+        """Reset banner state before each test."""
+        import mmrelay.main
+        mmrelay.main._banner_printed = False
+
+    @patch('asyncio.run')
+    @patch('mmrelay.config.load_config')
+    @patch('mmrelay.config.set_config')
+    @patch('mmrelay.log_utils.configure_component_debug_logging')
+    @patch('mmrelay.main.print_banner')
+    def test_run_main_success(self, mock_print_banner, mock_configure_logging,
+                             mock_set_config, mock_load_config, mock_asyncio_run):
+        """Test successful run_main execution."""
+        # Mock configuration
+        mock_config = {
+            "matrix": {"homeserver": "https://matrix.org"},
+            "meshtastic": {"connection_type": "serial"},
+            "matrix_rooms": [{"id": "!room:matrix.org"}]
+        }
+        mock_load_config.return_value = mock_config
+        mock_asyncio_run.return_value = None
+
+        # Mock args
+        mock_args = MagicMock()
+        mock_args.data_dir = None
+        mock_args.log_level = None
+
+        result = run_main(mock_args)
+
+        self.assertEqual(result, 0)
+        mock_print_banner.assert_called_once()
+        mock_load_config.assert_called_once_with(args=mock_args)
+        mock_asyncio_run.assert_called_once()
+
+    @patch('mmrelay.config.set_config')
+    @patch('mmrelay.config.load_config')
+    @patch('mmrelay.main.print_banner')
+    def test_run_main_missing_config_keys(self, mock_print_banner, mock_load_config, mock_set_config):
+        """Test run_main with missing required configuration keys."""
+        # Mock incomplete configuration
+        mock_config = {"matrix": {"homeserver": "https://matrix.org"}}  # Missing keys
+        mock_load_config.return_value = mock_config
+
+        mock_args = MagicMock()
+        mock_args.data_dir = None
+        mock_args.log_level = None
+
+        result = run_main(mock_args)
+
+        self.assertEqual(result, 1)  # Should return error code
+
+    @patch('asyncio.run')
+    @patch('mmrelay.config.load_config')
+    @patch('mmrelay.config.set_config')
+    @patch('mmrelay.log_utils.configure_component_debug_logging')
+    @patch('mmrelay.main.print_banner')
+    def test_run_main_keyboard_interrupt(self, mock_print_banner, mock_configure_logging,
+                                        mock_set_config, mock_load_config, mock_asyncio_run):
+        """Test run_main handling KeyboardInterrupt."""
+        mock_config = {
+            "matrix": {"homeserver": "https://matrix.org"},
+            "meshtastic": {"connection_type": "serial"},
+            "matrix_rooms": [{"id": "!room:matrix.org"}]
+        }
+        mock_load_config.return_value = mock_config
+        mock_asyncio_run.side_effect = KeyboardInterrupt()
+
+        mock_args = MagicMock()
+        mock_args.data_dir = None
+        mock_args.log_level = None
+
+        result = run_main(mock_args)
+
+        self.assertEqual(result, 0)  # Should return success on keyboard interrupt
+
+    @patch('asyncio.run')
+    @patch('mmrelay.config.load_config')
+    @patch('mmrelay.config.set_config')
+    @patch('mmrelay.log_utils.configure_component_debug_logging')
+    @patch('mmrelay.main.print_banner')
+    def test_run_main_exception(self, mock_print_banner, mock_configure_logging,
+                               mock_set_config, mock_load_config, mock_asyncio_run):
+        """Test run_main handling general exceptions."""
+        mock_config = {
+            "matrix": {"homeserver": "https://matrix.org"},
+            "meshtastic": {"connection_type": "serial"},
+            "matrix_rooms": [{"id": "!room:matrix.org"}]
+        }
+        mock_load_config.return_value = mock_config
+        mock_asyncio_run.side_effect = Exception("Test error")
+
+        mock_args = MagicMock()
+        mock_args.data_dir = None
+        mock_args.log_level = None
+
+        result = run_main(mock_args)
+
+        self.assertEqual(result, 1)  # Should return error code
+
+    @patch('os.makedirs')
+    @patch('os.path.abspath')
+    @patch('asyncio.run')
+    @patch('mmrelay.config.load_config')
+    @patch('mmrelay.config.set_config')
+    @patch('mmrelay.log_utils.configure_component_debug_logging')
+    @patch('mmrelay.main.print_banner')
+    def test_run_main_with_data_dir(self, mock_print_banner, mock_configure_logging,
+                                   mock_set_config, mock_load_config, mock_asyncio_run,
+                                   mock_abspath, mock_makedirs):
+        """Test run_main with custom data directory."""
+        mock_config = {
+            "matrix": {"homeserver": "https://matrix.org"},
+            "meshtastic": {"connection_type": "serial"},
+            "matrix_rooms": [{"id": "!room:matrix.org"}]
+        }
+        mock_load_config.return_value = mock_config
+        mock_asyncio_run.return_value = None
+        mock_abspath.return_value = "/custom/data/dir"
+
+        mock_args = MagicMock()
+        mock_args.data_dir = "/custom/data/dir"
+        mock_args.log_level = None
+
+        result = run_main(mock_args)
+
+        self.assertEqual(result, 0)
+        mock_abspath.assert_called_once_with("/custom/data/dir")
+        mock_makedirs.assert_called_once_with("/custom/data/dir", exist_ok=True)
+
+    @patch('asyncio.run')
+    @patch('mmrelay.config.load_config')
+    @patch('mmrelay.config.set_config')
+    @patch('mmrelay.log_utils.configure_component_debug_logging')
+    @patch('mmrelay.main.print_banner')
+    def test_run_main_with_log_level(self, mock_print_banner, mock_configure_logging,
+                                    mock_set_config, mock_load_config, mock_asyncio_run):
+        """Test run_main with custom log level."""
+        mock_config = {
+            "matrix": {"homeserver": "https://matrix.org"},
+            "meshtastic": {"connection_type": "serial"},
+            "matrix_rooms": [{"id": "!room:matrix.org"}]
+        }
+        mock_load_config.return_value = mock_config
+        mock_asyncio_run.return_value = None
+
+        mock_args = MagicMock()
+        mock_args.data_dir = None
+        mock_args.log_level = "DEBUG"
+
+        result = run_main(mock_args)
+
+        self.assertEqual(result, 0)
+        # Check that log level was set in config
+        self.assertEqual(mock_config["logging"]["level"], "DEBUG")
+
+
+class TestMainFunctionEdgeCases(unittest.TestCase):
+    """Test cases for edge cases in the main function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_config = {
+            "matrix": {
+                "homeserver": "https://matrix.org",
+                "access_token": "test_token",
+                "bot_user_id": "@bot:matrix.org"
+            },
+            "matrix_rooms": [
+                {"id": "!room1:matrix.org", "meshtastic_channel": 0}
+            ],
+            "meshtastic": {
+                "connection_type": "serial",
+                "serial_port": "/dev/ttyUSB0"
+            }
+        }
+
+    @patch('mmrelay.main.wipe_message_map')
+    @patch('mmrelay.main.initialize_database')
+    @patch('mmrelay.main.load_plugins')
+    @patch('mmrelay.main.start_message_queue')
+    @patch('mmrelay.main.connect_meshtastic')
+    @patch('mmrelay.main.connect_matrix')
+    @patch('mmrelay.main.join_matrix_room')
+    @patch('mmrelay.main.stop_message_queue')
+    def test_main_with_database_wipe_new_format(self, mock_stop_queue, mock_join_room,
+                                               mock_connect_matrix, mock_connect_meshtastic,
+                                               mock_start_queue, mock_load_plugins,
+                                               mock_init_db, mock_wipe_db):
+        """Test main function with database wipe enabled (new config format)."""
+        # Add database config with wipe_on_restart
+        config_with_wipe = self.mock_config.copy()
+        config_with_wipe["database"] = {
+            "msg_map": {"wipe_on_restart": True}
+        }
+
+        # Mock clients
+        mock_matrix_client = AsyncMock()
+        mock_connect_matrix.return_value = mock_matrix_client
+        mock_meshtastic_client = MagicMock()
+        mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+        # Mock the sync_forever to complete quickly
+        mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+
+        try:
+            asyncio.run(main(config_with_wipe))
+        except KeyboardInterrupt:
+            pass
+
+        # Should call wipe_message_map
+        mock_wipe_db.assert_called_once()
+
+    @patch('mmrelay.main.wipe_message_map')
+    @patch('mmrelay.main.initialize_database')
+    @patch('mmrelay.main.load_plugins')
+    @patch('mmrelay.main.start_message_queue')
+    @patch('mmrelay.main.connect_meshtastic')
+    @patch('mmrelay.main.connect_matrix')
+    @patch('mmrelay.main.join_matrix_room')
+    @patch('mmrelay.main.stop_message_queue')
+    def test_main_with_database_wipe_legacy_format(self, mock_stop_queue, mock_join_room,
+                                                  mock_connect_matrix, mock_connect_meshtastic,
+                                                  mock_start_queue, mock_load_plugins,
+                                                  mock_init_db, mock_wipe_db):
+        """Test main function with database wipe enabled (legacy config format)."""
+        # Add legacy database config with wipe_on_restart
+        config_with_wipe = self.mock_config.copy()
+        config_with_wipe["db"] = {
+            "msg_map": {"wipe_on_restart": True}
+        }
+
+        # Mock clients
+        mock_matrix_client = AsyncMock()
+        mock_connect_matrix.return_value = mock_matrix_client
+        mock_meshtastic_client = MagicMock()
+        mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+        # Mock the sync_forever to complete quickly
+        mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+
+        try:
+            asyncio.run(main(config_with_wipe))
+        except KeyboardInterrupt:
+            pass
+
+        # Should call wipe_message_map
+        mock_wipe_db.assert_called_once()
+
+    @patch('mmrelay.main.initialize_database')
+    @patch('mmrelay.main.load_plugins')
+    @patch('mmrelay.main.start_message_queue')
+    @patch('mmrelay.main.connect_meshtastic')
+    @patch('mmrelay.main.connect_matrix')
+    @patch('mmrelay.main.join_matrix_room')
+    @patch('mmrelay.main.stop_message_queue')
+    def test_main_with_custom_message_delay(self, mock_stop_queue, mock_join_room,
+                                           mock_connect_matrix, mock_connect_meshtastic,
+                                           mock_start_queue, mock_load_plugins, mock_init_db):
+        """Test main function with custom message delay configuration."""
+        # Add custom message delay
+        config_with_delay = self.mock_config.copy()
+        config_with_delay["meshtastic"]["message_delay"] = 5.0
+
+        # Mock clients
+        mock_matrix_client = AsyncMock()
+        mock_connect_matrix.return_value = mock_matrix_client
+        mock_meshtastic_client = MagicMock()
+        mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+        # Mock the sync_forever to complete quickly
+        mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+
+        try:
+            asyncio.run(main(config_with_delay))
+        except KeyboardInterrupt:
+            pass
+
+        # Should call start_message_queue with custom delay
+        mock_start_queue.assert_called_once_with(message_delay=5.0)
+
+    @patch('mmrelay.main.initialize_database')
+    @patch('mmrelay.main.load_plugins')
+    @patch('mmrelay.main.start_message_queue')
+    @patch('mmrelay.main.connect_meshtastic')
+    @patch('mmrelay.main.connect_matrix')
+    @patch('mmrelay.main.join_matrix_room')
+    @patch('mmrelay.main.update_longnames')
+    @patch('mmrelay.main.update_shortnames')
+    @patch('mmrelay.main.stop_message_queue')
+    def test_main_no_meshtastic_client_warning(self, mock_stop_queue, mock_update_short,
+                                              mock_update_long, mock_join_room,
+                                              mock_connect_matrix, mock_connect_meshtastic,
+                                              mock_start_queue, mock_load_plugins, mock_init_db):
+        """Test main function behavior when Meshtastic client is None."""
+        # Mock clients - Meshtastic returns None
+        mock_matrix_client = AsyncMock()
+        mock_connect_matrix.return_value = mock_matrix_client
+        mock_connect_meshtastic.return_value = None  # No Meshtastic client
+
+        # Mock the sync_forever to complete quickly
+        mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+
+        try:
+            asyncio.run(main(self.mock_config))
+        except KeyboardInterrupt:
+            pass
+
+        # Should not call update functions when no Meshtastic client
+        mock_update_long.assert_not_called()
+        mock_update_short.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -531,8 +531,9 @@ class TestMainFunctionEdgeCases(unittest.TestCase):
         mock_meshtastic_client = MagicMock()
         mock_connect_meshtastic.return_value = mock_meshtastic_client
 
-        # Mock the sync_forever to complete quickly
+        # Mock the sync_forever to complete quickly and mock callback methods
         mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+        mock_matrix_client.add_event_callback = MagicMock()  # Use regular mock for non-async method
 
         try:
             asyncio.run(main(config_with_wipe))
@@ -567,8 +568,9 @@ class TestMainFunctionEdgeCases(unittest.TestCase):
         mock_meshtastic_client = MagicMock()
         mock_connect_meshtastic.return_value = mock_meshtastic_client
 
-        # Mock the sync_forever to complete quickly
+        # Mock the sync_forever to complete quickly and mock callback methods
         mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+        mock_matrix_client.add_event_callback = MagicMock()  # Use regular mock for non-async method
 
         try:
             asyncio.run(main(config_with_wipe))
@@ -599,8 +601,9 @@ class TestMainFunctionEdgeCases(unittest.TestCase):
         mock_meshtastic_client = MagicMock()
         mock_connect_meshtastic.return_value = mock_meshtastic_client
 
-        # Mock the sync_forever to complete quickly
+        # Mock the sync_forever to complete quickly and mock callback methods
         mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+        mock_matrix_client.add_event_callback = MagicMock()  # Use regular mock for non-async method
 
         try:
             asyncio.run(main(config_with_delay))
@@ -629,8 +632,9 @@ class TestMainFunctionEdgeCases(unittest.TestCase):
         mock_connect_matrix.return_value = mock_matrix_client
         mock_connect_meshtastic.return_value = None  # No Meshtastic client
 
-        # Mock the sync_forever to complete quickly
+        # Mock the sync_forever to complete quickly and mock callback methods
         mock_matrix_client.sync_forever = AsyncMock(side_effect=KeyboardInterrupt())
+        mock_matrix_client.add_event_callback = MagicMock()  # Use regular mock for non-async method
 
         try:
             asyncio.run(main(self.mock_config))

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -42,7 +42,9 @@ class TestTextLabel(unittest.TestCase):
     """Test cases for TextLabel class."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initialize a TextLabel instance with a San Francisco coordinate and label for use in tests.
+        """
         self.latlng = s2sphere.LatLng.from_degrees(37.7749, -122.4194)  # San Francisco
         self.text_label = TextLabel(self.latlng, "Test Label", fontSize=12)
 
@@ -55,16 +57,22 @@ class TestTextLabel(unittest.TestCase):
         self.assertEqual(self.text_label._arrow, 16)
 
     def test_latlng(self):
-        """Test latlng property."""
+        """
+        Verify that the latlng property of the TextLabel instance returns the correct coordinate.
+        """
         self.assertEqual(self.text_label.latlng(), self.latlng)
 
     def test_bounds(self):
-        """Test bounds calculation."""
+        """
+        Test that the bounds() method returns an s2sphere.LatLngRect instance for the TextLabel.
+        """
         bounds = self.text_label.bounds()
         self.assertIsInstance(bounds, s2sphere.LatLngRect)
 
     def test_extra_pixel_bounds(self):
-        """Test extra pixel bounds calculation."""
+        """
+        Test that extra_pixel_bounds returns a 4-tuple of positive values representing the label's pixel bounds.
+        """
         bounds = self.text_label.extra_pixel_bounds()
         self.assertIsInstance(bounds, tuple)
         self.assertEqual(len(bounds), 4)
@@ -75,7 +83,9 @@ class TestTextLabel(unittest.TestCase):
 
     @patch('staticmaps.PillowRenderer')
     def test_render_pillow(self, mock_renderer_class):
-        """Test Pillow rendering."""
+        """
+        Tests that the TextLabel's Pillow rendering method calls the expected drawing operations for polygon, line, and text.
+        """
         mock_renderer = MagicMock()
         mock_transformer = MagicMock()
         mock_transformer.ll2pixel.return_value = (100, 100)
@@ -95,7 +105,9 @@ class TestTextLabel(unittest.TestCase):
 
     @patch('staticmaps.SvgRenderer')
     def test_render_svg(self, mock_renderer_class):
-        """Test SVG rendering."""
+        """
+        Tests that the SVG rendering of a TextLabel creates the expected SVG path and text elements and adds them to the group.
+        """
         mock_renderer = MagicMock()
         mock_transformer = MagicMock()
         mock_transformer.ll2pixel.return_value = (100, 100)
@@ -122,7 +134,9 @@ class TestTextSizeFunction(unittest.TestCase):
     """Test cases for textsize function."""
 
     def test_textsize(self):
-        """Test textsize function."""
+        """
+        Tests that the textsize function returns the correct width and height based on the drawing context's text bounding box.
+        """
         mock_draw = MagicMock()
         mock_draw.textbbox.return_value = (0, 0, 100, 20)
         
@@ -137,7 +151,9 @@ class TestAnonymizeLocation(unittest.TestCase):
     """Test cases for location anonymization."""
 
     def test_anonymize_location_default_radius(self):
-        """Test location anonymization with default radius."""
+        """
+        Verify that anonymize_location changes coordinates within approximately 1km when using the default radius.
+        """
         lat, lon = 37.7749, -122.4194
         new_lat, new_lon = anonymize_location(lat, lon)
         
@@ -152,7 +168,9 @@ class TestAnonymizeLocation(unittest.TestCase):
         self.assertLess(lon_diff, 0.01)
 
     def test_anonymize_location_custom_radius(self):
-        """Test location anonymization with custom radius."""
+        """
+        Verify that anonymize_location modifies coordinates within a custom radius and that the changes remain within expected bounds.
+        """
         lat, lon = 37.7749, -122.4194
         radius = 5000  # 5km
         new_lat, new_lon = anonymize_location(lat, lon, radius)
@@ -167,7 +185,9 @@ class TestAnonymizeLocation(unittest.TestCase):
         self.assertLess(lat_diff, 0.05)  # Roughly 5km in degrees
 
     def test_anonymize_location_zero_radius(self):
-        """Test location anonymization with zero radius."""
+        """
+        Verify that anonymizing a location with a zero radius returns coordinates nearly identical to the original.
+        """
         lat, lon = 37.7749, -122.4194
         new_lat, new_lon = anonymize_location(lat, lon, 0)
         
@@ -180,7 +200,9 @@ class TestGetMap(unittest.TestCase):
     """Test cases for map generation."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initialize test locations for use in map-related test cases.
+        """
         self.test_locations = [
             {"lat": 37.7749, "lon": -122.4194, "label": "SF"},
             {"lat": 37.7849, "lon": -122.4094, "label": "Oakland"},
@@ -188,7 +210,9 @@ class TestGetMap(unittest.TestCase):
 
     @patch('staticmaps.Context')
     def test_get_map_default_params(self, mock_context_class):
-        """Test map generation with default parameters."""
+        """
+        Test that get_map generates a map with default zoom and image size, and adds all provided locations.
+        """
         mock_context = MagicMock()
         mock_context_class.return_value = mock_context
         mock_context.render_pillow.return_value = MagicMock()
@@ -202,7 +226,9 @@ class TestGetMap(unittest.TestCase):
 
     @patch('staticmaps.Context')
     def test_get_map_custom_params(self, mock_context_class):
-        """Test map generation with custom parameters."""
+        """
+        Tests that get_map generates a map image using custom zoom, image size, anonymization, and radius parameters.
+        """
         mock_context = MagicMock()
         mock_context_class.return_value = mock_context
         mock_context.render_pillow.return_value = MagicMock()
@@ -221,7 +247,9 @@ class TestGetMap(unittest.TestCase):
     @patch('mmrelay.plugins.map_plugin.anonymize_location')
     @patch('staticmaps.Context')
     def test_get_map_with_anonymization(self, mock_context_class, mock_anonymize):
-        """Test map generation with location anonymization."""
+        """
+        Tests that `get_map` calls the anonymization function for each location when anonymization is enabled and a radius is specified.
+        """
         mock_context = MagicMock()
         mock_context_class.return_value = mock_context
         mock_context.render_pillow.return_value = MagicMock()
@@ -245,9 +273,14 @@ class TestImageUploadAndSend(unittest.TestCase):
         self.mock_upload_response.content_uri = "mxc://example.com/test123"
 
     def test_upload_image(self):
-        """Test image upload functionality."""
+        """
+        Test that the image upload function correctly saves the image to a buffer, uploads it using the client, and returns the upload response.
+        """
         async def run_test():
             # Mock image save
+            """
+            Asynchronously tests the upload_image function to ensure it uploads an image using the client and returns the expected upload response.
+            """
             mock_buffer = MagicMock()
             mock_buffer.getvalue.return_value = b"fake_image_data"
 
@@ -262,8 +295,13 @@ class TestImageUploadAndSend(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_send_room_image(self):
-        """Test sending image to room."""
+        """
+        Test that send_room_image sends an image message to the specified room with the correct content using the client.
+        """
         async def run_test():
+            """
+            Asynchronously tests that an image is sent to a Matrix room with the correct message content.
+            """
             room_id = "!test:example.com"
 
             await send_room_image(self.mock_client, room_id, self.mock_upload_response)
@@ -283,8 +321,15 @@ class TestImageUploadAndSend(unittest.TestCase):
     @patch('mmrelay.plugins.map_plugin.upload_image')
     @patch('mmrelay.plugins.map_plugin.send_room_image')
     def test_send_image(self, mock_send_room_image, mock_upload_image):
-        """Test complete image sending workflow."""
+        """
+        Test that the image sending workflow uploads an image and sends it to the specified room.
+        
+        Verifies that `upload_image` is called with the correct client and image, and that `send_room_image` is called with the resulting upload response.
+        """
         async def run_test():
+            """
+            Asynchronously tests the image sending workflow by verifying that image upload and room image sending functions are called with the correct arguments.
+            """
             room_id = "!test:example.com"
             mock_upload_image.return_value = self.mock_upload_response
 
@@ -302,7 +347,9 @@ class TestMapPlugin(unittest.TestCase):
     """Test cases for the map Plugin class."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initializes a Plugin instance and sets its configuration for use in tests.
+        """
         self.plugin = Plugin()
         self.plugin.config = {
             "zoom": 10,
@@ -313,19 +360,28 @@ class TestMapPlugin(unittest.TestCase):
         }
 
     def test_plugin_name(self):
-        """Test plugin name property."""
+        """
+        Test that the plugin_name property returns the expected value "map".
+        """
         self.assertEqual(self.plugin.plugin_name, "map")
 
     def test_description(self):
-        """Test plugin description."""
+        """
+        Verifies that the plugin's description contains expected keywords related to map functionality.
+        """
         description = self.plugin.description
         self.assertIn("Map of mesh radio nodes", description)
         self.assertIn("zoom", description)
         self.assertIn("size", description)
 
     def test_handle_meshtastic_message(self):
-        """Test handling Meshtastic messages."""
+        """
+        Tests that handle_meshtastic_message returns False when called with a Meshtastic message.
+        """
         async def run_test():
+            """
+            Asynchronously tests that the plugin's `handle_meshtastic_message` method returns False when invoked with a sample message.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet=MagicMock(),
                 formatted_message="test",
@@ -337,12 +393,16 @@ class TestMapPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_get_matrix_commands(self):
-        """Test getting Matrix commands."""
+        """
+        Test that the plugin returns the correct list of Matrix commands.
+        """
         commands = self.plugin.get_matrix_commands()
         self.assertEqual(commands, ["map"])
 
     def test_get_mesh_commands(self):
-        """Test getting mesh commands."""
+        """
+        Test that the plugin returns an empty list for mesh commands.
+        """
         commands = self.plugin.get_mesh_commands()
         self.assertEqual(commands, [])
 
@@ -351,9 +411,18 @@ class TestMapPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_room_message_basic_map(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
-        """Test handling basic map command."""
+        """
+        Test that the plugin correctly handles a basic "!map" command in a Matrix room message.
+        
+        Verifies that the map is generated and sent when the command matches, and that the appropriate methods are called with the expected arguments.
+        """
         async def run_test():
             # Setup mocks
+            """
+            Asynchronously tests that the plugin handles a "!map" room message by generating a map and sending the resulting image.
+            
+            This test verifies that when a "!map" command is received, the plugin correctly matches the command, generates a map image using node positions, and sends the image to the specified Matrix room.
+            """
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
             mock_event = MagicMock()
@@ -389,8 +458,17 @@ class TestMapPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_room_message_with_zoom(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
-        """Test handling map command with zoom parameter."""
+        """
+        Test that the plugin correctly handles a "!map" command with a specified zoom parameter.
+        
+        Verifies that when a room message includes "zoom=15", the plugin parses the zoom value and passes it to the map generation function.
+        """
         async def run_test():
+            """
+            Asynchronously tests that the plugin handles a "!map zoom=15" command by generating a map with the specified zoom level.
+            
+            This test mocks the Matrix and Meshtastic clients, simulates a room message event, and verifies that the map generation function is called with the correct zoom parameter. It asserts that the plugin's message handler returns True, indicating successful handling.
+            """
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
             mock_event = MagicMock()
@@ -421,8 +499,15 @@ class TestMapPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_room_message_with_size(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
-        """Test handling map command with size parameter."""
+        """
+        Tests that the map plugin correctly handles the "!map" command with a custom image size parameter, ensuring the generated map uses the specified dimensions.
+        """
         async def run_test():
+            """
+            Asynchronously tests that the plugin handles a "!map size=500,400" command by generating a map image with the specified size and returns True.
+            
+            This test verifies that the `get_map` function is called with the correct `image_size` parameter when the command includes a custom size.
+            """
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
             mock_event = MagicMock()
@@ -449,8 +534,13 @@ class TestMapPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_no_match(self):
-        """Test handling non-map messages."""
+        """
+        Test that handle_room_message returns False when the message does not match the map command.
+        """
         async def run_test():
+            """
+            Asynchronously tests that the plugin's handle_room_message method returns False when the message does not match the plugin command.
+            """
             mock_room = MagicMock()
             mock_event = MagicMock()
             mock_event.body = "!help"
@@ -467,8 +557,17 @@ class TestMapPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_room_message_invalid_zoom(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
-        """Test handling map command with invalid zoom parameter."""
+        """
+        Test that the plugin resets an invalid zoom parameter to the default value when handling a map command.
+        
+        Verifies that when a map command with an out-of-range zoom value is received, the plugin uses the default zoom (8) for map generation.
+        """
         async def run_test():
+            """
+            Asynchronously tests that an invalid zoom parameter in the "!map" command is reset to the default value when handling a room message.
+            
+            The test mocks Matrix and Meshtastic clients, simulates a "!map zoom=50" command, and verifies that the map generation function is called with the default zoom level (8) instead of the invalid value.
+            """
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
             mock_event = MagicMock()
@@ -499,8 +598,17 @@ class TestMapPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_room_message_oversized_image(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
-        """Test handling map command with oversized image parameters."""
+        """
+        Test that the map command with oversized image size parameters results in the image size being capped at 1000x1000 pixels.
+        
+        Verifies that when a user requests an image size exceeding the allowed maximum, the plugin enforces the size limit before generating the map.
+        """
         async def run_test():
+            """
+            Test that oversized image size parameters in the "!map" command are capped at the maximum allowed dimensions when handling a room message.
+            
+            Asserts that the plugin processes the command, generates a map image with the capped size, and returns True.
+            """
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
             mock_event = MagicMock()

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""
+Test suite for map plugin functionality.
+
+Tests the map generation plugin including:
+- Map generation with various parameters
+- Location anonymization
+- Image upload and sending
+- Command parsing and validation
+- Configuration handling
+"""
+
+import asyncio
+import io
+import math
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import PIL.Image
+import s2sphere
+import staticmaps
+from nio import AsyncClient, UploadResponse
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.map_plugin import (
+    Plugin,
+    TextLabel,
+    anonymize_location,
+    get_map,
+    send_image,
+    send_room_image,
+    textsize,
+    upload_image,
+)
+
+
+class TestTextLabel(unittest.TestCase):
+    """Test cases for TextLabel class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.latlng = s2sphere.LatLng.from_degrees(37.7749, -122.4194)  # San Francisco
+        self.text_label = TextLabel(self.latlng, "Test Label", fontSize=12)
+
+    def test_init(self):
+        """Test TextLabel initialization."""
+        self.assertEqual(self.text_label._latlng, self.latlng)
+        self.assertEqual(self.text_label._text, "Test Label")
+        self.assertEqual(self.text_label._font_size, 12)
+        self.assertEqual(self.text_label._margin, 4)
+        self.assertEqual(self.text_label._arrow, 16)
+
+    def test_latlng(self):
+        """Test latlng property."""
+        self.assertEqual(self.text_label.latlng(), self.latlng)
+
+    def test_bounds(self):
+        """Test bounds calculation."""
+        bounds = self.text_label.bounds()
+        self.assertIsInstance(bounds, s2sphere.LatLngRect)
+
+    def test_extra_pixel_bounds(self):
+        """Test extra pixel bounds calculation."""
+        bounds = self.text_label.extra_pixel_bounds()
+        self.assertIsInstance(bounds, tuple)
+        self.assertEqual(len(bounds), 4)
+        # Check that bounds are reasonable
+        self.assertGreater(bounds[0], 0)  # left
+        self.assertGreater(bounds[1], 0)  # top
+        self.assertGreater(bounds[2], 0)  # right
+
+    @patch('staticmaps.PillowRenderer')
+    def test_render_pillow(self, mock_renderer_class):
+        """Test Pillow rendering."""
+        mock_renderer = MagicMock()
+        mock_transformer = MagicMock()
+        mock_transformer.ll2pixel.return_value = (100, 100)
+        mock_renderer.transformer.return_value = mock_transformer
+        mock_renderer.offset_x.return_value = 0
+        
+        mock_draw = MagicMock()
+        mock_draw.textbbox.return_value = (0, 0, 50, 12)
+        mock_renderer.draw.return_value = mock_draw
+        
+        self.text_label.render_pillow(mock_renderer)
+        
+        # Verify drawing methods were called
+        mock_draw.polygon.assert_called_once()
+        mock_draw.line.assert_called_once()
+        mock_draw.text.assert_called_once()
+
+    @patch('staticmaps.SvgRenderer')
+    def test_render_svg(self, mock_renderer_class):
+        """Test SVG rendering."""
+        mock_renderer = MagicMock()
+        mock_transformer = MagicMock()
+        mock_transformer.ll2pixel.return_value = (100, 100)
+        mock_renderer.transformer.return_value = mock_transformer
+        
+        mock_drawing = MagicMock()
+        mock_path = MagicMock()
+        mock_drawing.path.return_value = mock_path
+        mock_drawing.text.return_value = MagicMock()
+        mock_renderer.drawing.return_value = mock_drawing
+        
+        mock_group = MagicMock()
+        mock_renderer.group.return_value = mock_group
+        
+        self.text_label.render_svg(mock_renderer)
+        
+        # Verify SVG elements were created
+        mock_drawing.path.assert_called_once()
+        mock_drawing.text.assert_called_once()
+        self.assertEqual(mock_group.add.call_count, 2)
+
+
+class TestTextSizeFunction(unittest.TestCase):
+    """Test cases for textsize function."""
+
+    def test_textsize(self):
+        """Test textsize function."""
+        mock_draw = MagicMock()
+        mock_draw.textbbox.return_value = (0, 0, 100, 20)
+        
+        width, height = textsize(mock_draw, "Test text")
+        
+        self.assertEqual(width, 100)
+        self.assertEqual(height, 20)
+        mock_draw.textbbox.assert_called_once_with((0, 0), "Test text")
+
+
+class TestAnonymizeLocation(unittest.TestCase):
+    """Test cases for location anonymization."""
+
+    def test_anonymize_location_default_radius(self):
+        """Test location anonymization with default radius."""
+        lat, lon = 37.7749, -122.4194
+        new_lat, new_lon = anonymize_location(lat, lon)
+        
+        # Check that coordinates changed
+        self.assertNotEqual(new_lat, lat)
+        self.assertNotEqual(new_lon, lon)
+        
+        # Check that change is within reasonable bounds (roughly 1km)
+        lat_diff = abs(new_lat - lat)
+        lon_diff = abs(new_lon - lon)
+        self.assertLess(lat_diff, 0.01)  # Roughly 1km in degrees
+        self.assertLess(lon_diff, 0.01)
+
+    def test_anonymize_location_custom_radius(self):
+        """Test location anonymization with custom radius."""
+        lat, lon = 37.7749, -122.4194
+        radius = 5000  # 5km
+        new_lat, new_lon = anonymize_location(lat, lon, radius)
+        
+        # Check that coordinates changed
+        self.assertNotEqual(new_lat, lat)
+        self.assertNotEqual(new_lon, lon)
+        
+        # Check that change is within expected bounds
+        lat_diff = abs(new_lat - lat)
+        lon_diff = abs(new_lon - lon)
+        self.assertLess(lat_diff, 0.05)  # Roughly 5km in degrees
+
+    def test_anonymize_location_zero_radius(self):
+        """Test location anonymization with zero radius."""
+        lat, lon = 37.7749, -122.4194
+        new_lat, new_lon = anonymize_location(lat, lon, 0)
+        
+        # With zero radius, coordinates should be very close to original
+        self.assertAlmostEqual(new_lat, lat, places=5)
+        self.assertAlmostEqual(new_lon, lon, places=5)
+
+
+class TestGetMap(unittest.TestCase):
+    """Test cases for map generation."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_locations = [
+            {"lat": 37.7749, "lon": -122.4194, "label": "SF"},
+            {"lat": 37.7849, "lon": -122.4094, "label": "Oakland"},
+        ]
+
+    @patch('staticmaps.Context')
+    def test_get_map_default_params(self, mock_context_class):
+        """Test map generation with default parameters."""
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+        
+        result = get_map(self.test_locations)
+        
+        mock_context.set_tile_provider.assert_called_once()
+        mock_context.set_zoom.assert_called_once_with(None)
+        self.assertEqual(mock_context.add_object.call_count, len(self.test_locations))
+        mock_context.render_pillow.assert_called_once_with(1000, 1000)
+
+    @patch('staticmaps.Context')
+    def test_get_map_custom_params(self, mock_context_class):
+        """Test map generation with custom parameters."""
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+        
+        result = get_map(
+            self.test_locations,
+            zoom=10,
+            image_size=(800, 600),
+            anonymize=False,
+            radius=2000
+        )
+        
+        mock_context.set_zoom.assert_called_once_with(10)
+        mock_context.render_pillow.assert_called_once_with(800, 600)
+
+    @patch('mmrelay.plugins.map_plugin.anonymize_location')
+    @patch('staticmaps.Context')
+    def test_get_map_with_anonymization(self, mock_context_class, mock_anonymize):
+        """Test map generation with location anonymization."""
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+        mock_anonymize.return_value = (37.7750, -122.4195)
+        
+        result = get_map(self.test_locations, anonymize=True, radius=5000)
+        
+        # Should call anonymize_location for each location
+        self.assertEqual(mock_anonymize.call_count, len(self.test_locations))
+        mock_anonymize.assert_any_call(lat=37.7749, lon=-122.4194, radius=5000)
+
+
+class TestImageUploadAndSend(unittest.TestCase):
+    """Test cases for image upload and sending functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_client = AsyncMock()
+        self.mock_image = MagicMock()
+        self.mock_upload_response = MagicMock()
+        self.mock_upload_response.content_uri = "mxc://example.com/test123"
+
+    def test_upload_image(self):
+        """Test image upload functionality."""
+        async def run_test():
+            # Mock image save
+            mock_buffer = MagicMock()
+            mock_buffer.getvalue.return_value = b"fake_image_data"
+
+            with patch('io.BytesIO', return_value=mock_buffer):
+                self.mock_client.upload.return_value = (self.mock_upload_response, None)
+
+                result = await upload_image(self.mock_client, self.mock_image)
+
+                self.assertEqual(result, self.mock_upload_response)
+                self.mock_client.upload.assert_called_once()
+
+        asyncio.run(run_test())
+
+    def test_send_room_image(self):
+        """Test sending image to room."""
+        async def run_test():
+            room_id = "!test:example.com"
+
+            await send_room_image(self.mock_client, room_id, self.mock_upload_response)
+
+            self.mock_client.room_send.assert_called_once_with(
+                room_id=room_id,
+                message_type="m.room.message",
+                content={
+                    "msgtype": "m.image",
+                    "url": "mxc://example.com/test123",
+                    "body": "image.png",
+                },
+            )
+
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.map_plugin.upload_image')
+    @patch('mmrelay.plugins.map_plugin.send_room_image')
+    def test_send_image(self, mock_send_room_image, mock_upload_image):
+        """Test complete image sending workflow."""
+        async def run_test():
+            room_id = "!test:example.com"
+            mock_upload_image.return_value = self.mock_upload_response
+
+            await send_image(self.mock_client, room_id, self.mock_image)
+
+            mock_upload_image.assert_called_once_with(client=self.mock_client, image=self.mock_image)
+            mock_send_room_image.assert_called_once_with(
+                self.mock_client, room_id, upload_response=self.mock_upload_response
+            )
+
+        asyncio.run(run_test())
+
+
+class TestMapPlugin(unittest.TestCase):
+    """Test cases for the map Plugin class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.config = {
+            "zoom": 10,
+            "image_width": 800,
+            "image_height": 600,
+            "anonymize": True,
+            "radius": 2000,
+        }
+
+    def test_plugin_name(self):
+        """Test plugin name property."""
+        self.assertEqual(self.plugin.plugin_name, "map")
+
+    def test_description(self):
+        """Test plugin description."""
+        description = self.plugin.description
+        self.assertIn("Map of mesh radio nodes", description)
+        self.assertIn("zoom", description)
+        self.assertIn("size", description)
+
+    def test_handle_meshtastic_message(self):
+        """Test handling Meshtastic messages."""
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet=MagicMock(),
+                formatted_message="test",
+                longname="Test User",
+                meshnet_name="TestNet"
+            )
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    def test_get_matrix_commands(self):
+        """Test getting Matrix commands."""
+        commands = self.plugin.get_matrix_commands()
+        self.assertEqual(commands, ["map"])
+
+    def test_get_mesh_commands(self):
+        """Test getting mesh commands."""
+        commands = self.plugin.get_mesh_commands()
+        self.assertEqual(commands, [])
+
+    @patch('mmrelay.plugins.map_plugin.send_image')
+    @patch('mmrelay.plugins.map_plugin.get_map')
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_room_message_basic_map(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
+        """Test handling basic map command."""
+        async def run_test():
+            # Setup mocks
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map"
+
+            mock_matrix_client = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_meshtastic_client = MagicMock()
+            mock_meshtastic_client.nodes = {
+                "node1": {
+                    "position": {"latitude": 37.7749, "longitude": -122.4194},
+                    "user": {"shortName": "SF"}
+                }
+            }
+            mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+            mock_image = MagicMock()
+            mock_get_map.return_value = mock_image
+
+            # Mock the matches method to return True
+            with patch.object(self.plugin, 'matches', return_value=True):
+                result = await self.plugin.handle_room_message(mock_room, mock_event, "user: !map")
+
+            self.assertTrue(result)
+            mock_get_map.assert_called_once()
+            mock_send_image.assert_called_once_with(mock_matrix_client, mock_room.room_id, mock_image)
+
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.map_plugin.send_image')
+    @patch('mmrelay.plugins.map_plugin.get_map')
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_room_message_with_zoom(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
+        """Test handling map command with zoom parameter."""
+        async def run_test():
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map zoom=15"
+
+            mock_matrix_client = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_meshtastic_client = MagicMock()
+            mock_meshtastic_client.nodes = {}
+            mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+            mock_image = MagicMock()
+            mock_get_map.return_value = mock_image
+
+            with patch.object(self.plugin, 'matches', return_value=True):
+                result = await self.plugin.handle_room_message(mock_room, mock_event, "user: !map zoom=15")
+
+            self.assertTrue(result)
+            # Check that get_map was called with zoom=15
+            call_args = mock_get_map.call_args
+            self.assertEqual(call_args[1]['zoom'], 15)
+
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.map_plugin.send_image')
+    @patch('mmrelay.plugins.map_plugin.get_map')
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_room_message_with_size(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
+        """Test handling map command with size parameter."""
+        async def run_test():
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map size=500,400"
+
+            mock_matrix_client = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_meshtastic_client = MagicMock()
+            mock_meshtastic_client.nodes = {}
+            mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+            mock_image = MagicMock()
+            mock_get_map.return_value = mock_image
+
+            with patch.object(self.plugin, 'matches', return_value=True):
+                result = await self.plugin.handle_room_message(mock_room, mock_event, "user: !map size=500,400")
+
+            self.assertTrue(result)
+            # Check that get_map was called with correct image_size
+            call_args = mock_get_map.call_args
+            self.assertEqual(call_args[1]['image_size'], (500, 400))
+
+        asyncio.run(run_test())
+
+    def test_handle_room_message_no_match(self):
+        """Test handling non-map messages."""
+        async def run_test():
+            mock_room = MagicMock()
+            mock_event = MagicMock()
+            mock_event.body = "!help"
+
+            with patch.object(self.plugin, 'matches', return_value=False):
+                result = await self.plugin.handle_room_message(mock_room, mock_event, "!help")
+
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.map_plugin.send_image')
+    @patch('mmrelay.plugins.map_plugin.get_map')
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_room_message_invalid_zoom(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
+        """Test handling map command with invalid zoom parameter."""
+        async def run_test():
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map zoom=50"  # Invalid zoom > 30
+
+            mock_matrix_client = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_meshtastic_client = MagicMock()
+            mock_meshtastic_client.nodes = {}
+            mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+            mock_image = MagicMock()
+            mock_get_map.return_value = mock_image
+
+            with patch.object(self.plugin, 'matches', return_value=True):
+                result = await self.plugin.handle_room_message(mock_room, mock_event, "user: !map zoom=50")
+
+            self.assertTrue(result)
+            # Check that zoom was reset to default (8)
+            call_args = mock_get_map.call_args
+            self.assertEqual(call_args[1]['zoom'], 8)
+
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.map_plugin.send_image')
+    @patch('mmrelay.plugins.map_plugin.get_map')
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_room_message_oversized_image(self, mock_connect_matrix, mock_connect_meshtastic, mock_get_map, mock_send_image):
+        """Test handling map command with oversized image parameters."""
+        async def run_test():
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map size=2000,1500"  # Oversized
+
+            mock_matrix_client = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_meshtastic_client = MagicMock()
+            mock_meshtastic_client.nodes = {}
+            mock_connect_meshtastic.return_value = mock_meshtastic_client
+
+            mock_image = MagicMock()
+            mock_get_map.return_value = mock_image
+
+            with patch.object(self.plugin, 'matches', return_value=True):
+                result = await self.plugin.handle_room_message(mock_room, mock_event, "user: !map size=2000,1500")
+
+            self.assertTrue(result)
+            # Check that image size was capped at 1000x1000
+            call_args = mock_get_map.call_args
+            self.assertEqual(call_args[1]['image_size'], (1000, 1000))
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -295,9 +295,9 @@ class TestMatrixUtils(unittest.TestCase):
         self, mock_queue_message, mock_connect_meshtastic
     ):
         """
-        Test that messages from unsupported Matrix rooms are ignored by on_room_message.
+        Test that messages from Matrix rooms not in the configured list are ignored.
         
-        Verifies that when a message event originates from a room not listed in the configured matrix rooms, the message is not queued for Meshtastic relay.
+        Ensures that when a message event originates from an unsupported Matrix room, it is not queued for Meshtastic relay.
         """
         self.mock_room.room_id = "!unsupported:matrix.org"
         with patch("mmrelay.matrix_utils.config", self.config), patch(
@@ -317,7 +317,9 @@ class TestUtilityFunctions(unittest.TestCase):
     """Test cases for Matrix utility functions."""
 
     def test_get_msgs_to_keep_config_default(self):
-        """Test default message retention configuration."""
+        """
+        Test that the default message retention value is returned when no configuration is set.
+        """
         import mmrelay.matrix_utils
         original_config = mmrelay.matrix_utils.config
         try:
@@ -328,7 +330,9 @@ class TestUtilityFunctions(unittest.TestCase):
             mmrelay.matrix_utils.config = original_config
 
     def test_get_msgs_to_keep_config_legacy(self):
-        """Test legacy message retention configuration."""
+        """
+        Test that the legacy configuration format correctly sets the message retention value.
+        """
         import mmrelay.matrix_utils
         original_config = mmrelay.matrix_utils.config
         try:
@@ -339,7 +343,11 @@ class TestUtilityFunctions(unittest.TestCase):
             mmrelay.matrix_utils.config = original_config
 
     def test_get_msgs_to_keep_config_new_format(self):
-        """Test new message retention configuration format."""
+        """
+        Test that the new configuration format correctly sets the message retention value.
+        
+        Verifies that `_get_msgs_to_keep_config()` returns the expected value when the configuration uses the new nested format for message retention.
+        """
         import mmrelay.matrix_utils
         original_config = mmrelay.matrix_utils.config
         try:
@@ -350,7 +358,9 @@ class TestUtilityFunctions(unittest.TestCase):
             mmrelay.matrix_utils.config = original_config
 
     def test_create_mapping_info(self):
-        """Test creation of message mapping information."""
+        """
+        Tests that _create_mapping_info returns a dictionary with the correct message mapping information based on the provided parameters.
+        """
         result = _create_mapping_info(
             matrix_event_id="$event123",
             room_id="!room:matrix.org",
@@ -369,7 +379,9 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_create_mapping_info_defaults(self):
-        """Test creation of mapping info with default values."""
+        """
+        Test that _create_mapping_info returns a mapping dictionary with default values when optional parameters are not provided.
+        """
         with patch('mmrelay.matrix_utils._get_msgs_to_keep_config', return_value=500):
             result = _create_mapping_info(
                 matrix_event_id="$event123",
@@ -381,7 +393,9 @@ class TestUtilityFunctions(unittest.TestCase):
             self.assertIsNone(result["meshnet"])
 
     def test_get_interaction_settings_new_format(self):
-        """Test interaction settings with new configuration format."""
+        """
+        Tests that interaction settings are correctly retrieved from a configuration using the new format.
+        """
         config = {
             "meshtastic": {
                 "message_interactions": {
@@ -396,7 +410,11 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_get_interaction_settings_legacy_format(self):
-        """Test interaction settings with legacy configuration format."""
+        """
+        Test that interaction settings are correctly parsed from a legacy configuration format.
+        
+        Verifies that the function returns the expected dictionary when only legacy keys are present in the configuration.
+        """
         config = {
             "meshtastic": {
                 "relay_reactions": True
@@ -408,7 +426,9 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_get_interaction_settings_defaults(self):
-        """Test interaction settings with no configuration."""
+        """
+        Test that default interaction settings are returned as disabled when no configuration is provided.
+        """
         config = {}
 
         result = get_interaction_settings(config)
@@ -416,7 +436,9 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_message_storage_enabled_true(self):
-        """Test message storage enabled when interactions are enabled."""
+        """
+        Test that message storage is enabled when either reactions or replies are enabled in the interaction settings.
+        """
         interactions = {"reactions": True, "replies": False}
         self.assertTrue(message_storage_enabled(interactions))
 
@@ -427,12 +449,16 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertTrue(message_storage_enabled(interactions))
 
     def test_message_storage_enabled_false(self):
-        """Test message storage disabled when no interactions are enabled."""
+        """
+        Test that message storage is disabled when both reactions and replies are disabled in the interaction settings.
+        """
         interactions = {"reactions": False, "replies": False}
         self.assertFalse(message_storage_enabled(interactions))
 
     def test_add_truncated_vars(self):
-        """Test addition of truncated variables to format dictionary."""
+        """
+        Tests that truncated versions of a string are correctly added to a format dictionary with specific key suffixes.
+        """
         format_vars = {}
         _add_truncated_vars(format_vars, "display", "Hello World")
 
@@ -443,7 +469,9 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(format_vars["display20"], "Hello World")
 
     def test_add_truncated_vars_empty_text(self):
-        """Test truncated variables with empty text."""
+        """
+        Test that _add_truncated_vars correctly handles empty string input by setting truncated variables to empty strings.
+        """
         format_vars = {}
         _add_truncated_vars(format_vars, "display", "")
 
@@ -452,7 +480,9 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(format_vars["display5"], "")
 
     def test_add_truncated_vars_none_text(self):
-        """Test truncated variables with None text."""
+        """
+        Test that truncated variable keys are added with empty string values when the input text is None.
+        """
         format_vars = {}
         _add_truncated_vars(format_vars, "display", None)
 
@@ -465,7 +495,9 @@ class TestPrefixFormatting(unittest.TestCase):
     """Test cases for prefix formatting functions."""
 
     def test_validate_prefix_format_valid(self):
-        """Test validation of valid prefix format."""
+        """
+        Tests that a valid prefix format string with available variables passes validation without errors.
+        """
         format_string = "{display5}[M]: "
         available_vars = {"display5": "Alice"}
 
@@ -474,7 +506,11 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertIsNone(error)
 
     def test_validate_prefix_format_invalid_key(self):
-        """Test validation of invalid prefix format with missing key."""
+        """
+        Tests that validate_prefix_format correctly identifies an invalid prefix format string containing a missing key.
+        
+        Verifies that the function returns False and provides an error message when the format string references a key not present in the available variables.
+        """
         format_string = "{invalid_key}: "
         available_vars = {"display5": "Alice"}
 
@@ -483,7 +519,9 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertIsNotNone(error)
 
     def test_get_meshtastic_prefix_enabled(self):
-        """Test Meshtastic prefix generation when enabled."""
+        """
+        Tests that the Meshtastic prefix is generated using the specified format when prefixing is enabled in the configuration.
+        """
         config = {
             "meshtastic": {
                 "prefix_enabled": True,
@@ -495,7 +533,9 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertEqual(result, "Alice[M]: ")
 
     def test_get_meshtastic_prefix_disabled(self):
-        """Test Meshtastic prefix generation when disabled."""
+        """
+        Tests that no Meshtastic prefix is generated when prefixing is disabled in the configuration.
+        """
         config = {
             "meshtastic": {
                 "prefix_enabled": False
@@ -506,7 +546,9 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertEqual(result, "")
 
     def test_get_meshtastic_prefix_custom_format(self):
-        """Test Meshtastic prefix with custom format."""
+        """
+        Tests that a custom Meshtastic prefix format is applied correctly using the truncated display name.
+        """
         config = {
             "meshtastic": {
                 "prefix_enabled": True,
@@ -518,7 +560,9 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertEqual(result, "[Ali]: ")
 
     def test_get_meshtastic_prefix_invalid_format(self):
-        """Test Meshtastic prefix with invalid format falls back to default."""
+        """
+        Test that get_meshtastic_prefix falls back to the default format when given an invalid prefix format string.
+        """
         config = {
             "meshtastic": {
                 "prefix_enabled": True,
@@ -530,7 +574,9 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertEqual(result, "Alice[M]: ")  # Default format
 
     def test_get_matrix_prefix_enabled(self):
-        """Test Matrix prefix generation when enabled."""
+        """
+        Tests that the Matrix prefix is generated correctly when prefixing is enabled and a custom format is provided.
+        """
         config = {
             "matrix": {
                 "prefix_enabled": True,
@@ -542,7 +588,9 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertEqual(result, "[Ali/TestMesh]: ")
 
     def test_get_matrix_prefix_disabled(self):
-        """Test Matrix prefix generation when disabled."""
+        """
+        Test that no Matrix prefix is generated when prefixing is disabled in the configuration.
+        """
         config = {
             "matrix": {
                 "prefix_enabled": False
@@ -553,7 +601,9 @@ class TestPrefixFormatting(unittest.TestCase):
         self.assertEqual(result, "")
 
     def test_get_matrix_prefix_default_format(self):
-        """Test Matrix prefix with default format."""
+        """
+        Tests that the default Matrix prefix format is used when no custom format is specified in the configuration.
+        """
         config = {
             "matrix": {
                 "prefix_enabled": True
@@ -569,27 +619,35 @@ class TestTextProcessing(unittest.TestCase):
     """Test cases for text processing functions."""
 
     def test_truncate_message_under_limit(self):
-        """Test message truncation when under byte limit."""
+        """
+        Tests that a message shorter than the specified byte limit is not truncated by the truncate_message function.
+        """
         text = "Hello world"
         result = truncate_message(text, max_bytes=50)
         self.assertEqual(result, "Hello world")
 
     def test_truncate_message_over_limit(self):
-        """Test message truncation when over byte limit."""
+        """
+        Test that messages exceeding the specified byte limit are truncated without breaking character encoding.
+        """
         text = "This is a very long message that exceeds the byte limit"
         result = truncate_message(text, max_bytes=20)
         self.assertTrue(len(result.encode('utf-8')) <= 20)
         self.assertTrue(result.startswith("This is"))
 
     def test_truncate_message_unicode(self):
-        """Test message truncation with Unicode characters."""
+        """
+        Tests that truncating a message containing Unicode characters does not split characters and respects the byte limit.
+        """
         text = "Hello 🌍 world"
         result = truncate_message(text, max_bytes=10)
         # Should handle Unicode properly without breaking characters
         self.assertTrue(len(result.encode('utf-8')) <= 10)
 
     def test_strip_quoted_lines_with_quotes(self):
-        """Test stripping quoted lines from text."""
+        """
+        Tests that quoted lines (starting with '>') are removed from multi-line text, and remaining lines are joined with spaces.
+        """
         text = "This is a reply\n> Original message\n> Another quoted line\nNew content"
         result = strip_quoted_lines(text)
         expected = "This is a reply New content"  # Joined with spaces
@@ -603,13 +661,17 @@ class TestTextProcessing(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_strip_quoted_lines_only_quotes(self):
-        """Test stripping quoted lines when all lines are quoted."""
+        """
+        Tests that stripping quoted lines from text returns an empty string when all lines are quoted.
+        """
         text = "> First quoted line\n> Second quoted line"
         result = strip_quoted_lines(text)
         self.assertEqual(result, "")
 
     def test_format_reply_message(self):
-        """Test formatting of reply messages."""
+        """
+        Tests that reply messages are formatted with a truncated display name and quoted lines are removed from the message body.
+        """
         config = {}  # Using defaults
         result = format_reply_message(config, "Alice Smith", "This is a reply\n> Original message")
 
@@ -625,7 +687,9 @@ class TestBotCommand(unittest.TestCase):
     @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
     @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
     def test_bot_command_direct_mention(self):
-        """Test bot command with direct mention."""
+        """
+        Tests that a message starting with the bot command triggers correct command detection.
+        """
         mock_event = MagicMock()
         mock_event.body = "!help"
         mock_event.source = {"content": {"formatted_body": "!help"}}
@@ -636,7 +700,9 @@ class TestBotCommand(unittest.TestCase):
     @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
     @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
     def test_bot_command_no_match(self):
-        """Test bot command that doesn't match."""
+        """
+        Test that a non-command message does not trigger bot command detection.
+        """
         mock_event = MagicMock()
         mock_event.body = "regular message"
         mock_event.source = {"content": {"formatted_body": "regular message"}}
@@ -647,7 +713,9 @@ class TestBotCommand(unittest.TestCase):
     @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
     @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
     def test_bot_command_case_insensitive(self):
-        """Test bot command case insensitivity."""
+        """
+        Test that bot command detection is case-insensitive by verifying a command matches regardless of letter case.
+        """
         mock_event = MagicMock()
         mock_event.body = "!HELP"
         mock_event.source = {"content": {"formatted_body": "!HELP"}}
@@ -658,7 +726,9 @@ class TestBotCommand(unittest.TestCase):
     @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
     @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
     def test_bot_command_with_args(self):
-        """Test bot command with arguments."""
+        """
+        Test that the bot command is correctly detected when followed by additional arguments.
+        """
         mock_event = MagicMock()
         mock_event.body = "!help me please"
         mock_event.source = {"content": {"formatted_body": "!help me please"}}

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -7,7 +7,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from mmrelay.matrix_utils import on_room_message
+from mmrelay.matrix_utils import (
+    _add_truncated_vars,
+    _create_mapping_info,
+    _get_msgs_to_keep_config,
+    bot_command,
+    format_reply_message,
+    get_interaction_settings,
+    get_matrix_prefix,
+    get_meshtastic_prefix,
+    message_storage_enabled,
+    on_room_message,
+    strip_quoted_lines,
+    truncate_message,
+    validate_prefix_format,
+)
 
 
 class TestMatrixUtils(unittest.TestCase):
@@ -297,6 +311,360 @@ class TestMatrixUtils(unittest.TestCase):
 
                 # Assert that the message was not queued
                 mock_queue_message.assert_not_called()
+
+
+class TestUtilityFunctions(unittest.TestCase):
+    """Test cases for Matrix utility functions."""
+
+    def test_get_msgs_to_keep_config_default(self):
+        """Test default message retention configuration."""
+        import mmrelay.matrix_utils
+        original_config = mmrelay.matrix_utils.config
+        try:
+            mmrelay.matrix_utils.config = {}
+            result = _get_msgs_to_keep_config()
+            self.assertEqual(result, 500)
+        finally:
+            mmrelay.matrix_utils.config = original_config
+
+    def test_get_msgs_to_keep_config_legacy(self):
+        """Test legacy message retention configuration."""
+        import mmrelay.matrix_utils
+        original_config = mmrelay.matrix_utils.config
+        try:
+            mmrelay.matrix_utils.config = {"db": {"msg_map": {"msgs_to_keep": 100}}}
+            result = _get_msgs_to_keep_config()
+            self.assertEqual(result, 100)
+        finally:
+            mmrelay.matrix_utils.config = original_config
+
+    def test_get_msgs_to_keep_config_new_format(self):
+        """Test new message retention configuration format."""
+        import mmrelay.matrix_utils
+        original_config = mmrelay.matrix_utils.config
+        try:
+            mmrelay.matrix_utils.config = {"database": {"msg_map": {"msgs_to_keep": 200}}}
+            result = _get_msgs_to_keep_config()
+            self.assertEqual(result, 200)
+        finally:
+            mmrelay.matrix_utils.config = original_config
+
+    def test_create_mapping_info(self):
+        """Test creation of message mapping information."""
+        result = _create_mapping_info(
+            matrix_event_id="$event123",
+            room_id="!room:matrix.org",
+            text="Hello world",
+            meshnet="test_mesh",
+            msgs_to_keep=100
+        )
+
+        expected = {
+            "matrix_event_id": "$event123",
+            "room_id": "!room:matrix.org",
+            "text": "Hello world",
+            "meshnet": "test_mesh",
+            "msgs_to_keep": 100
+        }
+        self.assertEqual(result, expected)
+
+    def test_create_mapping_info_defaults(self):
+        """Test creation of mapping info with default values."""
+        with patch('mmrelay.matrix_utils._get_msgs_to_keep_config', return_value=500):
+            result = _create_mapping_info(
+                matrix_event_id="$event123",
+                room_id="!room:matrix.org",
+                text="Hello world"
+            )
+
+            self.assertEqual(result["msgs_to_keep"], 500)
+            self.assertIsNone(result["meshnet"])
+
+    def test_get_interaction_settings_new_format(self):
+        """Test interaction settings with new configuration format."""
+        config = {
+            "meshtastic": {
+                "message_interactions": {
+                    "reactions": True,
+                    "replies": False
+                }
+            }
+        }
+
+        result = get_interaction_settings(config)
+        expected = {"reactions": True, "replies": False}
+        self.assertEqual(result, expected)
+
+    def test_get_interaction_settings_legacy_format(self):
+        """Test interaction settings with legacy configuration format."""
+        config = {
+            "meshtastic": {
+                "relay_reactions": True
+            }
+        }
+
+        result = get_interaction_settings(config)
+        expected = {"reactions": True, "replies": False}
+        self.assertEqual(result, expected)
+
+    def test_get_interaction_settings_defaults(self):
+        """Test interaction settings with no configuration."""
+        config = {}
+
+        result = get_interaction_settings(config)
+        expected = {"reactions": False, "replies": False}
+        self.assertEqual(result, expected)
+
+    def test_message_storage_enabled_true(self):
+        """Test message storage enabled when interactions are enabled."""
+        interactions = {"reactions": True, "replies": False}
+        self.assertTrue(message_storage_enabled(interactions))
+
+        interactions = {"reactions": False, "replies": True}
+        self.assertTrue(message_storage_enabled(interactions))
+
+        interactions = {"reactions": True, "replies": True}
+        self.assertTrue(message_storage_enabled(interactions))
+
+    def test_message_storage_enabled_false(self):
+        """Test message storage disabled when no interactions are enabled."""
+        interactions = {"reactions": False, "replies": False}
+        self.assertFalse(message_storage_enabled(interactions))
+
+    def test_add_truncated_vars(self):
+        """Test addition of truncated variables to format dictionary."""
+        format_vars = {}
+        _add_truncated_vars(format_vars, "display", "Hello World")
+
+        # Check that truncated variables are added
+        self.assertEqual(format_vars["display1"], "H")
+        self.assertEqual(format_vars["display5"], "Hello")
+        self.assertEqual(format_vars["display10"], "Hello Worl")
+        self.assertEqual(format_vars["display20"], "Hello World")
+
+    def test_add_truncated_vars_empty_text(self):
+        """Test truncated variables with empty text."""
+        format_vars = {}
+        _add_truncated_vars(format_vars, "display", "")
+
+        # Should handle empty text gracefully
+        self.assertEqual(format_vars["display1"], "")
+        self.assertEqual(format_vars["display5"], "")
+
+    def test_add_truncated_vars_none_text(self):
+        """Test truncated variables with None text."""
+        format_vars = {}
+        _add_truncated_vars(format_vars, "display", None)
+
+        # Should convert None to empty string
+        self.assertEqual(format_vars["display1"], "")
+        self.assertEqual(format_vars["display5"], "")
+
+
+class TestPrefixFormatting(unittest.TestCase):
+    """Test cases for prefix formatting functions."""
+
+    def test_validate_prefix_format_valid(self):
+        """Test validation of valid prefix format."""
+        format_string = "{display5}[M]: "
+        available_vars = {"display5": "Alice"}
+
+        is_valid, error = validate_prefix_format(format_string, available_vars)
+        self.assertTrue(is_valid)
+        self.assertIsNone(error)
+
+    def test_validate_prefix_format_invalid_key(self):
+        """Test validation of invalid prefix format with missing key."""
+        format_string = "{invalid_key}: "
+        available_vars = {"display5": "Alice"}
+
+        is_valid, error = validate_prefix_format(format_string, available_vars)
+        self.assertFalse(is_valid)
+        self.assertIsNotNone(error)
+
+    def test_get_meshtastic_prefix_enabled(self):
+        """Test Meshtastic prefix generation when enabled."""
+        config = {
+            "meshtastic": {
+                "prefix_enabled": True,
+                "prefix_format": "{display5}[M]: "
+            }
+        }
+
+        result = get_meshtastic_prefix(config, "Alice", "@alice:matrix.org")
+        self.assertEqual(result, "Alice[M]: ")
+
+    def test_get_meshtastic_prefix_disabled(self):
+        """Test Meshtastic prefix generation when disabled."""
+        config = {
+            "meshtastic": {
+                "prefix_enabled": False
+            }
+        }
+
+        result = get_meshtastic_prefix(config, "Alice")
+        self.assertEqual(result, "")
+
+    def test_get_meshtastic_prefix_custom_format(self):
+        """Test Meshtastic prefix with custom format."""
+        config = {
+            "meshtastic": {
+                "prefix_enabled": True,
+                "prefix_format": "[{display3}]: "
+            }
+        }
+
+        result = get_meshtastic_prefix(config, "Alice")
+        self.assertEqual(result, "[Ali]: ")
+
+    def test_get_meshtastic_prefix_invalid_format(self):
+        """Test Meshtastic prefix with invalid format falls back to default."""
+        config = {
+            "meshtastic": {
+                "prefix_enabled": True,
+                "prefix_format": "{invalid_var}: "
+            }
+        }
+
+        result = get_meshtastic_prefix(config, "Alice")
+        self.assertEqual(result, "Alice[M]: ")  # Default format
+
+    def test_get_matrix_prefix_enabled(self):
+        """Test Matrix prefix generation when enabled."""
+        config = {
+            "matrix": {
+                "prefix_enabled": True,
+                "prefix_format": "[{long3}/{mesh}]: "
+            }
+        }
+
+        result = get_matrix_prefix(config, "Alice", "A", "TestMesh")
+        self.assertEqual(result, "[Ali/TestMesh]: ")
+
+    def test_get_matrix_prefix_disabled(self):
+        """Test Matrix prefix generation when disabled."""
+        config = {
+            "matrix": {
+                "prefix_enabled": False
+            }
+        }
+
+        result = get_matrix_prefix(config, "Alice", "A", "TestMesh")
+        self.assertEqual(result, "")
+
+    def test_get_matrix_prefix_default_format(self):
+        """Test Matrix prefix with default format."""
+        config = {
+            "matrix": {
+                "prefix_enabled": True
+                # No custom format specified
+            }
+        }
+
+        result = get_matrix_prefix(config, "Alice", "A", "TestMesh")
+        self.assertEqual(result, "[Alice/TestMesh]: ")  # Default format
+
+
+class TestTextProcessing(unittest.TestCase):
+    """Test cases for text processing functions."""
+
+    def test_truncate_message_under_limit(self):
+        """Test message truncation when under byte limit."""
+        text = "Hello world"
+        result = truncate_message(text, max_bytes=50)
+        self.assertEqual(result, "Hello world")
+
+    def test_truncate_message_over_limit(self):
+        """Test message truncation when over byte limit."""
+        text = "This is a very long message that exceeds the byte limit"
+        result = truncate_message(text, max_bytes=20)
+        self.assertTrue(len(result.encode('utf-8')) <= 20)
+        self.assertTrue(result.startswith("This is"))
+
+    def test_truncate_message_unicode(self):
+        """Test message truncation with Unicode characters."""
+        text = "Hello 🌍 world"
+        result = truncate_message(text, max_bytes=10)
+        # Should handle Unicode properly without breaking characters
+        self.assertTrue(len(result.encode('utf-8')) <= 10)
+
+    def test_strip_quoted_lines_with_quotes(self):
+        """Test stripping quoted lines from text."""
+        text = "This is a reply\n> Original message\n> Another quoted line\nNew content"
+        result = strip_quoted_lines(text)
+        expected = "This is a reply New content"  # Joined with spaces
+        self.assertEqual(result, expected)
+
+    def test_strip_quoted_lines_no_quotes(self):
+        """Test stripping quoted lines when no quotes exist."""
+        text = "This is a normal message\nWith multiple lines"
+        result = strip_quoted_lines(text)
+        expected = "This is a normal message With multiple lines"  # Joined with spaces
+        self.assertEqual(result, expected)
+
+    def test_strip_quoted_lines_only_quotes(self):
+        """Test stripping quoted lines when all lines are quoted."""
+        text = "> First quoted line\n> Second quoted line"
+        result = strip_quoted_lines(text)
+        self.assertEqual(result, "")
+
+    def test_format_reply_message(self):
+        """Test formatting of reply messages."""
+        config = {}  # Using defaults
+        result = format_reply_message(config, "Alice Smith", "This is a reply\n> Original message")
+
+        # Should include truncated display name and strip quoted lines
+        self.assertTrue(result.startswith("Alice[M]: "))
+        self.assertNotIn("> Original message", result)
+        self.assertIn("This is a reply", result)
+
+
+class TestBotCommand(unittest.TestCase):
+    """Test cases for bot command detection."""
+
+    @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
+    @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
+    def test_bot_command_direct_mention(self):
+        """Test bot command with direct mention."""
+        mock_event = MagicMock()
+        mock_event.body = "!help"
+        mock_event.source = {"content": {"formatted_body": "!help"}}
+
+        result = bot_command("help", mock_event)
+        self.assertTrue(result)
+
+    @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
+    @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
+    def test_bot_command_no_match(self):
+        """Test bot command that doesn't match."""
+        mock_event = MagicMock()
+        mock_event.body = "regular message"
+        mock_event.source = {"content": {"formatted_body": "regular message"}}
+
+        result = bot_command("help", mock_event)
+        self.assertFalse(result)
+
+    @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
+    @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
+    def test_bot_command_case_insensitive(self):
+        """Test bot command case insensitivity."""
+        mock_event = MagicMock()
+        mock_event.body = "!HELP"
+        mock_event.source = {"content": {"formatted_body": "!HELP"}}
+
+        result = bot_command("HELP", mock_event)  # Command should match case
+        self.assertTrue(result)
+
+    @patch('mmrelay.matrix_utils.bot_user_id', '@bot:matrix.org')
+    @patch('mmrelay.matrix_utils.bot_user_name', 'Bot')
+    def test_bot_command_with_args(self):
+        """Test bot command with arguments."""
+        mock_event = MagicMock()
+        mock_event.body = "!help me please"
+        mock_event.source = {"content": {"formatted_body": "!help me please"}}
+
+        result = bot_command("help", mock_event)
+        self.assertTrue(result)
 
 
 if __name__ == "__main__":

--- a/tests/test_mesh_relay_plugin.py
+++ b/tests/test_mesh_relay_plugin.py
@@ -27,7 +27,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
     """Test cases for the mesh relay plugin."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initializes the Plugin instance and mocks dependencies for each test.
+        
+        Sets up a Plugin object, replaces its logger with a mock, and mocks the strip_raw method to return its input unchanged.
+        """
         self.plugin = Plugin()
         self.plugin.logger = MagicMock()
         
@@ -35,25 +39,35 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.plugin.strip_raw = MagicMock(side_effect=lambda x: x)
 
     def test_plugin_name(self):
-        """Test that plugin name is correctly set."""
+        """
+        Test that the plugin's name attribute is set to "mesh_relay".
+        """
         self.assertEqual(self.plugin.plugin_name, "mesh_relay")
 
     def test_max_data_rows_per_node(self):
-        """Test that max data rows per node is set correctly."""
+        """
+        Verify that the plugin's maximum data rows per node is set to 50.
+        """
         self.assertEqual(self.plugin.max_data_rows_per_node, 50)
 
     def test_get_matrix_commands(self):
-        """Test that get_matrix_commands returns empty list."""
+        """
+        Test that get_matrix_commands returns an empty list.
+        """
         commands = self.plugin.get_matrix_commands()
         self.assertEqual(commands, [])
 
     def test_get_mesh_commands(self):
-        """Test that get_mesh_commands returns empty list."""
+        """
+        Test that get_mesh_commands returns an empty list.
+        """
         commands = self.plugin.get_mesh_commands()
         self.assertEqual(commands, [])
 
     def test_normalize_dict_input(self):
-        """Test normalize method with dictionary input."""
+        """
+        Tests that the normalize method correctly processes a dictionary input by calling strip_raw and returning the unchanged dictionary.
+        """
         input_dict = {"decoded": {"text": "test message"}}
         
         result = self.plugin.normalize(input_dict)
@@ -63,7 +77,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(result, input_dict)
 
     def test_normalize_json_string_input(self):
-        """Test normalize method with JSON string input."""
+        """
+        Test that the normalize method correctly parses a JSON string input and returns the expected dictionary.
+        
+        Verifies that the input JSON string is parsed, passed to strip_raw, and the resulting dictionary matches the expected output.
+        """
         input_json = '{"decoded": {"text": "test message"}}'
         expected_dict = {"decoded": {"text": "test message"}}
         
@@ -74,7 +92,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(result, expected_dict)
 
     def test_normalize_plain_string_input(self):
-        """Test normalize method with plain string input."""
+        """
+        Test that the normalize method wraps a plain string input in a dictionary under the 'decoded.text' key.
+        """
         input_string = "plain text message"
         expected_dict = {"decoded": {"text": "plain text message"}}
         
@@ -85,7 +105,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(result, expected_dict)
 
     def test_normalize_invalid_json_input(self):
-        """Test normalize method with invalid JSON string."""
+        """
+        Test that the normalize method treats an invalid JSON string as plain text.
+        
+        Verifies that when given a string that cannot be parsed as JSON, the normalize method wraps it in a dictionary under the "decoded" key and passes it to strip_raw.
+        """
         input_string = '{"invalid": json}'
         expected_dict = {"decoded": {"text": '{"invalid": json}'}}
         
@@ -96,7 +120,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(result, expected_dict)
 
     def test_process_packet_without_payload(self):
-        """Test process method with packet without binary payload."""
+        """
+        Test that the process method returns the original packet unchanged when no binary payload is present.
+        """
         packet = {"decoded": {"text": "test message"}}
         
         result = self.plugin.process(packet)
@@ -105,7 +131,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(result, packet)
 
     def test_process_packet_with_binary_payload(self):
-        """Test process method with packet containing binary payload."""
+        """
+        Test that the process method base64-encodes binary payloads in a packet.
+        
+        Verifies that when a packet contains a binary payload, the process method encodes it as a base64 UTF-8 string in the output.
+        """
         binary_data = b"binary payload data"
         packet = {"decoded": {"payload": binary_data}}
         
@@ -116,7 +146,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(result["decoded"]["payload"], expected_payload)
 
     def test_process_packet_with_string_payload(self):
-        """Test process method with packet containing string payload."""
+        """
+        Test that the process method leaves string payloads in the packet unchanged.
+        """
         packet = {"decoded": {"payload": "string payload"}}
         
         result = self.plugin.process(packet)
@@ -125,7 +157,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(result["decoded"]["payload"], "string payload")
 
     def test_matches_valid_radio_packet_message(self):
-        """Test matches method with valid radio packet message."""
+        """
+        Test that the matches method returns True for an event containing a valid radio packet message.
+        """
         event = MagicMock()
         event.source = {
             "content": {
@@ -138,7 +172,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertTrue(result)
 
     def test_matches_invalid_message_format(self):
-        """Test matches method with invalid message format."""
+        """
+        Test that the matches method returns False when the event body is not a valid radio packet message.
+        """
         event = MagicMock()
         event.source = {
             "content": {
@@ -151,7 +187,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertFalse(result)
 
     def test_matches_missing_content(self):
-        """Test matches method with missing content."""
+        """
+        Test that the matches method returns False when the event has no content.
+        """
         event = MagicMock()
         event.source = {}
         
@@ -160,7 +198,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertFalse(result)
 
     def test_matches_non_string_body(self):
-        """Test matches method with non-string body."""
+        """
+        Test that the matches method returns False when the event body is not a string.
+        """
         event = MagicMock()
         event.source = {
             "content": {
@@ -175,7 +215,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
     @patch('mmrelay.plugins.mesh_relay_plugin.config', None)
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_meshtastic_message_no_config(self, mock_connect):
-        """Test handle_meshtastic_message with no configuration."""
+        """
+        Test that handle_meshtastic_message returns None and does not send a Matrix message when no configuration is present.
+        """
         mock_matrix_client = AsyncMock()
         mock_connect.return_value = mock_matrix_client
 
@@ -185,6 +227,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Asynchronously tests that `handle_meshtastic_message` returns None and does not send a Matrix message when no configuration is present.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "longname", "meshnet_name"
             )
@@ -201,7 +246,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
     @patch('mmrelay.plugins.mesh_relay_plugin.config')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_meshtastic_message_unmapped_channel(self, mock_connect, mock_config):
-        """Test handle_meshtastic_message with unmapped channel."""
+        """
+        Test that handle_meshtastic_message returns None and does not send a Matrix message when the packet's channel is not mapped in the configuration.
+        """
         mock_matrix_client = AsyncMock()
         mock_connect.return_value = mock_matrix_client
 
@@ -216,6 +263,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Asynchronously tests that handle_meshtastic_message returns None and skips sending a Matrix message when the channel is not mapped in the configuration.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "longname", "meshnet_name"
             )
@@ -237,7 +287,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
     @patch('mmrelay.plugins.mesh_relay_plugin.config')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_meshtastic_message_mapped_channel(self, mock_connect, mock_config):
-        """Test handle_meshtastic_message with mapped channel."""
+        """
+        Test that handle_meshtastic_message sends a Matrix message when the packet's channel is mapped in the configuration.
+        
+        Verifies that the correct Matrix room, message type, and content are used, and that the function returns False to allow further processing by other plugins.
+        """
         mock_matrix_client = AsyncMock()
         mock_connect.return_value = mock_matrix_client
 
@@ -252,6 +306,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Asynchronously tests that a Meshtastic message on a mapped channel triggers correct Matrix message sending.
+            
+            Verifies that the plugin returns False to allow further processing, sends a Matrix message to the expected room with the correct message type and content, and includes the processed Meshtastic packet in the message body.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "longname", "meshnet_name"
             )
@@ -278,7 +337,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
     @patch('mmrelay.plugins.mesh_relay_plugin.config')
     @patch('mmrelay.matrix_utils.connect_matrix')
     def test_handle_meshtastic_message_no_channel_field(self, mock_connect, mock_config):
-        """Test handle_meshtastic_message with packet missing channel field."""
+        """
+        Test that handle_meshtastic_message correctly defaults to channel 0 when the packet lacks a channel field.
+        
+        Verifies that a Matrix message is sent to the room mapped to channel 0 and that the method returns False.
+        """
         mock_matrix_client = AsyncMock()
         mock_connect.return_value = mock_matrix_client
 
@@ -293,6 +356,12 @@ class TestMeshRelayPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Runs an asynchronous test for handling a Meshtastic message with a missing channel field, verifying that the plugin defaults to channel 0 and sends a Matrix message.
+            
+            Returns:
+                None
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "longname", "meshnet_name"
             )
@@ -305,13 +374,18 @@ class TestMeshRelayPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_no_match(self):
-        """Test handle_room_message when event doesn't match."""
+        """
+        Test that handle_room_message returns False when the event does not match plugin criteria.
+        """
         self.plugin.matches = MagicMock(return_value=False)
 
         room = MagicMock()
         event = MagicMock()
 
         async def run_test():
+            """
+            Asynchronously tests that `handle_room_message` returns False and calls `matches` with the given event.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -321,7 +395,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.mesh_relay_plugin.config', None)
     def test_handle_room_message_no_config(self):
-        """Test handle_room_message with no configuration."""
+        """
+        Test that handle_room_message returns False and logs a debug message when no configuration is present.
+        """
         self.plugin.matches = MagicMock(return_value=True)
 
         room = MagicMock()
@@ -329,6 +405,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         event = MagicMock()
 
         async def run_test():
+            """
+            Asynchronously tests that handle_room_message returns False and logs a debug message when no configuration is present.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
 
             # Should return False when no config
@@ -344,7 +423,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.mesh_relay_plugin.config')
     def test_handle_room_message_unmapped_room(self, mock_config):
-        """Test handle_room_message with unmapped room."""
+        """
+        Test that handle_room_message returns False and logs a debug message when the room is not mapped in the configuration.
+        """
         self.plugin.matches = MagicMock(return_value=True)
 
         # Mock config with no matching room
@@ -357,6 +438,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         event = MagicMock()
 
         async def run_test():
+            """
+            Runs an asynchronous test to verify that `handle_room_message` returns False and logs a debug message when called with an unmapped room.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
 
             # Should return False for unmapped room
@@ -372,7 +456,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.mesh_relay_plugin.config')
     def test_handle_room_message_missing_packet(self, mock_config):
-        """Test handle_room_message with missing embedded packet."""
+        """
+        Test that handle_room_message returns False and logs a debug message when the embedded packet is missing from the event.
+        """
         self.plugin.matches = MagicMock(return_value=True)
 
         # Mock config with matching room
@@ -388,6 +474,11 @@ class TestMeshRelayPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Runs the test for handling a Matrix room message when the embedded packet is missing.
+            
+            Asserts that the handler returns False and logs a debug message indicating the missing packet.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
 
             # Should return False when packet is missing
@@ -401,7 +492,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
 
     @patch('mmrelay.plugins.mesh_relay_plugin.config')
     def test_handle_room_message_invalid_json_packet(self, mock_config):
-        """Test handle_room_message with invalid JSON packet."""
+        """
+        Test that handle_room_message returns None and logs an error when the embedded packet contains invalid JSON.
+        """
         self.plugin.matches = MagicMock(return_value=True)
 
         # Mock config with matching room
@@ -419,6 +512,9 @@ class TestMeshRelayPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Asynchronously tests that `handle_room_message` returns None and logs an error when embedded packet JSON parsing fails.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
 
             # Should return None when JSON parsing fails

--- a/tests/test_mesh_relay_plugin.py
+++ b/tests/test_mesh_relay_plugin.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay mesh relay plugin.
+
+Tests the core mesh-to-Matrix relay functionality including:
+- Packet normalization and processing
+- Bidirectional message relay
+- Channel mapping and configuration
+- Matrix event matching
+- Meshtastic packet reconstruction
+"""
+
+import base64
+import json
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.mesh_relay_plugin import Plugin
+
+
+class TestMeshRelayPlugin(unittest.TestCase):
+    """Test cases for the mesh relay plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        
+        # Mock the strip_raw method from base plugin
+        self.plugin.strip_raw = MagicMock(side_effect=lambda x: x)
+
+    def test_plugin_name(self):
+        """Test that plugin name is correctly set."""
+        self.assertEqual(self.plugin.plugin_name, "mesh_relay")
+
+    def test_max_data_rows_per_node(self):
+        """Test that max data rows per node is set correctly."""
+        self.assertEqual(self.plugin.max_data_rows_per_node, 50)
+
+    def test_get_matrix_commands(self):
+        """Test that get_matrix_commands returns empty list."""
+        commands = self.plugin.get_matrix_commands()
+        self.assertEqual(commands, [])
+
+    def test_get_mesh_commands(self):
+        """Test that get_mesh_commands returns empty list."""
+        commands = self.plugin.get_mesh_commands()
+        self.assertEqual(commands, [])
+
+    def test_normalize_dict_input(self):
+        """Test normalize method with dictionary input."""
+        input_dict = {"decoded": {"text": "test message"}}
+        
+        result = self.plugin.normalize(input_dict)
+        
+        # Should call strip_raw and return the result
+        self.plugin.strip_raw.assert_called_once_with(input_dict)
+        self.assertEqual(result, input_dict)
+
+    def test_normalize_json_string_input(self):
+        """Test normalize method with JSON string input."""
+        input_json = '{"decoded": {"text": "test message"}}'
+        expected_dict = {"decoded": {"text": "test message"}}
+        
+        result = self.plugin.normalize(input_json)
+        
+        # Should parse JSON and call strip_raw
+        self.plugin.strip_raw.assert_called_once_with(expected_dict)
+        self.assertEqual(result, expected_dict)
+
+    def test_normalize_plain_string_input(self):
+        """Test normalize method with plain string input."""
+        input_string = "plain text message"
+        expected_dict = {"decoded": {"text": "plain text message"}}
+        
+        result = self.plugin.normalize(input_string)
+        
+        # Should wrap in TEXT_MESSAGE_APP format
+        self.plugin.strip_raw.assert_called_once_with(expected_dict)
+        self.assertEqual(result, expected_dict)
+
+    def test_normalize_invalid_json_input(self):
+        """Test normalize method with invalid JSON string."""
+        input_string = '{"invalid": json}'
+        expected_dict = {"decoded": {"text": '{"invalid": json}'}}
+        
+        result = self.plugin.normalize(input_string)
+        
+        # Should treat as plain string when JSON parsing fails
+        self.plugin.strip_raw.assert_called_once_with(expected_dict)
+        self.assertEqual(result, expected_dict)
+
+    def test_process_packet_without_payload(self):
+        """Test process method with packet without binary payload."""
+        packet = {"decoded": {"text": "test message"}}
+        
+        result = self.plugin.process(packet)
+        
+        # Should normalize but not modify payload
+        self.assertEqual(result, packet)
+
+    def test_process_packet_with_binary_payload(self):
+        """Test process method with packet containing binary payload."""
+        binary_data = b"binary payload data"
+        packet = {"decoded": {"payload": binary_data}}
+        
+        result = self.plugin.process(packet)
+        
+        # Should encode binary payload as base64
+        expected_payload = base64.b64encode(binary_data).decode("utf-8")
+        self.assertEqual(result["decoded"]["payload"], expected_payload)
+
+    def test_process_packet_with_string_payload(self):
+        """Test process method with packet containing string payload."""
+        packet = {"decoded": {"payload": "string payload"}}
+        
+        result = self.plugin.process(packet)
+        
+        # Should not modify string payload
+        self.assertEqual(result["decoded"]["payload"], "string payload")
+
+    def test_matches_valid_radio_packet_message(self):
+        """Test matches method with valid radio packet message."""
+        event = MagicMock()
+        event.source = {
+            "content": {
+                "body": "Processed TEXT_MESSAGE_APP radio packet"
+            }
+        }
+        
+        result = self.plugin.matches(event)
+        
+        self.assertTrue(result)
+
+    def test_matches_invalid_message_format(self):
+        """Test matches method with invalid message format."""
+        event = MagicMock()
+        event.source = {
+            "content": {
+                "body": "This is not a radio packet message"
+            }
+        }
+        
+        result = self.plugin.matches(event)
+        
+        self.assertFalse(result)
+
+    def test_matches_missing_content(self):
+        """Test matches method with missing content."""
+        event = MagicMock()
+        event.source = {}
+        
+        result = self.plugin.matches(event)
+        
+        self.assertFalse(result)
+
+    def test_matches_non_string_body(self):
+        """Test matches method with non-string body."""
+        event = MagicMock()
+        event.source = {
+            "content": {
+                "body": 123  # Non-string body
+            }
+        }
+        
+        result = self.plugin.matches(event)
+        
+        self.assertFalse(result)
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config', None)
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_meshtastic_message_no_config(self, mock_connect):
+        """Test handle_meshtastic_message with no configuration."""
+        mock_matrix_client = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+
+        packet = {
+            "decoded": {"portnum": "TEXT_MESSAGE_APP", "text": "test"},
+            "channel": 0
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            # Should return None when no config
+            self.assertIsNone(result)
+
+            # Should not send any Matrix messages
+            mock_matrix_client.room_send.assert_not_called()
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_meshtastic_message_unmapped_channel(self, mock_connect, mock_config):
+        """Test handle_meshtastic_message with unmapped channel."""
+        mock_matrix_client = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+
+        # Mock config with no matching channel
+        mock_config.get.return_value = [
+            {"meshtastic_channel": 1, "id": "!room1:matrix.org"}
+        ]
+
+        packet = {
+            "decoded": {"portnum": "TEXT_MESSAGE_APP", "text": "test"},
+            "channel": 0  # Channel 0 not mapped
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            # Should return None for unmapped channel
+            self.assertIsNone(result)
+
+            # Should log debug message
+            self.plugin.logger.debug.assert_called_with(
+                "Skipping message from unmapped channel 0"
+            )
+
+            # Should not send any Matrix messages
+            mock_matrix_client.room_send.assert_not_called()
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_meshtastic_message_mapped_channel(self, mock_connect, mock_config):
+        """Test handle_meshtastic_message with mapped channel."""
+        mock_matrix_client = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+
+        # Mock config with matching channel
+        mock_config.get.return_value = [
+            {"meshtastic_channel": 0, "id": "!room1:matrix.org"}
+        ]
+
+        packet = {
+            "decoded": {"portnum": "TEXT_MESSAGE_APP", "text": "test"},
+            "channel": 0
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            # Should return False (allows other plugins to process)
+            self.assertFalse(result)
+
+            # Should send Matrix message
+            mock_matrix_client.room_send.assert_called_once()
+            call_args = mock_matrix_client.room_send.call_args
+
+            self.assertEqual(call_args.kwargs['room_id'], "!room1:matrix.org")
+            self.assertEqual(call_args.kwargs['message_type'], "m.room.message")
+
+            content = call_args.kwargs['content']
+            self.assertEqual(content['msgtype'], "m.text")
+            self.assertTrue(content['mmrelay_suppress'])
+            self.assertIn("meshtastic_packet", content)
+            self.assertEqual(content['body'], "Processed TEXT_MESSAGE_APP radio packet")
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config')
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    def test_handle_meshtastic_message_no_channel_field(self, mock_connect, mock_config):
+        """Test handle_meshtastic_message with packet missing channel field."""
+        mock_matrix_client = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+
+        # Mock config with channel 0 mapped (default channel)
+        mock_config.get.return_value = [
+            {"meshtastic_channel": 0, "id": "!room1:matrix.org"}
+        ]
+
+        packet = {
+            "decoded": {"portnum": "TEXT_MESSAGE_APP", "text": "test"}
+            # No channel field - should default to 0
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            # Should return False and send message (channel defaults to 0)
+            self.assertFalse(result)
+            mock_matrix_client.room_send.assert_called_once()
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_no_match(self):
+        """Test handle_room_message when event doesn't match."""
+        self.plugin.matches = MagicMock(return_value=False)
+
+        room = MagicMock()
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.matches.assert_called_once_with(event)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config', None)
+    def test_handle_room_message_no_config(self):
+        """Test handle_room_message with no configuration."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+
+            # Should return False when no config
+            self.assertFalse(result)
+
+            # Should log debug message
+            self.plugin.logger.debug.assert_called_with(
+                "Skipping message from unmapped channel None"
+            )
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config')
+    def test_handle_room_message_unmapped_room(self, mock_config):
+        """Test handle_room_message with unmapped room."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        # Mock config with no matching room
+        mock_config.get.return_value = [
+            {"id": "!other:matrix.org", "meshtastic_channel": 1}
+        ]
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"  # Not in config
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+
+            # Should return False for unmapped room
+            self.assertFalse(result)
+
+            # Should log debug message
+            self.plugin.logger.debug.assert_called_with(
+                "Skipping message from unmapped channel None"
+            )
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config')
+    def test_handle_room_message_missing_packet(self, mock_config):
+        """Test handle_room_message with missing embedded packet."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        # Mock config with matching room
+        mock_config.get.return_value = [
+            {"id": "!test:matrix.org", "meshtastic_channel": 1}
+        ]
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        event.source = {
+            "content": {}  # No meshtastic_packet field
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+
+            # Should return False when packet is missing
+            self.assertFalse(result)
+
+            # Should log debug message
+            self.plugin.logger.debug.assert_called_with("Missing embedded packet")
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.plugins.mesh_relay_plugin.config')
+    def test_handle_room_message_invalid_json_packet(self, mock_config):
+        """Test handle_room_message with invalid JSON packet."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        # Mock config with matching room
+        mock_config.get.return_value = [
+            {"id": "!test:matrix.org", "meshtastic_channel": 1}
+        ]
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        event.source = {
+            "content": {
+                "meshtastic_packet": "invalid json"
+            }
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+
+            # Should return None when JSON parsing fails
+            self.assertIsNone(result)
+
+            # Should log error message
+            self.plugin.logger.error.assert_called()
+            error_call = self.plugin.logger.error.call_args[0][0]
+            self.assertIn("Error processing embedded packet", error_call)
+
+        import asyncio
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -14,15 +14,18 @@ import asyncio
 import os
 import sys
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mmrelay.meshtastic_utils import (
     connect_meshtastic,
+    is_running_as_service,
+    on_lost_meshtastic_connection,
     on_meshtastic_message,
     sendTextReply,
+    serial_port_exists,
 )
 
 
@@ -318,6 +321,305 @@ class TestMeshtasticUtils(unittest.TestCase):
             # Meshtastic->Matrix messages are still relayed regardless of broadcast_enabled
             # (broadcast_enabled only affects Matrix->Meshtastic direction)
             mock_run_coro.assert_called_once()
+
+
+class TestServiceDetection(unittest.TestCase):
+    """Test cases for service detection functionality."""
+
+    @patch.dict(os.environ, {'INVOCATION_ID': 'test-service-id'})
+    def test_is_running_as_service_with_invocation_id(self):
+        """Test service detection when INVOCATION_ID environment variable is set."""
+        result = is_running_as_service()
+        self.assertTrue(result)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_is_running_as_service_with_systemd_parent(self):
+        """Test service detection when parent process is systemd."""
+        status_data = "PPid:\t1\n"
+        comm_data = "systemd"
+
+        def mock_open_func(filename, *args, **kwargs):
+            if filename == "/proc/self/status":
+                return mock_open(read_data=status_data)()
+            elif filename.startswith("/proc/") and filename.endswith("/comm"):
+                return mock_open(read_data=comm_data)()
+            else:
+                raise FileNotFoundError()
+
+        with patch('builtins.open', side_effect=mock_open_func):
+            result = is_running_as_service()
+            self.assertTrue(result)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_is_running_as_service_normal_process(self):
+        """Test service detection for normal (non-service) process."""
+        status_data = "PPid:\t1234\n"
+        comm_data = "bash"
+
+        def mock_open_func(filename, *args, **kwargs):
+            if filename == "/proc/self/status":
+                return mock_open(read_data=status_data)()
+            elif filename.startswith("/proc/") and filename.endswith("/comm"):
+                return mock_open(read_data=comm_data)()
+            else:
+                raise FileNotFoundError()
+
+        with patch('builtins.open', side_effect=mock_open_func):
+            result = is_running_as_service()
+            self.assertFalse(result)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch('builtins.open', side_effect=FileNotFoundError())
+    def test_is_running_as_service_file_not_found(self, mock_open_func):
+        """Test service detection when parent process file cannot be read."""
+        result = is_running_as_service()
+        self.assertFalse(result)
+
+
+class TestSerialPortDetection(unittest.TestCase):
+    """Test cases for serial port detection functionality."""
+
+    @patch('mmrelay.meshtastic_utils.serial.tools.list_ports.comports')
+    def test_serial_port_exists_found(self, mock_comports):
+        """Test serial port detection when port exists."""
+        mock_port = MagicMock()
+        mock_port.device = '/dev/ttyUSB0'
+        mock_comports.return_value = [mock_port]
+
+        result = serial_port_exists('/dev/ttyUSB0')
+        self.assertTrue(result)
+
+    @patch('mmrelay.meshtastic_utils.serial.tools.list_ports.comports')
+    def test_serial_port_exists_not_found(self, mock_comports):
+        """Test serial port detection when port doesn't exist."""
+        mock_port = MagicMock()
+        mock_port.device = '/dev/ttyUSB1'
+        mock_comports.return_value = [mock_port]
+
+        result = serial_port_exists('/dev/ttyUSB0')
+        self.assertFalse(result)
+
+    @patch('mmrelay.meshtastic_utils.serial.tools.list_ports.comports')
+    def test_serial_port_exists_no_ports(self, mock_comports):
+        """Test serial port detection when no ports are available."""
+        mock_comports.return_value = []
+
+        result = serial_port_exists('/dev/ttyUSB0')
+        self.assertFalse(result)
+
+
+class TestConnectionLossHandling(unittest.TestCase):
+    """Test cases for connection loss handling."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Reset global state
+        import mmrelay.meshtastic_utils
+        mmrelay.meshtastic_utils.reconnecting = False
+        mmrelay.meshtastic_utils.shutting_down = False
+        mmrelay.meshtastic_utils.reconnect_task = None
+
+    @patch('mmrelay.meshtastic_utils.logger')
+    @patch('mmrelay.meshtastic_utils.event_loop', MagicMock())
+    @patch('mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe')
+    def test_on_lost_meshtastic_connection_normal(self, mock_run_coro, mock_logger):
+        """Test normal connection loss handling."""
+        import mmrelay.meshtastic_utils
+        mmrelay.meshtastic_utils.reconnecting = False
+        mmrelay.meshtastic_utils.shutting_down = False
+
+        mock_interface = MagicMock()
+
+        on_lost_meshtastic_connection(mock_interface, "test_source")
+
+        mock_logger.error.assert_called()
+        # Should log the connection loss
+        error_call = mock_logger.error.call_args[0][0]
+        self.assertIn("Lost connection", error_call)
+        self.assertIn("test_source", error_call)
+
+    @patch('mmrelay.meshtastic_utils.logger')
+    def test_on_lost_meshtastic_connection_already_reconnecting(self, mock_logger):
+        """Test connection loss handling when already reconnecting."""
+        import mmrelay.meshtastic_utils
+        mmrelay.meshtastic_utils.reconnecting = True
+        mmrelay.meshtastic_utils.shutting_down = False
+
+        mock_interface = MagicMock()
+
+        on_lost_meshtastic_connection(mock_interface, "test_source")
+
+        # Should log that reconnection is already in progress
+        mock_logger.debug.assert_called_with("Reconnection already in progress. Skipping additional reconnection attempt.")
+
+    @patch('mmrelay.meshtastic_utils.logger')
+    def test_on_lost_meshtastic_connection_shutting_down(self, mock_logger):
+        """Test connection loss handling during shutdown."""
+        import mmrelay.meshtastic_utils
+        mmrelay.meshtastic_utils.reconnecting = False
+        mmrelay.meshtastic_utils.shutting_down = True
+
+        mock_interface = MagicMock()
+
+        on_lost_meshtastic_connection(mock_interface, "test_source")
+
+        # Should log that system is shutting down
+        mock_logger.debug.assert_called_with("Shutdown in progress. Not attempting to reconnect.")
+
+
+class TestConnectMeshtasticEdgeCases(unittest.TestCase):
+    """Test cases for edge cases in Meshtastic connection."""
+
+    @patch('mmrelay.meshtastic_utils.serial_port_exists')
+    @patch('mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface')
+    def test_connect_meshtastic_serial_port_not_exists(self, mock_serial, mock_port_exists):
+        """Test connection attempt when serial port doesn't exist."""
+        mock_port_exists.return_value = False
+
+        config = {
+            "meshtastic": {
+                "connection_type": "serial",
+                "serial_port": "/dev/ttyUSB0"
+            }
+        }
+
+        result = connect_meshtastic(passed_config=config)
+
+        self.assertIsNone(result)
+        mock_serial.assert_not_called()
+
+    @patch('mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface')
+    def test_connect_meshtastic_serial_exception(self, mock_serial):
+        """Test connection when serial interface raises an exception."""
+        mock_serial.side_effect = Exception("Serial connection failed")
+
+        config = {
+            "meshtastic": {
+                "connection_type": "serial",
+                "serial_port": "/dev/ttyUSB0"
+            }
+        }
+
+        with patch('mmrelay.meshtastic_utils.serial_port_exists', return_value=True):
+            result = connect_meshtastic(passed_config=config)
+
+        self.assertIsNone(result)
+
+    @patch('mmrelay.meshtastic_utils.meshtastic.tcp_interface.TCPInterface')
+    def test_connect_meshtastic_tcp_exception(self, mock_tcp):
+        """Test connection when TCP interface raises an exception."""
+        mock_tcp.side_effect = Exception("TCP connection failed")
+
+        config = {
+            "meshtastic": {
+                "connection_type": "tcp",
+                "host": "192.168.1.100"
+            }
+        }
+
+        result = connect_meshtastic(passed_config=config)
+
+        self.assertIsNone(result)
+
+    @patch('mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface')
+    def test_connect_meshtastic_ble_exception(self, mock_ble):
+        """Test connection when BLE interface raises an exception."""
+        mock_ble.side_effect = Exception("BLE connection failed")
+
+        config = {
+            "meshtastic": {
+                "connection_type": "ble",
+                "ble_address": "AA:BB:CC:DD:EE:FF"
+            }
+        }
+
+        result = connect_meshtastic(passed_config=config)
+
+        self.assertIsNone(result)
+
+    def test_connect_meshtastic_no_config(self):
+        """Test connection attempt with no configuration."""
+        result = connect_meshtastic(passed_config=None)
+        self.assertIsNone(result)
+
+    def test_connect_meshtastic_existing_client_simple(self):
+        """Test basic connection functionality."""
+        config = {
+            "meshtastic": {
+                "connection_type": "serial",
+                "serial_port": "/dev/ttyUSB0"
+            }
+        }
+
+        # Test with no config
+        result = connect_meshtastic(passed_config=None)
+        # Should handle gracefully
+        self.assertIsNone(result)
+
+
+class TestMessageProcessingEdgeCases(unittest.TestCase):
+    """Test cases for edge cases in message processing."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_config = {
+            "meshtastic": {
+                "connection_type": "serial",
+                "serial_port": "/dev/ttyUSB0",
+                "broadcast_enabled": True,
+                "meshnet_name": "test_mesh"
+            },
+            "matrix_rooms": [
+                {"id": "!room1:matrix.org", "meshtastic_channel": 0}
+            ]
+        }
+
+    def test_on_meshtastic_message_no_decoded(self):
+        """Test message processing when packet has no decoded field."""
+        packet = {
+            "from": 123456789,
+            "to": 987654321,
+            "channel": 0,
+            "id": 12345,
+            "rxTime": 1234567890
+            # No 'decoded' field
+        }
+
+        with patch('mmrelay.meshtastic_utils.config', self.mock_config), \
+             patch('mmrelay.meshtastic_utils.matrix_rooms', self.mock_config["matrix_rooms"]), \
+             patch('mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe') as mock_run_coro:
+
+            mock_interface = MagicMock()
+
+            on_meshtastic_message(packet, mock_interface)
+
+            # Should not process message without decoded field
+            mock_run_coro.assert_not_called()
+
+    def test_on_meshtastic_message_empty_text(self):
+        """Test message processing with empty text."""
+        packet = {
+            "from": 123456789,
+            "to": 987654321,
+            "decoded": {
+                "text": "",  # Empty text
+                "portnum": "TEXT_MESSAGE_APP"
+            },
+            "channel": 0,
+            "id": 12345,
+            "rxTime": 1234567890
+        }
+
+        with patch('mmrelay.meshtastic_utils.config', self.mock_config), \
+             patch('mmrelay.meshtastic_utils.matrix_rooms', self.mock_config["matrix_rooms"]), \
+             patch('mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe') as mock_run_coro:
+
+            mock_interface = MagicMock()
+
+            on_meshtastic_message(packet, mock_interface)
+
+            # Should not process empty text messages
+            mock_run_coro.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_nodes_plugin.py
+++ b/tests/test_nodes_plugin.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay nodes plugin.
+
+Tests the node listing functionality including:
+- Relative time calculations
+- Node data formatting and display
+- Meshtastic client integration
+- Matrix room message handling
+- Device metrics parsing
+"""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.nodes_plugin import Plugin, get_relative_time
+
+
+class TestGetRelativeTime(unittest.TestCase):
+    """Test cases for the get_relative_time utility function."""
+
+    def test_get_relative_time_just_now(self):
+        """Test relative time for very recent timestamps."""
+        now = datetime.now()
+        timestamp = now.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "Just now")
+
+    def test_get_relative_time_minutes_ago(self):
+        """Test relative time for timestamps within the last hour."""
+        now = datetime.now()
+        five_minutes_ago = now - timedelta(minutes=5)
+        timestamp = five_minutes_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "5 minutes ago")
+
+    def test_get_relative_time_one_minute_ago(self):
+        """Test relative time for exactly one minute ago."""
+        now = datetime.now()
+        one_minute_ago = now - timedelta(minutes=1)
+        timestamp = one_minute_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "1 minutes ago")
+
+    def test_get_relative_time_hours_ago(self):
+        """Test relative time for timestamps within the last day."""
+        now = datetime.now()
+        three_hours_ago = now - timedelta(hours=3)
+        timestamp = three_hours_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "3 hours ago")
+
+    def test_get_relative_time_one_hour_ago(self):
+        """Test relative time for exactly one hour ago."""
+        now = datetime.now()
+        one_hour_ago = now - timedelta(hours=1)
+        timestamp = one_hour_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "1 hours ago")
+
+    def test_get_relative_time_days_ago(self):
+        """Test relative time for timestamps within the last week."""
+        now = datetime.now()
+        three_days_ago = now - timedelta(days=3)
+        timestamp = three_days_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "3 days ago")
+
+    def test_get_relative_time_one_day_ago(self):
+        """Test relative time for exactly one day ago."""
+        now = datetime.now()
+        one_day_ago = now - timedelta(days=1)
+        timestamp = one_day_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "1 days ago")
+
+    def test_get_relative_time_old_date(self):
+        """Test relative time for timestamps older than 7 days."""
+        now = datetime.now()
+        ten_days_ago = now - timedelta(days=10)
+        timestamp = ten_days_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        # Should return formatted date like "Jan 15, 2024"
+        expected_format = ten_days_ago.strftime("%b %d, %Y")
+        self.assertEqual(result, expected_format)
+
+    def test_get_relative_time_exactly_seven_days(self):
+        """Test relative time for exactly 7 days ago (boundary case)."""
+        now = datetime.now()
+        seven_days_ago = now - timedelta(days=7)
+        timestamp = seven_days_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        self.assertEqual(result, "7 days ago")
+
+    def test_get_relative_time_exactly_eight_days(self):
+        """Test relative time for exactly 8 days ago (should use date format)."""
+        now = datetime.now()
+        eight_days_ago = now - timedelta(days=8)
+        timestamp = eight_days_ago.timestamp()
+        
+        result = get_relative_time(timestamp)
+        
+        # Should return formatted date
+        expected_format = eight_days_ago.strftime("%b %d, %Y")
+        self.assertEqual(result, expected_format)
+
+
+class TestNodesPlugin(unittest.TestCase):
+    """Test cases for the nodes plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        
+        # Mock Matrix client methods
+        self.plugin.send_matrix_message = AsyncMock()
+        
+        # Mock meshtastic client with sample node data
+        self.mock_meshtastic_client = MagicMock()
+        self.mock_meshtastic_client.nodes = {
+            "node1": {
+                "user": {
+                    "shortName": "N1",
+                    "longName": "Node One",
+                    "hwModel": "HELTEC_V3"
+                },
+                "snr": 12.5,
+                "lastHeard": (datetime.now() - timedelta(minutes=5)).timestamp(),
+                "deviceMetrics": {
+                    "voltage": 4.2,
+                    "batteryLevel": 85
+                }
+            },
+            "node2": {
+                "user": {
+                    "shortName": "N2", 
+                    "longName": "Node Two",
+                    "hwModel": "TBEAM"
+                },
+                "snr": -8.0,
+                "lastHeard": (datetime.now() - timedelta(hours=2)).timestamp(),
+                "deviceMetrics": {
+                    "voltage": 3.8,
+                    "batteryLevel": 45
+                }
+            },
+            "node3": {
+                "user": {
+                    "shortName": "N3",
+                    "longName": "Node Three", 
+                    "hwModel": "LORA32_V2_1"
+                }
+                # No SNR, lastHeard, or deviceMetrics data
+            }
+        }
+
+    def test_plugin_name(self):
+        """Test that plugin name is correctly set."""
+        self.assertEqual(self.plugin.plugin_name, "nodes")
+
+    def test_description_property(self):
+        """Test that description property returns expected format."""
+        description = self.plugin.description
+
+        self.assertIn("Show mesh radios and node data", description)
+        self.assertIn("$shortname $longname", description)
+        self.assertIn("$devicemodel", description)
+        self.assertIn("$battery $voltage", description)
+        self.assertIn("$snr", description)
+        self.assertIn("$lastseen", description)
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_with_full_data(self, mock_connect):
+        """Test response generation with complete node data."""
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        response = self.plugin.generate_response()
+
+        # Should start with node count
+        self.assertIn("Nodes: 3", response)
+
+        # Should contain node information
+        self.assertIn("N1 Node One", response)
+        self.assertIn("N2 Node Two", response)
+        self.assertIn("N3 Node Three", response)
+
+        # Should contain hardware models
+        self.assertIn("HELTEC_V3", response)
+        self.assertIn("TBEAM", response)
+        self.assertIn("LORA32_V2_1", response)
+
+        # Should contain battery and voltage info for nodes with data
+        self.assertIn("85%  4.2V", response)
+        self.assertIn("45%  3.8V", response)
+
+        # Should contain SNR info for nodes with data
+        self.assertIn("12.5 dB ", response)
+        self.assertIn("-8.0 dB ", response)
+
+        # Should contain relative time info
+        self.assertIn("minutes ago", response)
+        self.assertIn("hours ago", response)
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_with_missing_data(self, mock_connect):
+        """Test response generation with missing node data."""
+        # Create a client with minimal node data
+        minimal_client = MagicMock()
+        minimal_client.nodes = {
+            "node_minimal": {
+                "user": {
+                    "shortName": "MIN",
+                    "longName": "Minimal Node",
+                    "hwModel": "UNKNOWN"
+                }
+                # No SNR, lastHeard, or deviceMetrics
+            }
+        }
+        mock_connect.return_value = minimal_client
+
+        response = self.plugin.generate_response()
+
+        # Should handle missing data gracefully
+        self.assertIn("Nodes: 1", response)
+        self.assertIn("MIN Minimal Node", response)
+        self.assertIn("UNKNOWN", response)
+        self.assertIn("?% ?V", response)  # Default values for missing battery/voltage
+        self.assertIn("None", response)  # No last heard time
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_generate_response_with_null_values(self, mock_connect):
+        """Test response generation with null values in node data."""
+        null_client = MagicMock()
+        null_client.nodes = {
+            "node_null": {
+                "user": {
+                    "shortName": "NULL",
+                    "longName": "Null Node",
+                    "hwModel": "TEST"
+                },
+                "snr": None,
+                "lastHeard": None,
+                "deviceMetrics": {
+                    "voltage": None,
+                    "batteryLevel": None
+                }
+            }
+        }
+        mock_connect.return_value = null_client
+
+        response = self.plugin.generate_response()
+
+        # Should handle null values gracefully
+        self.assertIn("Nodes: 1", response)
+        self.assertIn("NULL Null Node", response)
+        self.assertIn("?% ?V", response)  # Default values for null battery/voltage
+        self.assertIn("None", response)  # No last heard time
+
+    def test_handle_meshtastic_message_always_false(self):
+        """Test that handle_meshtastic_message always returns False."""
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                {}, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_no_match(self):
+        """Test handle_room_message when event doesn't match."""
+        self.plugin.matches = MagicMock(return_value=False)
+
+        room = MagicMock()
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_not_called()
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_room_message_with_match(self, mock_connect):
+        """Test handle_room_message when event matches."""
+        mock_connect.return_value = self.mock_meshtastic_client
+        self.plugin.matches = MagicMock(return_value=True)
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+
+            self.assertTrue(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_called_once()
+
+            # Check the call arguments
+            call_args = self.plugin.send_matrix_message.call_args
+            self.assertEqual(call_args.kwargs['room_id'], "!test:matrix.org")
+            self.assertIn("Nodes: 3", call_args.kwargs['message'])
+            self.assertEqual(call_args.kwargs['formatted'], False)
+
+        import asyncio
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nodes_plugin.py
+++ b/tests/test_nodes_plugin.py
@@ -26,7 +26,9 @@ class TestGetRelativeTime(unittest.TestCase):
     """Test cases for the get_relative_time utility function."""
 
     def test_get_relative_time_just_now(self):
-        """Test relative time for very recent timestamps."""
+        """
+        Test that `get_relative_time` returns "Just now" for timestamps within a few seconds of the current time.
+        """
         now = datetime.now()
         timestamp = now.timestamp()
         
@@ -35,7 +37,9 @@ class TestGetRelativeTime(unittest.TestCase):
         self.assertEqual(result, "Just now")
 
     def test_get_relative_time_minutes_ago(self):
-        """Test relative time for timestamps within the last hour."""
+        """
+        Tests that `get_relative_time` returns the correct string for a timestamp five minutes ago.
+        """
         now = datetime.now()
         five_minutes_ago = now - timedelta(minutes=5)
         timestamp = five_minutes_ago.timestamp()
@@ -55,7 +59,9 @@ class TestGetRelativeTime(unittest.TestCase):
         self.assertEqual(result, "1 minutes ago")
 
     def test_get_relative_time_hours_ago(self):
-        """Test relative time for timestamps within the last day."""
+        """
+        Test that `get_relative_time` returns the correct string for a timestamp three hours ago.
+        """
         now = datetime.now()
         three_hours_ago = now - timedelta(hours=3)
         timestamp = three_hours_ago.timestamp()
@@ -75,7 +81,9 @@ class TestGetRelativeTime(unittest.TestCase):
         self.assertEqual(result, "1 hours ago")
 
     def test_get_relative_time_days_ago(self):
-        """Test relative time for timestamps within the last week."""
+        """
+        Tests that `get_relative_time` returns the correct string for a timestamp three days ago.
+        """
         now = datetime.now()
         three_days_ago = now - timedelta(days=3)
         timestamp = three_days_ago.timestamp()
@@ -95,7 +103,9 @@ class TestGetRelativeTime(unittest.TestCase):
         self.assertEqual(result, "1 days ago")
 
     def test_get_relative_time_old_date(self):
-        """Test relative time for timestamps older than 7 days."""
+        """
+        Test that `get_relative_time` returns a formatted date string for timestamps older than 7 days.
+        """
         now = datetime.now()
         ten_days_ago = now - timedelta(days=10)
         timestamp = ten_days_ago.timestamp()
@@ -107,7 +117,9 @@ class TestGetRelativeTime(unittest.TestCase):
         self.assertEqual(result, expected_format)
 
     def test_get_relative_time_exactly_seven_days(self):
-        """Test relative time for exactly 7 days ago (boundary case)."""
+        """
+        Test that `get_relative_time` returns "7 days ago" for a timestamp exactly seven days in the past.
+        """
         now = datetime.now()
         seven_days_ago = now - timedelta(days=7)
         timestamp = seven_days_ago.timestamp()
@@ -117,7 +129,9 @@ class TestGetRelativeTime(unittest.TestCase):
         self.assertEqual(result, "7 days ago")
 
     def test_get_relative_time_exactly_eight_days(self):
-        """Test relative time for exactly 8 days ago (should use date format)."""
+        """
+        Test that `get_relative_time` returns a formatted date string for a timestamp exactly eight days ago.
+        """
         now = datetime.now()
         eight_days_ago = now - timedelta(days=8)
         timestamp = eight_days_ago.timestamp()
@@ -133,7 +147,11 @@ class TestNodesPlugin(unittest.TestCase):
     """Test cases for the nodes plugin."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initialize the test environment with a mocked Plugin instance and a Meshtastic client containing sample node data for testing.
+        
+        Creates a Plugin object with mocked logger and asynchronous message sending. Sets up a mock Meshtastic client with three nodes, each having varying completeness of user, SNR, lastHeard, and deviceMetrics data.
+        """
         self.plugin = Plugin()
         self.plugin.logger = MagicMock()
         
@@ -180,11 +198,15 @@ class TestNodesPlugin(unittest.TestCase):
         }
 
     def test_plugin_name(self):
-        """Test that plugin name is correctly set."""
+        """
+        Verify that the plugin's name attribute is set to "nodes".
+        """
         self.assertEqual(self.plugin.plugin_name, "nodes")
 
     def test_description_property(self):
-        """Test that description property returns expected format."""
+        """
+        Verify that the plugin's description property contains expected placeholders and descriptive text for node data fields.
+        """
         description = self.plugin.description
 
         self.assertIn("Show mesh radios and node data", description)
@@ -196,7 +218,11 @@ class TestNodesPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_with_full_data(self, mock_connect):
-        """Test response generation with complete node data."""
+        """
+        Test that `generate_response` produces correct output when all node data fields are present.
+        
+        Verifies that the response includes node count, names, hardware models, battery and voltage information, SNR values, and relative time phrases for nodes with complete data.
+        """
         mock_connect.return_value = self.mock_meshtastic_client
 
         response = self.plugin.generate_response()
@@ -228,7 +254,11 @@ class TestNodesPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_with_missing_data(self, mock_connect):
-        """Test response generation with missing node data."""
+        """
+        Test that the response generated by the plugin correctly handles nodes with missing data fields.
+        
+        Verifies that the output includes appropriate placeholders for missing battery, voltage, and last heard time, and still displays available node information.
+        """
         # Create a client with minimal node data
         minimal_client = MagicMock()
         minimal_client.nodes = {
@@ -254,7 +284,9 @@ class TestNodesPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_generate_response_with_null_values(self, mock_connect):
-        """Test response generation with null values in node data."""
+        """
+        Test that the response generated by the plugin correctly handles nodes with null values for SNR, lastHeard, voltage, and batteryLevel, using default placeholders where appropriate.
+        """
         null_client = MagicMock()
         null_client.nodes = {
             "node_null": {
@@ -282,8 +314,13 @@ class TestNodesPlugin(unittest.TestCase):
         self.assertIn("None", response)  # No last heard time
 
     def test_handle_meshtastic_message_always_false(self):
-        """Test that handle_meshtastic_message always returns False."""
+        """
+        Test that handle_meshtastic_message always returns False regardless of input.
+        """
         async def run_test():
+            """
+            Asynchronously tests that handle_meshtastic_message always returns False.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 {}, "formatted_message", "longname", "meshnet_name"
             )
@@ -293,13 +330,20 @@ class TestNodesPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_no_match(self):
-        """Test handle_room_message when event doesn't match."""
+        """
+        Test that handle_room_message returns False and does not send a message when the event does not match.
+        """
         self.plugin.matches = MagicMock(return_value=False)
 
         room = MagicMock()
         event = MagicMock()
 
         async def run_test():
+            """
+            Asynchronously tests that handle_room_message returns False and does not send a Matrix message when the event does not match.
+            
+            Verifies that the matches method is called once with the event and send_matrix_message is not called.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -310,7 +354,9 @@ class TestNodesPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_handle_room_message_with_match(self, mock_connect):
-        """Test handle_room_message when event matches."""
+        """
+        Tests that handle_room_message sends a Matrix message and returns True when the event matches, verifying correct message content and parameters.
+        """
         mock_connect.return_value = self.mock_meshtastic_client
         self.plugin.matches = MagicMock(return_value=True)
 
@@ -319,6 +365,12 @@ class TestNodesPlugin(unittest.TestCase):
         event = MagicMock()
 
         async def run_test():
+            """
+            Asynchronously tests that a room message matching the plugin's criteria triggers a Matrix message with correct node information.
+            
+            Returns:
+                bool: True if the plugin handled the room message and sent a Matrix message.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
 
             self.assertTrue(result)

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay ping plugin.
+
+Tests the ping/pong functionality including:
+- Case matching utility function
+- Ping detection with various punctuation patterns
+- Direct message vs broadcast handling
+- Response delay and message routing
+- Matrix room message handling
+- Channel enablement checking
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.ping_plugin import Plugin, match_case
+
+
+class TestMatchCase(unittest.TestCase):
+    """Test cases for the match_case utility function."""
+
+    def test_match_case_all_lowercase(self):
+        """Test match_case with all lowercase source."""
+        result = match_case("ping", "pong")
+        self.assertEqual(result, "pong")
+
+    def test_match_case_all_uppercase(self):
+        """Test match_case with all uppercase source."""
+        result = match_case("PING", "pong")
+        self.assertEqual(result, "PONG")
+
+    def test_match_case_mixed_case(self):
+        """Test match_case with mixed case source."""
+        result = match_case("PiNg", "pong")
+        self.assertEqual(result, "PoNg")
+
+    def test_match_case_first_letter_uppercase(self):
+        """Test match_case with first letter uppercase."""
+        result = match_case("Ping", "pong")
+        self.assertEqual(result, "Pong")
+
+    def test_match_case_different_lengths(self):
+        """Test match_case with different length strings."""
+        result = match_case("Pi", "pong")
+        self.assertEqual(result, "Po")
+
+    def test_match_case_empty_strings(self):
+        """Test match_case with empty strings."""
+        result = match_case("", "pong")
+        self.assertEqual(result, "")
+
+
+class TestPingPlugin(unittest.TestCase):
+    """Test cases for the ping plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        
+        # Mock the is_channel_enabled method
+        self.plugin.is_channel_enabled = MagicMock(return_value=True)
+        
+        # Mock the get_response_delay method
+        self.plugin.get_response_delay = MagicMock(return_value=1.0)
+        
+        # Mock Matrix client methods
+        self.plugin.send_matrix_message = AsyncMock()
+
+    def test_plugin_name(self):
+        """Test that plugin name is correctly set."""
+        self.assertEqual(self.plugin.plugin_name, "ping")
+
+    def test_description_property(self):
+        """Test that description property returns expected string."""
+        description = self.plugin.description
+        self.assertEqual(description, "Check connectivity with the relay or respond to pings over the mesh")
+
+    def test_get_matrix_commands(self):
+        """Test that get_matrix_commands returns ping command."""
+        commands = self.plugin.get_matrix_commands()
+        self.assertEqual(commands, ["ping"])
+
+    def test_get_mesh_commands(self):
+        """Test that get_mesh_commands returns ping command."""
+        commands = self.plugin.get_mesh_commands()
+        self.assertEqual(commands, ["ping"])
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('asyncio.sleep')
+    def test_handle_meshtastic_message_simple_ping_broadcast(self, mock_sleep, mock_connect):
+        """Test handling simple ping message as broadcast."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        
+        packet = {
+            "decoded": {
+                "text": "ping"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295  # BROADCAST_NUM
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            
+            self.assertTrue(result)
+            
+            # Should check channel enablement for broadcast
+            self.plugin.is_channel_enabled.assert_called_once_with(0, is_direct_message=False)
+            
+            # Should wait for response delay
+            mock_sleep.assert_called_once_with(1.0)
+            
+            # Should send broadcast response
+            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            
+            # Should log processing
+            self.plugin.logger.info.assert_called_once()
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('asyncio.sleep')
+    def test_handle_meshtastic_message_ping_direct_message(self, mock_sleep, mock_connect):
+        """Test handling ping message as direct message."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        
+        packet = {
+            "decoded": {
+                "text": "ping"
+            },
+            "channel": 1,
+            "fromId": "!12345678",
+            "to": 123456789  # Direct to relay
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            
+            self.assertTrue(result)
+            
+            # Should check channel enablement for direct message
+            self.plugin.is_channel_enabled.assert_called_once_with(1, is_direct_message=True)
+            
+            # Should send direct message response
+            mock_client.sendText.assert_called_once_with(
+                text="pong", destinationId="!12345678"
+            )
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('asyncio.sleep')
+    def test_handle_meshtastic_message_ping_with_punctuation(self, mock_sleep, mock_connect):
+        """Test handling ping message with punctuation."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        
+        packet = {
+            "decoded": {
+                "text": "!ping!"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295  # BROADCAST_NUM
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            
+            self.assertTrue(result)
+            
+            # Should preserve punctuation in response
+            mock_client.sendText.assert_called_once_with(text="!pong!", channelIndex=0)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('asyncio.sleep')
+    def test_handle_meshtastic_message_ping_excessive_punctuation(self, mock_sleep, mock_connect):
+        """Test handling ping message with excessive punctuation."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        
+        packet = {
+            "decoded": {
+                "text": "!!!ping!!!"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295  # BROADCAST_NUM
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            
+            self.assertTrue(result)
+            
+            # Should use "Pong..." for excessive punctuation (>5 chars)
+            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('asyncio.sleep')
+    def test_handle_meshtastic_message_ping_case_matching(self, mock_sleep, mock_connect):
+        """Test handling ping message with case matching."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        
+        packet = {
+            "decoded": {
+                "text": "PING"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295  # BROADCAST_NUM
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            
+            self.assertTrue(result)
+            
+            # Should match case of original ping
+            mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_meshtastic_message_no_ping(self, mock_connect):
+        """Test handling message without ping."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        
+        packet = {
+            "decoded": {
+                "text": "Hello world"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            
+            self.assertFalse(result)
+            
+            # Should not send any message
+            mock_client.sendText.assert_not_called()
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_meshtastic_message_channel_disabled(self, mock_connect):
+        """Test handling ping when channel is disabled."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        
+        # Mock channel as disabled
+        self.plugin.is_channel_enabled = MagicMock(return_value=False)
+        
+        packet = {
+            "decoded": {
+                "text": "ping"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            
+            self.assertFalse(result)
+            
+            # Should not send any message
+            mock_client.sendText.assert_not_called()
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_no_match(self):
+        """Test handle_room_message when event doesn't match."""
+        self.plugin.matches = MagicMock(return_value=False)
+
+        room = MagicMock()
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_not_called()
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_ping_match(self):
+        """Test handle_room_message with ping command match."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "bot: !ping")
+
+            self.assertTrue(result)
+            self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_called_once_with("!test:matrix.org", "pong!")
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_no_decoded(self):
+        """Test handling packet without decoded field."""
+        packet = {
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+
+            self.assertFalse(result)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_no_text(self):
+        """Test handling packet without text field."""
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+
+            self.assertFalse(result)
+
+        import asyncio
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -31,27 +31,37 @@ class TestMatchCase(unittest.TestCase):
         self.assertEqual(result, "pong")
 
     def test_match_case_all_uppercase(self):
-        """Test match_case with all uppercase source."""
+        """
+        Tests that match_case converts the target string to all uppercase when the source string is all uppercase.
+        """
         result = match_case("PING", "pong")
         self.assertEqual(result, "PONG")
 
     def test_match_case_mixed_case(self):
-        """Test match_case with mixed case source."""
+        """
+        Test that match_case adjusts the target string to match a mixed case source string.
+        """
         result = match_case("PiNg", "pong")
         self.assertEqual(result, "PoNg")
 
     def test_match_case_first_letter_uppercase(self):
-        """Test match_case with first letter uppercase."""
+        """
+        Tests that match_case returns a target string with its first letter capitalized to match a source string with an initial uppercase letter.
+        """
         result = match_case("Ping", "pong")
         self.assertEqual(result, "Pong")
 
     def test_match_case_different_lengths(self):
-        """Test match_case with different length strings."""
+        """
+        Test that match_case returns a target string adjusted to the source's length and case when the strings have different lengths.
+        """
         result = match_case("Pi", "pong")
         self.assertEqual(result, "Po")
 
     def test_match_case_empty_strings(self):
-        """Test match_case with empty strings."""
+        """
+        Test that match_case returns an empty string when the source string is empty.
+        """
         result = match_case("", "pong")
         self.assertEqual(result, "")
 
@@ -60,7 +70,9 @@ class TestPingPlugin(unittest.TestCase):
     """Test cases for the ping plugin."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Initializes the Plugin instance and mocks its dependencies for isolated testing.
+        """
         self.plugin = Plugin()
         self.plugin.logger = MagicMock()
         
@@ -74,28 +86,40 @@ class TestPingPlugin(unittest.TestCase):
         self.plugin.send_matrix_message = AsyncMock()
 
     def test_plugin_name(self):
-        """Test that plugin name is correctly set."""
+        """
+        Verify that the plugin's name attribute is set to "ping".
+        """
         self.assertEqual(self.plugin.plugin_name, "ping")
 
     def test_description_property(self):
-        """Test that description property returns expected string."""
+        """
+        Verify that the plugin's description property returns the expected string.
+        """
         description = self.plugin.description
         self.assertEqual(description, "Check connectivity with the relay or respond to pings over the mesh")
 
     def test_get_matrix_commands(self):
-        """Test that get_matrix_commands returns ping command."""
+        """
+        Test that the plugin's get_matrix_commands method returns a list containing the "ping" command.
+        """
         commands = self.plugin.get_matrix_commands()
         self.assertEqual(commands, ["ping"])
 
     def test_get_mesh_commands(self):
-        """Test that get_mesh_commands returns ping command."""
+        """
+        Test that the plugin's get_mesh_commands method returns a list containing the "ping" command.
+        """
         commands = self.plugin.get_mesh_commands()
         self.assertEqual(commands, ["ping"])
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('asyncio.sleep')
     def test_handle_meshtastic_message_simple_ping_broadcast(self, mock_sleep, mock_connect):
-        """Test handling simple ping message as broadcast."""
+        """
+        Test that a simple "ping" broadcast message is correctly handled by the plugin.
+        
+        Verifies that the plugin checks channel enablement, waits for the configured response delay, sends a "pong" broadcast response on the same channel, logs the processing, and returns True to indicate the message was handled.
+        """
         # Mock meshtastic client
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -111,6 +135,11 @@ class TestPingPlugin(unittest.TestCase):
         }
         
         async def run_test():
+            """
+            Asynchronously tests that the plugin correctly handles a Meshtastic broadcast ping message.
+            
+            Verifies that the plugin checks channel enablement, waits for the configured response delay, sends a broadcast "pong" response, and logs the processing. Asserts that the message handling result is True.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -135,7 +164,11 @@ class TestPingPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('asyncio.sleep')
     def test_handle_meshtastic_message_ping_direct_message(self, mock_sleep, mock_connect):
-        """Test handling ping message as direct message."""
+        """
+        Test that the plugin correctly handles a "ping" message received as a direct Meshtastic message.
+        
+        Verifies that the plugin checks channel enablement for direct messages, sends a direct "pong" response to the sender, and returns True to indicate the message was handled.
+        """
         # Mock meshtastic client
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -151,6 +184,11 @@ class TestPingPlugin(unittest.TestCase):
         }
         
         async def run_test():
+            """
+            Asynchronously tests that the plugin correctly handles a direct "ping" Meshtastic message.
+            
+            Verifies that the plugin checks channel enablement for direct messages, sends a direct "pong" response to the sender, and returns True to indicate the message was handled.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -171,7 +209,11 @@ class TestPingPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('asyncio.sleep')
     def test_handle_meshtastic_message_ping_with_punctuation(self, mock_sleep, mock_connect):
-        """Test handling ping message with punctuation."""
+        """
+        Test that a Meshtastic "ping" message with punctuation receives a "pong" response preserving the original punctuation.
+        
+        Verifies that the plugin responds to a ping message containing punctuation (e.g., "!ping!") by sending a pong message with matching punctuation (e.g., "!pong!"), and confirms the response is sent on the correct channel.
+        """
         # Mock meshtastic client
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -187,6 +229,12 @@ class TestPingPlugin(unittest.TestCase):
         }
         
         async def run_test():
+            """
+            Runs an asynchronous test to verify that the plugin responds to a Meshtastic ping message with a correctly punctuated pong response.
+            
+            Returns:
+                bool: True if the plugin handled the message as expected.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -202,7 +250,11 @@ class TestPingPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('asyncio.sleep')
     def test_handle_meshtastic_message_ping_excessive_punctuation(self, mock_sleep, mock_connect):
-        """Test handling ping message with excessive punctuation."""
+        """
+        Test that the plugin responds with "Pong..." when handling a Meshtastic ping message containing excessive punctuation.
+        
+        Verifies that when a ping message with more than five punctuation characters is received, the plugin sends a "Pong..." response on the same channel.
+        """
         # Mock meshtastic client
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -218,6 +270,12 @@ class TestPingPlugin(unittest.TestCase):
         }
         
         async def run_test():
+            """
+            Runs an asynchronous test to verify that the plugin responds with "Pong..." when handling a ping message containing excessive punctuation.
+            
+            Returns:
+                bool: True if the plugin handled the message as expected.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -233,7 +291,9 @@ class TestPingPlugin(unittest.TestCase):
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     @patch('asyncio.sleep')
     def test_handle_meshtastic_message_ping_case_matching(self, mock_sleep, mock_connect):
-        """Test handling ping message with case matching."""
+        """
+        Tests that the plugin responds to a Meshtastic "PING" message with a "PONG" reply that matches the original message's case.
+        """
         # Mock meshtastic client
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -249,6 +309,12 @@ class TestPingPlugin(unittest.TestCase):
         }
         
         async def run_test():
+            """
+            Runs an asynchronous test to verify that the plugin responds to a Meshtastic "ping" message with a correctly cased "PONG" response.
+            
+            Returns:
+                bool: True if the plugin handled the message as expected.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -263,7 +329,11 @@ class TestPingPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_handle_meshtastic_message_no_ping(self, mock_connect):
-        """Test handling message without ping."""
+        """
+        Test that the plugin does not respond to Meshtastic messages that do not contain a ping command.
+        
+        Verifies that no message is sent and the handler returns False when the incoming message lacks a ping trigger.
+        """
         # Mock meshtastic client
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -279,6 +349,12 @@ class TestPingPlugin(unittest.TestCase):
         }
         
         async def run_test():
+            """
+            Asynchronously runs a test to verify that no response is sent when handling a Meshtastic message that should not trigger a reply.
+            
+            Returns:
+                None
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -293,7 +369,11 @@ class TestPingPlugin(unittest.TestCase):
 
     @patch('mmrelay.meshtastic_utils.connect_meshtastic')
     def test_handle_meshtastic_message_channel_disabled(self, mock_connect):
-        """Test handling ping when channel is disabled."""
+        """
+        Test that no response is sent when handling a ping message on a disabled channel.
+        
+        Verifies that the plugin does not respond to a "ping" Meshtastic message if the channel is disabled, and that no message is sent.
+        """
         # Mock meshtastic client
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -312,6 +392,12 @@ class TestPingPlugin(unittest.TestCase):
         }
         
         async def run_test():
+            """
+            Asynchronously runs a test to verify that no response is sent when handling a Meshtastic message that should not trigger a reply.
+            
+            Returns:
+                None
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -325,13 +411,21 @@ class TestPingPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_no_match(self):
-        """Test handle_room_message when event doesn't match."""
+        """
+        Test that handle_room_message returns False and does not send a message when the event does not match the plugin's criteria.
+        """
         self.plugin.matches = MagicMock(return_value=False)
 
         room = MagicMock()
         event = MagicMock()
 
         async def run_test():
+            """
+            Asynchronously tests that no Matrix message is sent when the event does not match the plugin's criteria.
+            
+            Returns:
+                bool: False, indicating the message was not handled.
+            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -341,7 +435,9 @@ class TestPingPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_ping_match(self):
-        """Test handle_room_message with ping command match."""
+        """
+        Tests that handle_room_message sends a "pong!" response when a ping command is detected in a Matrix room message.
+        """
         self.plugin.matches = MagicMock(return_value=True)
 
         room = MagicMock()
@@ -349,6 +445,11 @@ class TestPingPlugin(unittest.TestCase):
         event = MagicMock()
 
         async def run_test():
+            """
+            Runs an asynchronous test to verify that the plugin responds to a ping command in a Matrix room message.
+            
+            Asserts that the plugin correctly matches the event, sends a "pong!" response to the specified Matrix room, and returns True.
+            """
             result = await self.plugin.handle_room_message(room, event, "bot: !ping")
 
             self.assertTrue(result)
@@ -359,7 +460,11 @@ class TestPingPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_meshtastic_message_no_decoded(self):
-        """Test handling packet without decoded field."""
+        """
+        Test that the plugin does not handle a Meshtastic packet missing the "decoded" field.
+        
+        Verifies that when the "decoded" field is absent from the packet, the handler returns False, indicating the message was not processed.
+        """
         packet = {
             "channel": 0,
             "fromId": "!12345678",
@@ -367,6 +472,12 @@ class TestPingPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Runs an asynchronous test to verify that the plugin does not handle a given Meshtastic message.
+            
+            Returns:
+                bool: False, indicating the message was not handled by the plugin.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -377,7 +488,11 @@ class TestPingPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_meshtastic_message_no_text(self):
-        """Test handling packet without text field."""
+        """
+        Test that the plugin does not handle a Meshtastic packet missing the "text" field in the "decoded" section.
+        
+        Verifies that no response is sent and the handler returns False.
+        """
         packet = {
             "decoded": {
                 "portnum": "TEXT_MESSAGE_APP"
@@ -388,6 +503,12 @@ class TestPingPlugin(unittest.TestCase):
         }
 
         async def run_test():
+            """
+            Runs an asynchronous test to verify that the plugin does not handle a given Meshtastic message.
+            
+            Returns:
+                bool: False, indicating the message was not handled by the plugin.
+            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -103,16 +103,21 @@ class TestPluginLoader(unittest.TestCase):
         
         Verifies that `get_custom_plugin_dirs()` returns the expected list of custom plugin directories and that the directory creation function is called.
         """
+        import tempfile
+
         mock_get_base_dir.return_value = self.test_dir
-        mock_get_app_path.return_value = "/app"
 
-        dirs = get_custom_plugin_dirs()
+        # Use a temporary directory instead of hardcoded path
+        with tempfile.TemporaryDirectory() as temp_app_dir:
+            mock_get_app_path.return_value = temp_app_dir
 
-        expected_dirs = [
-            os.path.join(self.test_dir, "plugins", "custom"),
-            "/app/plugins/custom"
-        ]
-        self.assertEqual(dirs, expected_dirs)
+            dirs = get_custom_plugin_dirs()
+
+            expected_dirs = [
+                os.path.join(self.test_dir, "plugins", "custom"),
+                os.path.join(temp_app_dir, "plugins", "custom")
+            ]
+            self.assertEqual(dirs, expected_dirs)
         mock_makedirs.assert_called_once()
 
     @patch('mmrelay.plugin_loader.get_base_dir')
@@ -122,16 +127,21 @@ class TestPluginLoader(unittest.TestCase):
         """
         Test that the community plugin directory discovery function returns the correct directories and creates them if necessary.
         """
+        import tempfile
+
         mock_get_base_dir.return_value = self.test_dir
-        mock_get_app_path.return_value = "/app"
 
-        dirs = get_community_plugin_dirs()
+        # Use a temporary directory instead of hardcoded path
+        with tempfile.TemporaryDirectory() as temp_app_dir:
+            mock_get_app_path.return_value = temp_app_dir
 
-        expected_dirs = [
-            os.path.join(self.test_dir, "plugins", "community"),
-            "/app/plugins/community"
-        ]
-        self.assertEqual(dirs, expected_dirs)
+            dirs = get_community_plugin_dirs()
+
+            expected_dirs = [
+                os.path.join(self.test_dir, "plugins", "community"),
+                os.path.join(temp_app_dir, "plugins", "community")
+            ]
+            self.assertEqual(dirs, expected_dirs)
         mock_makedirs.assert_called_once()
 
     def test_load_plugins_from_directory_empty(self):

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -125,7 +125,7 @@ class TestPluginLoader(unittest.TestCase):
     @patch('os.makedirs')
     def test_get_community_plugin_dirs(self, mock_makedirs, mock_get_app_path, mock_get_base_dir):
         """
-        Test that the community plugin directory discovery function returns the correct directories and creates them if necessary.
+        Verify that the community plugin directory discovery function returns the expected directories and ensures their creation when needed.
         """
         import tempfile
 
@@ -378,9 +378,9 @@ class Plugin:
     @patch('mmrelay.plugins.health_plugin.Plugin')
     def test_load_plugins_start_error(self, mock_health_plugin):
         """
-        Test that plugin start() method exceptions are handled gracefully during loading.
+        Test that plugins raising exceptions in their start() method are still loaded.
         
-        Verifies that if a plugin's start() method raises an exception, the error is logged but the plugin is still included in the loaded plugin list.
+        Ensures that if a plugin's start() method raises an exception during loading, the error is handled gracefully and the plugin remains in the loaded plugin list.
         """
         # Create a plugin that raises an error on start
         mock_plugin = MockPlugin("error_plugin")
@@ -408,12 +408,16 @@ class TestGitRepositoryHandling(unittest.TestCase):
     """Test cases for Git repository handling functions."""
 
     def setUp(self):
-        """Set up test fixtures."""
+        """
+        Create a temporary directory and a subdirectory for plugins for use in test setup.
+        """
         self.test_dir = tempfile.mkdtemp()
         self.plugins_dir = os.path.join(self.test_dir, "plugins")
 
     def tearDown(self):
-        """Clean up test fixtures."""
+        """
+        Remove the temporary directory used for test fixtures after each test.
+        """
         import shutil
         shutil.rmtree(self.test_dir, ignore_errors=True)
 
@@ -422,7 +426,9 @@ class TestGitRepositoryHandling(unittest.TestCase):
     @patch('subprocess.check_output')
     @patch('os.path.isdir')
     def test_clone_or_update_repo_new_repo_tag(self, mock_isdir, mock_check_output, mock_check_call, mock_makedirs):
-        """Test cloning a new repository with a specific tag."""
+        """
+        Verify that cloning a new Git repository with a specific tag invokes the correct git commands and returns success.
+        """
         mock_isdir.return_value = False  # Repository doesn't exist
 
         repo_url = "https://github.com/user/test-repo.git"
@@ -443,7 +449,11 @@ class TestGitRepositoryHandling(unittest.TestCase):
     @patch('subprocess.check_output')
     @patch('os.path.isdir')
     def test_clone_or_update_repo_new_repo_branch(self, mock_isdir, mock_check_output, mock_check_call, mock_makedirs):
-        """Test cloning a new repository with a specific branch."""
+        """
+        Test that cloning a new Git repository with a specified branch triggers the correct git commands.
+        
+        Verifies that when the repository does not exist locally, `clone_or_update_repo` clones the repository using the provided branch name and returns True.
+        """
         mock_isdir.return_value = False  # Repository doesn't exist
 
         repo_url = "https://github.com/user/test-repo.git"
@@ -464,7 +474,11 @@ class TestGitRepositoryHandling(unittest.TestCase):
     @patch('subprocess.check_output')
     @patch('os.path.isdir')
     def test_clone_or_update_repo_existing_repo_same_branch(self, mock_isdir, mock_check_output, mock_check_call, mock_makedirs):
-        """Test updating an existing repository on the same branch."""
+        """
+        Test that updating an existing Git repository on the same branch triggers fetch and pull operations.
+        
+        Verifies that when the repository directory exists and the current branch matches the requested branch, the `clone_or_update_repo` function performs a fetch and pull, and returns True.
+        """
         mock_isdir.return_value = True  # Repository exists
         mock_check_output.return_value = "main\n"  # Current branch is main
 
@@ -485,7 +499,11 @@ class TestGitRepositoryHandling(unittest.TestCase):
     @patch('subprocess.check_output')
     @patch('os.path.isdir')
     def test_clone_or_update_repo_existing_repo_different_branch(self, mock_isdir, mock_check_output, mock_check_call, mock_makedirs):
-        """Test updating an existing repository to a different branch."""
+        """
+        Test that updating an existing Git repository to a different branch triggers the appropriate Git commands.
+        
+        Verifies that when the current branch differs from the target branch, the repository is updated by switching branches and pulling the latest changes.
+        """
         mock_isdir.return_value = True  # Repository exists
         mock_check_output.return_value = "main\n"  # Current branch is main
 

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay telemetry plugin.
+
+Tests the telemetry data collection and graphing functionality including:
+- Telemetry data processing and storage
+- Time period generation
+- Matrix command handling
+- Graph generation and image upload
+- Device metrics parsing
+"""
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.telemetry_plugin import Plugin
+
+
+class TestTelemetryPlugin(unittest.TestCase):
+    """Test cases for the telemetry plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        
+        # Mock database operations
+        self.plugin.get_node_data = MagicMock(return_value=[])
+        self.plugin.set_node_data = MagicMock()
+        self.plugin.get_data = MagicMock(return_value=[])
+        
+        # Mock Matrix client methods
+        self.plugin.send_matrix_message = AsyncMock()
+
+    def test_plugin_name(self):
+        """Test that plugin name is correctly set."""
+        self.assertEqual(self.plugin.plugin_name, "telemetry")
+
+    def test_max_data_rows_per_node(self):
+        """Test that max data rows per node is set correctly."""
+        self.assertEqual(self.plugin.max_data_rows_per_node, 50)
+
+    def test_commands(self):
+        """Test that commands returns expected list."""
+        commands = self.plugin.commands()
+        expected = ["batteryLevel", "voltage", "airUtilTx"]
+        self.assertEqual(commands, expected)
+
+    def test_description(self):
+        """Test that description returns expected string."""
+        description = self.plugin.description()
+        self.assertEqual(description, "Graph of avg Mesh telemetry value for last 12 hours")
+
+    def test_get_matrix_commands(self):
+        """Test that get_matrix_commands returns expected list."""
+        commands = self.plugin.get_matrix_commands()
+        expected = ["batteryLevel", "voltage", "airUtilTx"]
+        self.assertEqual(commands, expected)
+
+    def test_get_mesh_commands(self):
+        """Test that get_mesh_commands returns empty list."""
+        commands = self.plugin.get_mesh_commands()
+        self.assertEqual(commands, [])
+
+    def test_generate_timeperiods_default(self):
+        """Test time period generation with default 12 hours."""
+        with patch('mmrelay.plugins.telemetry_plugin.datetime') as mock_datetime:
+            # Mock current time
+            mock_now = datetime(2024, 1, 15, 12, 0, 0)
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+            
+            intervals = self.plugin._generate_timeperiods()
+            
+            # Should have 13 intervals (12 hours + 1 for end time)
+            self.assertEqual(len(intervals), 13)
+            
+            # First interval should be 12 hours ago
+            expected_start = mock_now - timedelta(hours=12)
+            self.assertEqual(intervals[0], expected_start)
+            
+            # Last interval should be current time
+            self.assertEqual(intervals[-1], mock_now)
+            
+            # Each interval should be 1 hour apart
+            for i in range(len(intervals) - 1):
+                diff = intervals[i + 1] - intervals[i]
+                self.assertEqual(diff, timedelta(hours=1))
+
+    def test_generate_timeperiods_custom_hours(self):
+        """Test time period generation with custom hours."""
+        with patch('mmrelay.plugins.telemetry_plugin.datetime') as mock_datetime:
+            mock_now = datetime(2024, 1, 15, 12, 0, 0)
+            mock_datetime.now.return_value = mock_now
+            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
+            
+            intervals = self.plugin._generate_timeperiods(hours=6)
+            
+            # Should have 7 intervals (6 hours + 1 for end time)
+            self.assertEqual(len(intervals), 7)
+            
+            # First interval should be 6 hours ago
+            expected_start = mock_now - timedelta(hours=6)
+            self.assertEqual(intervals[0], expected_start)
+
+    def test_handle_meshtastic_message_valid_telemetry(self):
+        """Test handling valid telemetry message."""
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "telemetry": {
+                    "time": 1642248000,  # Unix timestamp
+                    "deviceMetrics": {
+                        "batteryLevel": 85,
+                        "voltage": 4.2,
+                        "airUtilTx": 12.5
+                    }
+                }
+            }
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            
+            # Should return False (doesn't relay to Matrix)
+            self.assertFalse(result)
+            
+            # Should store telemetry data
+            self.plugin.set_node_data.assert_called_once()
+            call_args = self.plugin.set_node_data.call_args
+            self.assertEqual(call_args.kwargs['meshtastic_id'], "!12345678")
+            
+            # Check stored data structure
+            stored_data = call_args.kwargs['node_data']
+            self.assertEqual(len(stored_data), 1)
+            self.assertEqual(stored_data[0]['time'], 1642248000)
+            self.assertEqual(stored_data[0]['batteryLevel'], 85)
+            self.assertEqual(stored_data[0]['voltage'], 4.2)
+            self.assertEqual(stored_data[0]['airUtilTx'], 12.5)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_partial_metrics(self):
+        """Test handling telemetry message with partial device metrics."""
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "telemetry": {
+                    "time": 1642248000,
+                    "deviceMetrics": {
+                        "batteryLevel": 75
+                        # Missing voltage and airUtilTx
+                    }
+                }
+            }
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            
+            self.assertFalse(result)
+            
+            # Check stored data has default values for missing metrics
+            call_args = self.plugin.set_node_data.call_args
+            stored_data = call_args.kwargs['node_data']
+            self.assertEqual(stored_data[0]['batteryLevel'], 75)
+            self.assertEqual(stored_data[0]['voltage'], 0)  # Default value
+            self.assertEqual(stored_data[0]['airUtilTx'], 0)  # Default value
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_non_telemetry(self):
+        """Test handling non-telemetry message."""
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Hello world"
+            }
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            
+            # Should return None (not processed)
+            self.assertIsNone(result)
+            
+            # Should not store any data
+            self.plugin.set_node_data.assert_not_called()
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_missing_device_metrics(self):
+        """Test handling telemetry message without device metrics."""
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "telemetry": {
+                    "time": 1642248000
+                    # Missing deviceMetrics
+                }
+            }
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            
+            # Should return None (not processed)
+            self.assertIsNone(result)
+            
+            # Should not store any data
+            self.plugin.set_node_data.assert_not_called()
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.matrix_utils.bot_command')
+    def test_matches_with_valid_command(self, mock_bot_command):
+        """Test matches method with valid telemetry command."""
+        mock_bot_command.side_effect = lambda cmd, event: cmd == "batteryLevel"
+
+        event = MagicMock()
+        result = self.plugin.matches(event)
+
+        self.assertTrue(result)
+        # Should check all commands until it finds a match
+        self.assertTrue(mock_bot_command.called)
+
+    @patch('mmrelay.matrix_utils.bot_command')
+    def test_matches_with_no_command(self, mock_bot_command):
+        """Test matches method with no matching command."""
+        mock_bot_command.return_value = False
+
+        event = MagicMock()
+        result = self.plugin.matches(event)
+
+        self.assertFalse(result)
+        # Should check all commands
+        self.assertEqual(mock_bot_command.call_count, 3)
+
+    def test_handle_room_message_no_match(self):
+        """Test handle_room_message when event doesn't match."""
+        self.plugin.matches = MagicMock(return_value=False)
+
+        room = MagicMock()
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.matches.assert_called_once_with(event)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    def test_handle_room_message_invalid_regex(self):
+        """Test handle_room_message with invalid command format."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        room = MagicMock()
+        event = MagicMock()
+        full_message = "some invalid message format"
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+            self.assertFalse(result)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    @patch('mmrelay.matrix_utils.upload_image')
+    @patch('mmrelay.matrix_utils.send_room_image')
+    @patch('mmrelay.plugins.telemetry_plugin.plt.xticks')
+    @patch('mmrelay.plugins.telemetry_plugin.plt.subplots')
+    def test_handle_room_message_valid_command_no_node(self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect):
+        """Test handle_room_message with valid command but no specific node."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        # Mock matplotlib
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_subplots.return_value = (mock_fig, mock_ax)
+
+        # Mock canvas and image operations
+        mock_canvas = MagicMock()
+        mock_fig.canvas = mock_canvas
+
+        # Mock PIL Image operations
+        with patch('mmrelay.plugins.telemetry_plugin.Image') as mock_image_class:
+            mock_image = MagicMock()
+            mock_image.size = (800, 600)
+            mock_image.tobytes.return_value = b'fake_image_data'
+            mock_image_class.open.return_value = mock_image
+            mock_image_class.frombytes.return_value = mock_image
+
+            # Mock Matrix operations
+            mock_matrix_client = AsyncMock()
+            mock_connect.return_value = mock_matrix_client
+            mock_upload.return_value = {"content_uri": "mxc://example.com/image"}
+
+            room = MagicMock()
+            room.room_id = "!test:matrix.org"
+            event = MagicMock()
+            full_message = "bot: !batteryLevel"
+
+            async def run_test():
+                result = await self.plugin.handle_room_message(room, event, full_message)
+
+                self.assertTrue(result)
+
+                # Should create plot
+                mock_subplots.assert_called_once()
+                mock_ax.plot.assert_called_once()
+                mock_ax.set_title.assert_called_once()
+                mock_ax.set_xlabel.assert_called_once_with("Hour")
+                mock_ax.set_ylabel.assert_called_once_with("batteryLevel")
+
+                # Should upload and send image
+                mock_upload.assert_called_once()
+                mock_send_image.assert_called_once()
+
+            import asyncio
+            asyncio.run(run_test())
+
+    @patch('mmrelay.matrix_utils.connect_matrix')
+    @patch('mmrelay.matrix_utils.upload_image')
+    @patch('mmrelay.matrix_utils.send_room_image')
+    @patch('mmrelay.plugins.telemetry_plugin.plt.xticks')
+    @patch('mmrelay.plugins.telemetry_plugin.plt.subplots')
+    def test_handle_room_message_with_specific_node(self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect):
+        """Test handle_room_message with specific node parameter."""
+        self.plugin.matches = MagicMock(return_value=True)
+
+        # Mock node data
+        mock_node_data = [
+            {"time": 1642248000, "voltage": 4.2},
+            {"time": 1642251600, "voltage": 4.1}
+        ]
+        self.plugin.get_node_data.return_value = mock_node_data
+
+        # Mock matplotlib
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_subplots.return_value = (mock_fig, mock_ax)
+        mock_canvas = MagicMock()
+        mock_fig.canvas = mock_canvas
+
+        # Mock PIL Image operations
+        with patch('mmrelay.plugins.telemetry_plugin.Image') as mock_image_class:
+            mock_image = MagicMock()
+            mock_image.size = (800, 600)
+            mock_image.tobytes.return_value = b'fake_image_data'
+            mock_image_class.open.return_value = mock_image
+            mock_image_class.frombytes.return_value = mock_image
+
+            # Mock Matrix operations
+            mock_matrix_client = AsyncMock()
+            mock_connect.return_value = mock_matrix_client
+            mock_upload.return_value = {"content_uri": "mxc://example.com/image"}
+
+            room = MagicMock()
+            room.room_id = "!test:matrix.org"
+            event = MagicMock()
+            full_message = "bot: !voltage NodeABC"
+
+            async def run_test():
+                result = await self.plugin.handle_room_message(room, event, full_message)
+
+                self.assertTrue(result)
+
+                # Should get data for specific node
+                self.plugin.get_node_data.assert_called_with("NodeABC")
+
+                # Should set title with node name
+                title_call = mock_ax.set_title.call_args[0][0]
+                self.assertIn("NodeABC", title_call)
+                self.assertIn("voltage", title_call)
+
+            import asyncio
+            asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""
+Test suite for the MMRelay weather plugin.
+
+Tests the weather forecast functionality including:
+- Weather API integration with Open-Meteo
+- Temperature unit conversion (metric/imperial)
+- Weather code to text/emoji mapping
+- GPS location-based weather requests
+- Direct message vs broadcast handling
+- Channel enablement checking
+- Error handling for API failures
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.plugins.weather_plugin import Plugin
+
+
+class TestWeatherPlugin(unittest.TestCase):
+    """Test cases for the weather plugin."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        self.plugin.config = {"units": "metric"}
+        
+        # Mock the is_channel_enabled method
+        self.plugin.is_channel_enabled = MagicMock(return_value=True)
+        
+        # Mock the get_response_delay method
+        self.plugin.get_response_delay = MagicMock(return_value=1.0)
+        
+        # Sample weather API response
+        self.sample_weather_data = {
+            "current_weather": {
+                "temperature": 22.5,
+                "weathercode": 1,
+                "is_day": 1
+            },
+            "hourly": {
+                "temperature_2m": [22.5, 22.0, 21.5, 21.0, 20.5, 20.0, 19.5, 19.0],
+                "precipitation_probability": [10, 15, 20, 25, 30, 35, 40, 45],
+                "weathercode": [1, 2, 3, 61, 63, 65, 71, 73]
+            }
+        }
+
+    def test_plugin_name(self):
+        """Test that plugin name is correctly set."""
+        self.assertEqual(self.plugin.plugin_name, "weather")
+
+    def test_description_property(self):
+        """Test that description property returns expected string."""
+        description = self.plugin.description
+        self.assertEqual(description, "Show weather forecast for a radio node using GPS location")
+
+    def test_get_matrix_commands(self):
+        """Test that get_matrix_commands returns empty list."""
+        commands = self.plugin.get_matrix_commands()
+        self.assertEqual(commands, [])
+
+    def test_get_mesh_commands(self):
+        """Test that get_mesh_commands returns plugin name."""
+        commands = self.plugin.get_mesh_commands()
+        self.assertEqual(commands, ["weather"])
+
+    def test_handle_room_message_always_false(self):
+        """Test that handle_room_message always returns False."""
+        async def run_test():
+            result = await self.plugin.handle_room_message(None, None, "message")
+            self.assertFalse(result)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('requests.get')
+    def test_generate_forecast_metric_units(self, mock_get):
+        """Test weather forecast generation with metric units."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_weather_data
+        mock_get.return_value = mock_response
+        
+        self.plugin.config = {"units": "metric"}
+        
+        forecast = self.plugin.generate_forecast(40.7128, -74.0060)
+        
+        # Should make API request with correct parameters
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args[0][0]
+        self.assertIn("latitude=40.7128", call_args)
+        self.assertIn("longitude=-74.006", call_args)  # May be formatted without trailing zero
+        self.assertIn("api.open-meteo.com", call_args)
+        
+        # Should contain current weather
+        self.assertIn("Now: 🌤️ Mainly clear", forecast)
+        self.assertIn("22.5°C", forecast)
+        
+        # Should contain 2h forecast (weathercode 3 = Overcast)
+        self.assertIn("+2h: ☁️ Overcast", forecast)
+        self.assertIn("21.5°C", forecast)
+        self.assertIn("20%", forecast)
+
+        # Should contain 5h forecast (weathercode 65 = Heavy rain)
+        self.assertIn("+5h: 🌧️ Heavy rain", forecast)
+        self.assertIn("20.0°C", forecast)  # Index 5 in temperature array
+        self.assertIn("35%", forecast)
+
+    @patch('requests.get')
+    def test_generate_forecast_imperial_units(self, mock_get):
+        """Test weather forecast generation with imperial units."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_weather_data
+        mock_get.return_value = mock_response
+        
+        self.plugin.config = {"units": "imperial"}
+        
+        forecast = self.plugin.generate_forecast(40.7128, -74.0060)
+        
+        # Should convert temperatures to Fahrenheit
+        # 22.5°C = 72.5°F, 21.5°C = 70.7°F, 20.5°C = 68.9°F (but rounded to 68.0°F)
+        self.assertIn("72.5°F", forecast)
+        self.assertIn("70.7°F", forecast)
+        self.assertIn("68.0°F", forecast)  # Rounded value
+
+    @patch('requests.get')
+    def test_generate_forecast_night_weather_codes(self, mock_get):
+        """Test weather forecast generation with night weather codes."""
+        night_weather_data = self.sample_weather_data.copy()
+        night_weather_data["current_weather"]["is_day"] = 0  # Night time
+        
+        mock_response = MagicMock()
+        mock_response.json.return_value = night_weather_data
+        mock_get.return_value = mock_response
+        
+        forecast = self.plugin.generate_forecast(40.7128, -74.0060)
+        
+        # Should use night weather descriptions
+        self.assertIn("🌙🌤️ Mainly clear", forecast)
+
+    @patch('requests.get')
+    def test_generate_forecast_unknown_weather_code(self, mock_get):
+        """Test weather forecast generation with unknown weather code."""
+        unknown_weather_data = self.sample_weather_data.copy()
+        unknown_weather_data["current_weather"]["weathercode"] = 999  # Unknown code
+        
+        mock_response = MagicMock()
+        mock_response.json.return_value = unknown_weather_data
+        mock_get.return_value = mock_response
+        
+        forecast = self.plugin.generate_forecast(40.7128, -74.0060)
+        
+        # Should handle unknown weather codes gracefully
+        self.assertIn("❓ Unknown", forecast)
+
+    def test_handle_meshtastic_message_not_text_message(self):
+        """Test handling non-text message."""
+        packet = {
+            "decoded": {
+                "portnum": "TELEMETRY_APP",  # Not TEXT_MESSAGE_APP
+                "data": "some data"
+            }
+        }
+        
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+        
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_meshtastic_message_no_weather_command(self, mock_connect):
+        """Test handling text message without weather command."""
+        mock_client = MagicMock()
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "Hello world"  # No !weather command
+            },
+            "channel": 0
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_meshtastic_message_channel_not_enabled(self, mock_connect):
+        """Test handling message on disabled channel."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        self.plugin.is_channel_enabled = MagicMock(return_value=False)
+
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!weather"
+            },
+            "channel": 0
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+            self.plugin.is_channel_enabled.assert_called_once_with(0, is_direct_message=False)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('requests.get')
+    def test_handle_meshtastic_message_direct_message_with_location(self, mock_get, mock_connect):
+        """Test handling direct message with node location."""
+        # Mock weather API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_weather_data
+        mock_get.return_value = mock_response
+
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_client.nodes = {
+            "!12345678": {
+                "position": {
+                    "latitude": 40.7128,
+                    "longitude": -74.0060
+                }
+            }
+        }
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!weather"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 123456789  # Direct message to relay
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            self.assertTrue(result)
+
+            # Should send direct message response
+            mock_client.sendText.assert_called_once()
+            call_args = mock_client.sendText.call_args
+            self.assertEqual(call_args.kwargs['destinationId'], "!12345678")
+            self.assertIn("Now: 🌤️ Mainly clear", call_args.kwargs['text'])
+
+            # Should check if channel is enabled for direct message
+            self.plugin.is_channel_enabled.assert_called_once_with(0, is_direct_message=True)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_meshtastic_message_broadcast_no_location(self, mock_connect):
+        """Test handling broadcast message with no node location."""
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_client.nodes = {
+            "!12345678": {
+                # No position data
+            }
+        }
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!weather"
+            },
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": 4294967295  # BROADCAST_NUM
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            self.assertTrue(result)
+
+            # Should send broadcast response with error message
+            mock_client.sendText.assert_called_once()
+            call_args = mock_client.sendText.call_args
+            self.assertEqual(call_args.kwargs['channelIndex'], 0)
+            self.assertEqual(call_args.kwargs['text'], "Cannot determine location")
+
+            # Should check if channel is enabled for broadcast
+            self.plugin.is_channel_enabled.assert_called_once_with(0, is_direct_message=False)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    @patch('requests.get')
+    def test_handle_meshtastic_message_broadcast_with_location(self, mock_get, mock_connect):
+        """Test handling broadcast message with node location."""
+        # Mock weather API response
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_weather_data
+        mock_get.return_value = mock_response
+
+        # Mock meshtastic client
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_client.nodes = {
+            "!12345678": {
+                "position": {
+                    "latitude": 40.7128,
+                    "longitude": -74.0060
+                }
+            }
+        }
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!weather please"
+            },
+            "channel": 1,
+            "fromId": "!12345678",
+            "to": 4294967295  # BROADCAST_NUM
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            self.assertTrue(result)
+
+            # Should send broadcast response with weather data
+            mock_client.sendText.assert_called_once()
+            call_args = mock_client.sendText.call_args
+            self.assertEqual(call_args.kwargs['channelIndex'], 1)
+            self.assertIn("Now: 🌤️ Mainly clear", call_args.kwargs['text'])
+
+            # Should check if channel is enabled for broadcast
+            self.plugin.is_channel_enabled.assert_called_once_with(1, is_direct_message=False)
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_meshtastic_message_unknown_node(self, mock_connect):
+        """Test handling message from unknown node."""
+        # Mock meshtastic client with no nodes
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_client.nodes = {}  # No nodes
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!weather"
+            },
+            "channel": 0,
+            "fromId": "!unknown",
+            "to": 4294967295
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            # Should return True but not send any message (node not found)
+            self.assertTrue(result)
+            mock_client.sendText.assert_not_called()
+
+        import asyncio
+        asyncio.run(run_test())
+
+    @patch('mmrelay.meshtastic_utils.connect_meshtastic')
+    def test_handle_meshtastic_message_missing_channel(self, mock_connect):
+        """Test handling message with missing channel field."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {
+                "portnum": "TEXT_MESSAGE_APP",
+                "text": "!weather"
+            },
+            "fromId": "!12345678"
+            # No channel field - should default to 0
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            # Should use default channel 0
+            self.plugin.is_channel_enabled.assert_called_once_with(0, is_direct_message=False)
+
+        import asyncio
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request significantly enhances the project's testing infrastructure by introducing comprehensive unit tests across various modules and plugins. It also integrates Codecov for continuous code coverage analysis and addresses several code quality and correctness issues identified during the testing process, improving overall code reliability and maintainability.

### Highlights

* **Code Coverage Setup**: I've added a `codecov.yml` file to configure Codecov for automated code coverage reporting. This includes setting project and patch coverage targets (55% and 80% respectively) and defining component management rules for different parts of the codebase like plugins, configuration, core utilities, CLI, and tests.
* **Extensive Unit Test Additions**: I've introduced a significant number of new unit test files across various modules and plugins. This dramatically increases the test coverage for core functionalities such as the base plugin, CLI, config checker, drop plugin, health plugin, help plugin, map plugin, mesh relay plugin, nodes plugin, ping plugin, telemetry plugin, and weather plugin.
* **Test Infrastructure Improvements**: Existing test files (`tests/test_cli.py`, `tests/test_db_utils.py`, `tests/test_log_utils.py`, `tests/test_main.py`, `tests/test_matrix_utils.py`, `tests/test_plugin_loader.py`) have been updated. These updates include adding new test cases, improving the robustness of temporary file handling using `tempfile.TemporaryDirectory`, and enhancing the testing of CLI arguments, database paths, logging, and main application flow.
* **Addressing Review Feedback**: I've started addressing the feedback from `gemini-code-assist[bot]`. This includes refactoring test setups to use `patch` as a context manager for managing global state (as seen in `tests/test_matrix_utils.py`), removing redundant `import tempfile` statements within test methods (as noted in `tests/test_db_utils.py`), and correcting pluralization for time units in `tests/test_nodes_plugin.py`.

<details>
<summary><b>Changelog</b></summary>

* **codecov.yml**
    * Added Codecov configuration for coverage reporting, including project and patch targets, and component management rules.
* **tests/test_base_plugin.py**
    * Added new unit tests for `BasePlugin` functionality, covering initialization, configuration, database operations, channel enablement, and message handling.
* **tests/test_cli.py**
    * Added new test cases for CLI commands, including version retrieval, sample config generation, and command handling.
* **tests/test_config_checker.py**
    * Added new unit tests for configuration validation, covering various valid and invalid config scenarios.
* **tests/test_db_utils.py**
    * Modified `test_get_db_path_default` to use `tempfile.TemporaryDirectory` for robust temporary path handling (lines 115-122).
* **tests/test_drop_plugin.py**
    * Added new unit tests for the `drop_plugin`, covering message dropping, pickup, location handling, and data storage.
* **tests/test_health_plugin.py**
    * Added new unit tests for the `health_plugin`, focusing on mesh health statistics generation and Matrix message handling.
* **tests/test_help_plugin.py**
    * Added new unit tests for the `help_plugin`, covering general and specific help command handling and plugin discovery.
* **tests/test_log_utils.py**
    * Modified `test_get_logger_file_creation_error` to use `tempfile.TemporaryDirectory` for better test isolation (lines 380-385).
* **tests/test_main.py**
    * Added new test cases for `main` function edge cases, including database wipe, custom message delay, and Meshtastic client handling.
    * Added tests for `print_banner` and `run_main` functions.
* **tests/test_map_plugin.py**
    * Added new unit tests for the `map_plugin`, covering map generation, location anonymization, image upload, and command parsing.
* **tests/test_matrix_utils.py**
    * Added new test cases for various Matrix utility functions, including message retention, interaction settings, prefix formatting, text processing, and bot command detection.
* **tests/test_mesh_relay_plugin.py**
    * Added new unit tests for the `mesh_relay_plugin`, covering packet normalization, message relay, and channel mapping.
* **tests/test_meshtastic_utils.py**
    * Added new test cases for service detection, serial port existence, connection loss handling, and message processing edge cases.
* **tests/test_nodes_plugin.py**
    * Added new unit tests for the `nodes_plugin`, covering relative time calculation, node data formatting, and Matrix message handling.
* **tests/test_ping_plugin.py**
    * Added new unit tests for the `ping_plugin`, covering ping/pong logic, case matching, and direct message handling.
* **tests/test_plugin_loader.py**
    * Modified `get_custom_plugin_dirs` (lines 106-120) and `get_community_plugin_dirs` (lines 130-145) tests to use `tempfile.TemporaryDirectory` for better isolation.
    * Added new tests for Git repository cloning and updating functionality.
* **tests/test_telemetry_plugin.py**
    * Added new unit tests for the `telemetry_plugin`, covering data storage, time period generation, and graph plotting.
* **tests/test_weather_plugin.py**
    * Added new unit tests for the `weather_plugin`, covering weather API integration, unit conversion, and location-based requests.
</details>

<details>
<summary><b>Activity</b></summary>

* The `codecov[bot]` posted a coverage report, noting that all modified and coverable lines are covered by tests.
* `jeremiah-k` requested a Gemini review of the pull request.
* `jeremiah-k` requested a Gemini summary of the pull request.
* `gemini-code-assist[bot]` provided a review comment on `tests/test_matrix_utils.py` (line 319), suggesting the use of `patch` as a context manager for managing global state in tests, for improved robustness and clarity.
* `gemini-code-assist[bot]` provided a review comment on `tests/test_db_utils.py` (line 3), highlighting redundant `import tempfile` statements within methods and recommending adherence to PEP 8 by placing imports at the top of the file. This feedback applies to several new test files.
* `gemini-code-assist[bot]` provided a review comment on `tests/test_nodes_plugin.py` (line 117), pointing out incorrect pluralization for time units (e.g., '1 minutes ago' instead of '1 minute ago') and suggesting a conditional fix.
</details>