### PR TITLE
Add links to v1.2 documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ MMRelay supports multiple deployment methods including Docker, pip installation,
 
 - [Installation Instructions](docs/INSTRUCTIONS.md) - Setup and configuration guide
 - [Docker Guide](docs/DOCKER.md) - Docker deployment methods
+- [What's New in v1.2](docs/WHATS_NEW_1.2.md) - New features and improvements
+- [E2EE Setup Guide](docs/E2EE.md) - Matrix End-to-End Encryption configuration
 
 ---
 


### PR DESCRIPTION
Add documentation links for new v1.2 features:

- Added 'What's New in v1.2' link to highlight new features and improvements
- Added 'E2EE Setup Guide' link for Matrix End-to-End Encryption configuration
- Links placed naturally in Documentation section alongside existing guides
- Maintains clean, organized documentation navigation