### PR TITLE
Update codecov components to include E2EE changes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -59,6 +59,7 @@ component_management:
       paths:
         - src/mmrelay/main.py
         - src/mmrelay/cli.py
+        - src/mmrelay/cli_utils.py
       statuses:
         - type: project
           target: 60%
@@ -89,8 +90,30 @@ component_management:
         - type: patch
           target: 30%
           threshold: 3%
+    - component_id: e2ee
+      name: E2EE (End-to-End Encryption)
+      paths:
+        - src/mmrelay/e2ee_utils.py
+      statuses:
+        - type: project
+          target: 60%
+          threshold: 3%
+        - type: patch
+          target: 60%
+          threshold: 3%
+    - component_id: constants
+      name: Constants
+      paths:
+        - src/mmrelay/constants/**
+      statuses:
+        - type: project
+          target: 80%
+          threshold: 2%
+        - type: patch
+          target: 80%
+          threshold: 2%
 
 comment:
-  layout: "header, diff, flags, components"
+  layout: header, diff, flags, components
   behavior: default
   require_changes: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -104,7 +104,7 @@ component_management:
     - component_id: constants
       name: Constants
       paths:
-        - src/mmrelay/constants/**
+        - src/mmrelay/constants/**/*.py
       statuses:
         - type: project
           target: 80%


### PR DESCRIPTION
- Add E2EE component covering src/mmrelay/e2ee_utils.py with 60% coverage targets
- Add Constants component covering src/mmrelay/constants/** with 80% coverage targets
- Extend CLI component to include src/mmrelay/cli_utils.py
- Preserve all existing patch coverage settings
- Ensure comprehensive coverage for all E2EE implementation work