### PR TITLE
ci: remove triggers from ARMv7 workflows

### DIFF
--- a/.github/workflows/build-armv7-builder-image.yml
+++ b/.github/workflows/build-armv7-builder-image.yml
@@ -8,9 +8,6 @@ on:
         required: false
         default: true
         type: boolean
-  schedule:
-    # Rebuild monthly to keep dependencies fresh
-    - cron: 0 2 1 * *
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-pyz-armv7.yml
+++ b/.github/workflows/build-pyz-armv7.yml
@@ -2,8 +2,6 @@ name: Build PYZ (armv7)
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
Removed monthly scheduled rebuild from armv7-builder-image workflow and release trigger from pyz-armv7 workflow to reduce unnecessary builds. Both are experimental and are currently not building properly due to dependency issues.