### PR TITLE
Add BasePlugin helper methods for DM detection

### DIFF
--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -256,6 +256,43 @@ class BasePlugin(ABC):
         """
         return self.response_delay
 
+    def get_my_node_id(self):
+        """Get the relay's Meshtastic node ID.
+
+        Returns:
+            int: The relay's node ID, or None if unavailable
+
+        This method provides access to the relay's own node ID without requiring
+        plugins to call connect_meshtastic() directly. Useful for determining
+        if messages are direct messages or for other node identification needs.
+        """
+        from mmrelay.meshtastic_utils import connect_meshtastic
+
+        meshtastic_client = connect_meshtastic()
+        if meshtastic_client and meshtastic_client.myInfo:
+            return meshtastic_client.myInfo.my_node_num
+        return None
+
+    def is_direct_message(self, packet):
+        """Check if a Meshtastic packet is a direct message to this relay.
+
+        Args:
+            packet (dict): Meshtastic packet data
+
+        Returns:
+            bool: True if the packet is a direct message to this relay, False otherwise
+
+        This method encapsulates the common pattern of checking if a message
+        is addressed directly to the relay node, eliminating the need for plugins
+        to call connect_meshtastic() directly for DM detection.
+        """
+        toId = packet.get("to")
+        if toId is None:
+            return False
+
+        myId = self.get_my_node_id()
+        return toId == myId if myId is not None else False
+
     def send_message(self, text: str, channel: int = 0, destination_id=None) -> bool:
         """
         Send a message to the Meshtastic network using the message queue.

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -469,6 +469,22 @@ class TestBasePlugin(unittest.TestCase):
         mock_connect_meshtastic.assert_called_once()
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_get_my_node_id_caches_on_success(self, mock_connect_meshtastic):
+        """Test that get_my_node_id caches the node ID on a successful call."""
+        plugin = MockPlugin()
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect_meshtastic.return_value = mock_client
+
+        # First call should connect and cache
+        self.assertEqual(plugin.get_my_node_id(), 123456789)
+        mock_connect_meshtastic.assert_called_once()
+
+        # Second call should use the cache
+        self.assertEqual(plugin.get_my_node_id(), 123456789)
+        mock_connect_meshtastic.assert_called_once()  # Still called only once
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     def test_get_my_node_id_no_client(self, mock_connect_meshtastic):
         """Test that get_my_node_id returns None when no client is available."""
         plugin = MockPlugin()

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -557,6 +557,40 @@ class TestBasePlugin(unittest.TestCase):
 
         self.assertFalse(result)
 
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_get_my_node_id_no_cache_no_client(self, mock_connect_meshtastic):
+        """Test that get_my_node_id returns None when no client and no cache."""
+        plugin = MockPlugin()
+
+        # Ensure no cache exists
+        if hasattr(plugin, '_my_node_id'):
+            delattr(plugin, '_my_node_id')
+
+        mock_connect_meshtastic.return_value = None
+
+        result = plugin.get_my_node_id()
+
+        self.assertIsNone(result)
+        mock_connect_meshtastic.assert_called_once()
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_is_direct_message_with_none_node_id(self, mock_connect_meshtastic):
+        """Test is_direct_message when get_my_node_id returns None."""
+        plugin = MockPlugin()
+
+        # Ensure no cache exists
+        if hasattr(plugin, '_my_node_id'):
+            delattr(plugin, '_my_node_id')
+
+        # Mock connect_meshtastic to return None (no client)
+        mock_connect_meshtastic.return_value = None
+
+        packet = {"to": 123456789}
+
+        result = plugin.is_direct_message(packet)
+
+        self.assertFalse(result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add get_my_node_id() method to get relay's node ID without direct connect_meshtastic() calls
- Add is_direct_message(packet) method to encapsulate DM detection logic
- Eliminates need for plugins to call connect_meshtastic() directly for DM detection
- Provides clean, consistent API for common plugin pattern
- Add comprehensive tests for both new methods with edge cases
- Maintains backward compatibility - existing plugins still work
