### PR TITLE
chore: refactor message queue delay handling and update trunk linter versions

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.2
+      ref: v1.7.3
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -20,17 +20,17 @@ lint:
     - dotenv-linter@3.3.0
     - hadolint@2.14.0
     - taplo@0.10.0
-    - actionlint@1.7.7
+    - actionlint@1.7.8
     - bandit@1.8.6
     - black@25.9.0
-    - checkov@3.2.475
+    - checkov@3.2.484
     - git-diff-check
-    - isort@6.1.0
+    - isort@7.0.0
     - markdownlint@0.45.0
     - osv-scanner@2.2.3
     - prettier@3.6.2
-    - ruff@0.14.0
-    - trufflehog@3.90.8
+    - ruff@0.14.1
+    - trufflehog@3.90.11
     - yamllint@1.37.1
   # Remove map_plugin.py after staticmaps is updated and we're able to work on it again
   # For more info: https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/117

--- a/src/mmrelay/constants/network.py
+++ b/src/mmrelay/constants/network.py
@@ -24,6 +24,9 @@ DEFAULT_BACKOFF_TIME = 10  # seconds
 DEFAULT_RETRY_ATTEMPTS = 1
 INFINITE_RETRIES = 0  # 0 means infinite retries
 MINIMUM_MESSAGE_DELAY = 2.0  # Minimum delay for message queue fallback
+RECOMMENDED_MINIMUM_DELAY = (
+    2.1  # Recommended minimum delay (MINIMUM_MESSAGE_DELAY + 0.1)
+)
 
 # Matrix client timeouts
 MATRIX_EARLY_SYNC_TIMEOUT = 2000  # milliseconds

--- a/src/mmrelay/message_queue.py
+++ b/src/mmrelay/message_queue.py
@@ -21,9 +21,6 @@ from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
 from mmrelay.constants.queue import (
     DEFAULT_MESSAGE_DELAY,
     MAX_QUEUE_SIZE,
-)
-from mmrelay.constants.queue import MINIMUM_MESSAGE_DELAY as RECOMMENDED_MINIMUM_DELAY
-from mmrelay.constants.queue import (
     QUEUE_HIGH_WATER_MARK,
     QUEUE_MEDIUM_WATER_MARK,
 )
@@ -102,7 +99,7 @@ class MessageQueue:
             if message_delay <= MINIMUM_MESSAGE_DELAY:
                 logger.warning(
                     f"Message delay {message_delay}s is at or below {MINIMUM_MESSAGE_DELAY}s. "
-                    f"Due to rate limiting in the Meshtastic Firmware, {RECOMMENDED_MINIMUM_DELAY}s or higher is recommended. "
+                    f"Due to rate limiting in the Meshtastic Firmware, {MINIMUM_MESSAGE_DELAY + 0.1:.1f}s or higher is recommended. "
                     f"Messages may be dropped by the firmware if sent too frequently."
                 )
 

--- a/src/mmrelay/message_queue.py
+++ b/src/mmrelay/message_queue.py
@@ -17,7 +17,7 @@ from queue import Empty, Full, Queue
 from typing import Callable, Optional
 
 from mmrelay.constants.database import DEFAULT_MSGS_TO_KEEP
-from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
+from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY, RECOMMENDED_MINIMUM_DELAY
 from mmrelay.constants.queue import (
     DEFAULT_MESSAGE_DELAY,
     MAX_QUEUE_SIZE,
@@ -99,7 +99,7 @@ class MessageQueue:
             if message_delay <= MINIMUM_MESSAGE_DELAY:
                 logger.warning(
                     f"Message delay {message_delay}s is at or below {MINIMUM_MESSAGE_DELAY}s. "
-                    f"Due to rate limiting in the Meshtastic Firmware, {MINIMUM_MESSAGE_DELAY + 0.1:.1f}s or higher is recommended. "
+                    f"Due to rate limiting in the Meshtastic Firmware, {RECOMMENDED_MINIMUM_DELAY}s or higher is recommended. "
                     f"Messages may be dropped by the firmware if sent too frequently."
                 )
 

--- a/src/mmrelay/message_queue.py
+++ b/src/mmrelay/message_queue.py
@@ -17,6 +17,7 @@ from queue import Empty, Full, Queue
 from typing import Callable, Optional
 
 from mmrelay.constants.database import DEFAULT_MSGS_TO_KEEP
+from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
 from mmrelay.constants.queue import (
     DEFAULT_MESSAGE_DELAY,
     MAX_QUEUE_SIZE,
@@ -94,10 +95,10 @@ class MessageQueue:
             # Set the message delay as requested
             self._message_delay = message_delay
 
-            # Log warning if delay is at or below 2.0 seconds due to firmware rate limiting
-            if message_delay <= 2.0:
+            # Log warning if delay is at or below MINIMUM_MESSAGE_DELAY seconds due to firmware rate limiting
+            if message_delay <= MINIMUM_MESSAGE_DELAY:
                 logger.warning(
-                    f"Message delay {message_delay}s is at or below 2.0s. "
+                    f"Message delay {message_delay}s is at or below {MINIMUM_MESSAGE_DELAY}s. "
                     f"Due to rate limiting in the Meshtastic Firmware, 2.1s or higher is recommended. "
                     f"Messages may be dropped by the firmware if sent too frequently."
                 )
@@ -407,10 +408,10 @@ class MessageQueue:
                         )
                         await asyncio.sleep(wait_time)
                         continue
-                    elif time_since_last < 2.0:
-                        # Warn when messages are sent less than 2.0s apart
+                    elif time_since_last < MINIMUM_MESSAGE_DELAY:
+                        # Warn when messages are sent less than MINIMUM_MESSAGE_DELAY seconds apart
                         logger.warning(
-                            f"Messages sent {time_since_last:.1f}s apart, which is below 2.0s. "
+                            f"Messages sent {time_since_last:.1f}s apart, which is below {MINIMUM_MESSAGE_DELAY}s. "
                             f"Due to rate limiting in the Meshtastic Firmware, messages may be dropped."
                         )
 

--- a/src/mmrelay/message_queue.py
+++ b/src/mmrelay/message_queue.py
@@ -21,6 +21,9 @@ from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
 from mmrelay.constants.queue import (
     DEFAULT_MESSAGE_DELAY,
     MAX_QUEUE_SIZE,
+)
+from mmrelay.constants.queue import MINIMUM_MESSAGE_DELAY as RECOMMENDED_MINIMUM_DELAY
+from mmrelay.constants.queue import (
     QUEUE_HIGH_WATER_MARK,
     QUEUE_MEDIUM_WATER_MARK,
 )
@@ -99,7 +102,7 @@ class MessageQueue:
             if message_delay <= MINIMUM_MESSAGE_DELAY:
                 logger.warning(
                     f"Message delay {message_delay}s is at or below {MINIMUM_MESSAGE_DELAY}s. "
-                    f"Due to rate limiting in the Meshtastic Firmware, 2.1s or higher is recommended. "
+                    f"Due to rate limiting in the Meshtastic Firmware, {RECOMMENDED_MINIMUM_DELAY}s or higher is recommended. "
                     f"Messages may be dropped by the firmware if sent too frequently."
                 )
 

--- a/src/mmrelay/message_queue.py
+++ b/src/mmrelay/message_queue.py
@@ -411,7 +411,7 @@ class MessageQueue:
                     elif time_since_last < MINIMUM_MESSAGE_DELAY:
                         # Warn when messages are sent less than MINIMUM_MESSAGE_DELAY seconds apart
                         logger.warning(
-                            f"Messages sent {time_since_last:.1f}s apart, which is below {MINIMUM_MESSAGE_DELAY}s. "
+                            f"[Runtime] Messages sent {time_since_last:.1f}s apart, which is below {MINIMUM_MESSAGE_DELAY}s. "
                             f"Due to rate limiting in the Meshtastic Firmware, messages may be dropped."
                         )
 

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -10,11 +10,11 @@ from mmrelay.plugins.base_plugin import BasePlugin
 def match_case(source, target):
     """
     Apply the letter-case pattern of `source` onto `target`.
-    
+
     Parameters:
         source (str): String whose uppercase/lowercase pattern will be used.
         target (str): String whose characters will be converted to match `source`'s case.
-    
+
     Returns:
         str: A new string where each character from `target` is uppercased if the corresponding character in `source` is uppercase, otherwise lowercased. The result length is the minimum of the two input lengths.
     """

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -59,3 +59,15 @@ TEST_MESHTASTIC_CONFIG_WITH_PREFIX = {
     "prefix_format": TEST_PREFIX_FORMAT_DISPLAY5,
     "message_interactions": {"reactions": False, "replies": False},
 }
+
+# Test message delay values for message queue testing
+TEST_MESSAGE_DELAY_LOW = 0.1
+TEST_MESSAGE_DELAY_WARNING_THRESHOLD = 1.0
+TEST_MESSAGE_DELAY_NEGATIVE = -1.0
+TEST_MESSAGE_DELAY_NORMAL = 2.5
+TEST_MESSAGE_DELAY_HIGH = 3.0
+
+# Test warning message constants
+TEST_LOW_DELAY_WARNING_PREFIX = "Message delay {delay}s is at or below {minimum}s"
+TEST_RECOMMENDED_DELAY_SUFFIX = "2.1s or higher is recommended"
+TEST_RUNTIME_WARNING_PREFIX = "[Runtime] Messages sent"

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -66,8 +66,3 @@ TEST_MESSAGE_DELAY_WARNING_THRESHOLD = 1.0
 TEST_MESSAGE_DELAY_NEGATIVE = -1.0
 TEST_MESSAGE_DELAY_NORMAL = 2.5
 TEST_MESSAGE_DELAY_HIGH = 3.0
-
-# Test warning message constants
-TEST_LOW_DELAY_WARNING_PREFIX = "Message delay {delay}s is at or below {minimum}s"
-TEST_RECOMMENDED_DELAY_SUFFIX = "2.1s or higher is recommended"
-TEST_RUNTIME_WARNING_PREFIX = "[Runtime] Messages sent"

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -3482,10 +3482,10 @@ async def test_resolve_aliases_in_mapping_list():
     async def mock_resolver(alias):
         """
         Resolve a room alias to a room ID for testing.
-        
+
         Parameters:
             alias (str): Room alias to resolve.
-        
+
         Returns:
             A room ID string for known aliases (`#room1:matrix.org` -> `!resolved1:matrix.org`, `#room3:matrix.org` -> `!resolved3:matrix.org`); otherwise returns the original input string.
         """
@@ -3514,10 +3514,10 @@ async def test_resolve_aliases_in_mapping_dict():
     async def mock_resolver(alias):
         """
         Resolve a Matrix room alias to a room ID (test helper).
-        
+
         Parameters:
             alias (str): A Matrix room alias to resolve, e.g. "#alias:matrix.org".
-        
+
         Returns:
             str: The resolved room ID for known aliases, otherwise the original `alias`.
         """

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -3513,13 +3513,13 @@ async def test_resolve_aliases_in_mapping_dict():
 
     async def mock_resolver(alias):
         """
-        Resolve a Matrix room alias to a room ID (test helper).
-
+        Resolve a Matrix room alias to a room ID for tests.
+        
         Parameters:
-            alias (str): A Matrix room alias to resolve, e.g. "#alias:matrix.org".
-
+            alias (str): Matrix room alias to resolve (e.g. "#alias:matrix.org").
+        
         Returns:
-            str: The resolved room ID for known aliases, otherwise the original `alias`.
+            str: Resolved room ID for known aliases, otherwise returns the original `alias`.
         """
         if alias == "#alias1:matrix.org":
             return "!resolved1:matrix.org"

--- a/tests/test_message_queue_edge_cases.py
+++ b/tests/test_message_queue_edge_cases.py
@@ -23,6 +23,7 @@ import pytest
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
 from mmrelay.message_queue import MessageQueue, get_message_queue, queue_message
 from tests.constants import (
     TEST_MESSAGE_DELAY_HIGH,
@@ -162,9 +163,6 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         """
         Verify that starting the queue with a message delay at or below MINIMUM_MESSAGE_DELAY seconds logs a warning but accepts the value.
         """
-        # Import the constant for consistent testing
-        from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
-
         # Test with delay below MINIMUM_MESSAGE_DELAY - should log warning but accept value
         self.queue.start(message_delay=TEST_MESSAGE_DELAY_WARNING_THRESHOLD)
         status = self.queue.get_status()
@@ -503,8 +501,6 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         """
         Verify that runtime warnings are logged when messages are sent less than MINIMUM_MESSAGE_DELAY seconds apart.
         """
-        # Import the constant for consistent testing
-        from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
 
         async def async_test():
             """

--- a/tests/test_message_queue_edge_cases.py
+++ b/tests/test_message_queue_edge_cases.py
@@ -25,14 +25,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mmrelay.message_queue import MessageQueue, get_message_queue, queue_message
 from tests.constants import (
-    TEST_LOW_DELAY_WARNING_PREFIX,
     TEST_MESSAGE_DELAY_HIGH,
     TEST_MESSAGE_DELAY_LOW,
     TEST_MESSAGE_DELAY_NEGATIVE,
     TEST_MESSAGE_DELAY_NORMAL,
     TEST_MESSAGE_DELAY_WARNING_THRESHOLD,
-    TEST_RECOMMENDED_DELAY_SUFFIX,
-    TEST_RUNTIME_WARNING_PREFIX,
 )
 
 
@@ -176,11 +173,14 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         )  # Should accept the value
         mock_logger.warning.assert_called_once()
         warning_call = mock_logger.warning.call_args[0][0]
-        expected_warning = TEST_LOW_DELAY_WARNING_PREFIX.format(
-            delay=TEST_MESSAGE_DELAY_WARNING_THRESHOLD, minimum=MINIMUM_MESSAGE_DELAY
+        # Test against real warning message patterns from the code
+        expected_warning_part = f"Message delay {TEST_MESSAGE_DELAY_WARNING_THRESHOLD}s is at or below {MINIMUM_MESSAGE_DELAY}s"
+        self.assertIn(expected_warning_part, warning_call)
+        # Test the dynamic recommendation: MINIMUM_MESSAGE_DELAY + 0.1
+        expected_recommendation = (
+            f"{MINIMUM_MESSAGE_DELAY + 0.1:.1f}s or higher is recommended"
         )
-        self.assertIn(expected_warning, warning_call)
-        self.assertIn(TEST_RECOMMENDED_DELAY_SUFFIX, warning_call)
+        self.assertIn(expected_recommendation, warning_call)
 
         # Test with negative delay - should log warning but accept value
         self.queue.stop()
@@ -193,10 +193,9 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         )  # Should accept the value
         mock_logger.warning.assert_called_once()
         warning_call = mock_logger.warning.call_args[0][0]
-        expected_warning = TEST_LOW_DELAY_WARNING_PREFIX.format(
-            delay=TEST_MESSAGE_DELAY_NEGATIVE, minimum=MINIMUM_MESSAGE_DELAY
-        )
-        self.assertIn(expected_warning, warning_call)
+        # Test against real warning message patterns from the code
+        expected_warning_part = f"Message delay {TEST_MESSAGE_DELAY_NEGATIVE}s is at or below {MINIMUM_MESSAGE_DELAY}s"
+        self.assertIn(expected_warning_part, warning_call)
 
     def test_double_start(self):
         """
@@ -553,7 +552,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
             # Check that we got the expected runtime warning
             warning_messages = "\n".join(cm.output)
-            self.assertIn(TEST_RUNTIME_WARNING_PREFIX, warning_messages)
+            self.assertIn("[Runtime] Messages sent", warning_messages)
             self.assertIn(f"below {MINIMUM_MESSAGE_DELAY}s", warning_messages)
             self.assertIn("may be dropped", warning_messages)
 

--- a/tests/test_message_queue_edge_cases.py
+++ b/tests/test_message_queue_edge_cases.py
@@ -23,7 +23,7 @@ import pytest
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
+from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY, RECOMMENDED_MINIMUM_DELAY
 from mmrelay.message_queue import MessageQueue, get_message_queue, queue_message
 from tests.constants import (
     TEST_MESSAGE_DELAY_HIGH,
@@ -174,9 +174,9 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         # Test against real warning message patterns from the code
         expected_warning_part = f"Message delay {TEST_MESSAGE_DELAY_WARNING_THRESHOLD}s is at or below {MINIMUM_MESSAGE_DELAY}s"
         self.assertIn(expected_warning_part, warning_call)
-        # Test the dynamic recommendation: MINIMUM_MESSAGE_DELAY + 0.1
+        # Test the recommendation using the constant
         expected_recommendation = (
-            f"{MINIMUM_MESSAGE_DELAY + 0.1:.1f}s or higher is recommended"
+            f"{RECOMMENDED_MINIMUM_DELAY}s or higher is recommended"
         )
         self.assertIn(expected_recommendation, warning_call)
 
@@ -527,7 +527,8 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
             def mock_send(text):
                 calls.append(text)
-                return {"id": len(calls)}
+                # Return an object with an 'id' attribute to match application expectations
+                return type("obj", (object,), {"id": len(calls)})()
 
             # Use assertLogs to capture log messages as recommended in testing guide
             # Use the correct logger name "MessageQueue" as defined in message_queue.py

--- a/tests/test_message_queue_edge_cases.py
+++ b/tests/test_message_queue_edge_cases.py
@@ -77,16 +77,16 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
     def test_queue_overflow_handling(self):
         """
-        Test that the message queue enforces its maximum capacity and rejects additional messages when full.
-
-        Fills the queue to its defined maximum size, verifies that enqueueing beyond this limit fails, and asserts the queue size does not exceed the allowed maximum.
+        Verify that the MessageQueue enforces its maximum capacity and rejects additional enqueues when full.
+        
+        Starts the queue, fills it up to the configured maximum, attempts one additional enqueue which must be rejected, and asserts the final queue size is greater than zero and does not exceed MAX_QUEUE_SIZE.
         """
 
         async def async_test():
             """
-            Asynchronously verifies that the message queue enforces its maximum capacity by filling it to the defined limit and confirming that additional enqueue attempts are rejected.
-
-            Ensures the queue does not exceed its maximum size and that overflow messages are not accepted.
+            Verify the message queue enforces its maximum capacity by filling it to its limit and asserting additional enqueue attempts are rejected.
+            
+            Starts the queue, fills it up to the configured MAX_QUEUE_SIZE (or the actual limit reached), then attempts one more enqueue which must be rejected. Asserts that at least one message was accepted and that the final queue size does not exceed the configured maximum.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
 
@@ -221,9 +221,9 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     @patch("mmrelay.message_queue.logger")
     def test_processor_import_error_handling(self, mock_logger):
         """
-        Verify the message queue handles ImportError raised during message processing without raising unhandled exceptions.
-
-        Starts the queue, causes MessageQueue._should_send_message to raise ImportError while a message is enqueued, and asserts the queue remains in a stable boolean running state after processing.
+        Ensure MessageQueue handles an ImportError raised during message processing without crashing.
+        
+        Starts the queue, patches MessageQueue._should_send_message to raise ImportError while enqueuing a message, waits for processing, asserts the queue remains in a stable running state (boolean), and verifies the logger recorded an exception or error.
         """
 
         async def async_test():
@@ -277,9 +277,9 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
         async def async_test():
             """
-            Asynchronously tests that the message queue processes messages whose send function returns an object lacking the expected 'id' attribute.
-
-            Verifies that enqueueing such a message succeeds and the queue handles the missing attribute without failure.
+            Verify the queue accepts and processes a message when the send function returns an object missing the `id` attribute.
+            
+            Asserts that enqueueing the message succeeds and allows the processor to handle the send result without raising an exception.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
             self.queue.ensure_processor_started()
@@ -322,12 +322,17 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
     def test_processor_task_cancellation(self):
         """
-        Verifies that the message processor task can be cancelled and properly transitions to a done state.
+        Verify that the message queue's processor task can be cancelled and transitions to a completed state.
+        
+        Starts the queue, ensures the processor is running, cancels the internal `_processor_task`, awaits its completion (handling `asyncio.CancelledError`), and asserts the task reports as done.
         """
 
         async def async_test():
             """
-            Cancels the message queue's processor task and verifies it is properly terminated.
+            Cancel the MessageQueue processor task and assert it terminates.
+            
+            Starts the queue, ensures the internal processor task is running, cancels that task,
+            awaits its completion (ignoring CancelledError), and asserts the task is done.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
             self.queue.ensure_processor_started()
@@ -377,7 +382,9 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
         async def async_test():
             """
-            Tests rate limiting behavior of the message queue by enqueueing messages with controlled timing and verifying that messages are processed according to the specified delay.
+            Verify that MessageQueue enforces the configured inter-send delay when messages are enqueued with controlled timing.
+            
+            Starts the queue with TEST_MESSAGE_DELAY_LOW, mocks wall-clock time to create two enqueue events separated by less than the configured delay, and asserts both enqueues succeed while processing occurs in a manner consistent with rate limiting.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
             self.queue.ensure_processor_started()
@@ -428,7 +435,9 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
     def test_concurrent_enqueue_operations(self):
         """
-        Verifies that the message queue can handle concurrent enqueue operations from multiple threads without errors.
+        Start the queue, spawn multiple threads that enqueue messages concurrently, and verify enqueues succeed.
+        
+        Starts the MessageQueue with a low delay, launches five threads that each enqueue ten messages labeled by thread and index, waits for all threads to finish, and asserts that at least one enqueue operation returned success.
         """
         self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
 
@@ -474,7 +483,9 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
         async def async_test():
             """
-            Asynchronously tests that a message with None mapping info can be enqueued and processed successfully.
+            Verify a message with `mapping_info` set to None can be enqueued and processed by the queue.
+            
+            The test starts the queue and its processor, enqueues a message with `mapping_info=None`, asserts the enqueue returned `True`, and waits briefly for processing.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
             self.queue.ensure_processor_started()
@@ -499,12 +510,16 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
 
     def test_runtime_warning_for_fast_messages(self):
         """
-        Verify that runtime warnings are logged when messages are sent less than MINIMUM_MESSAGE_DELAY seconds apart.
+        Assert that a runtime warning is emitted when two messages are enqueued with inter-send time below MINIMUM_MESSAGE_DELAY.
+        
+        Sets up a meshtastic client mock, starts the MessageQueue with a sub-minimum message_delay, enqueues two messages back-to-back, captures WARNING logs for the MessageQueue logger, and verifies the logs include indications that messages were sent below MINIMUM_MESSAGE_DELAY and "may be dropped".
         """
 
         async def async_test():
             """
-            Asynchronously tests that warnings are logged when messages are sent too quickly.
+            Verify that a WARNING is logged when messages are enqueued faster than the configured minimum inter-send delay.
+            
+            Sets up a mock meshtastic client, starts the MessageQueue with a message_delay below MINIMUM_MESSAGE_DELAY, enqueues two messages in quick succession, drains the queue, and asserts that the captured WARNING logs include runtime-warning text indicating messages were sent below the minimum delay and may be dropped.
             """
             # Set up mock meshtastic client to allow message sending
             from unittest.mock import MagicMock
@@ -526,6 +541,15 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
             calls = []
 
             def mock_send(text):
+                """
+                Record the provided text and return a simple object containing a sequential `id`.
+                
+                Parameters:
+                    text (str): The message text to record.
+                
+                Returns:
+                    obj: An object with an `id` attribute equal to the number of times this function has been called (1-based).
+                """
                 calls.append(text)
                 # Return an object with an 'id' attribute to match application expectations
                 return type("obj", (object,), {"id": len(calls)})()


### PR DESCRIPTION
Refactor message queue to remove minimum delay enforcement, accepting any delay value while logging warnings for delays at or below 2.0s due to Meshtastic firmware rate limiting. Add runtime warnings when messages are sent less than 2.0s apart. Update corresponding tests to reflect new behavior and add test for runtime warnings.

Update various linter and tool versions in .trunk/trunk.yaml including trunk, actionlint, checkov, isort, ruff, and trufflehog. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit user warnings when configured message delays are at or below 2.0s to indicate possible firmware rate-limiting instead of forcing a minimum delay
  * Log runtime warnings when messages are enqueued/sent in rapid succession to highlight potential dropped messages

* **Chores**
  * Updated linting and analysis tools and related plugins to newer versions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->