### PR TITLE
fix: reduce plugin warning spam and drop Python 3.9 support (EOL)

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,7 +23,7 @@ lint:
     - actionlint@1.7.8
     - bandit@1.8.6
     - black@25.9.0
-    - checkov@3.2.484
+    - checkov@3.2.485
     - git-diff-check
     - isort@7.0.0
     - markdownlint@0.45.0

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -63,7 +63,7 @@ That's it! MMRelay will automatically encrypt messages for encrypted rooms and d
 
 ## Requirements
 
-- **Python 3.9 or higher**
+- **Python 3.10 or higher**
 - **Linux or macOS** (E2EE is not supported on Windows due to library limitations)
 - **MMRelay v1.2+** with E2EE support: `pipx install 'mmrelay[e2e]'`
 

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # MMRelay Instructions
 
-MMRelay works on Linux, macOS, and Windows and requires Python 3.9+.
+MMRelay works on Linux, macOS, and Windows and requires Python 3.10+.
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@bdfe2232cb4ac44b8decd502162502d1398a088d
+meshtastic>=2.7.3
 Pillow==11.3.0
 matrix-nio==0.25.2
 matplotlib==3.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-meshtastic>=2.7.3
+meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@bdfe2232cb4ac44b8decd502162502d1398a088d
 Pillow==11.3.0
 matrix-nio==0.25.2
 matplotlib==3.10.1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     python_requires=">=3.10",
     install_requires=[
-        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@bdfe2232cb4ac44b8decd502162502d1398a088d",
+        "meshtastic>=2.7.3",
         "Pillow==11.3.0",
         "matrix-nio==0.25.2",
         "matplotlib==3.10.1",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -42,7 +41,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Topic :: Communications",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@bdfe2232cb4ac44b8decd502162502d1398a088d",
         "Pillow==11.3.0",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     python_requires=">=3.9",
     install_requires=[
-        "meshtastic>=2.7.3",
+        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@bdfe2232cb4ac44b8decd502162502d1398a088d",
         "Pillow==11.3.0",
         "matrix-nio==0.25.2",
         "matplotlib==3.10.1",

--- a/src/mmrelay/message_queue.py
+++ b/src/mmrelay/message_queue.py
@@ -82,9 +82,9 @@ class MessageQueue:
     def start(self, message_delay: float = DEFAULT_MESSAGE_DELAY):
         """
         Start the message queue processor and configure the inter-message delay.
-        
+
         Sets the queue to running, applies the provided delay (used as-is), ensures a single-worker ThreadPoolExecutor exists for send operations, and schedules the background processor when an asyncio event loop is available. If the provided delay is at or below MINIMUM_MESSAGE_DELAY, a warning is logged indicating that the Meshtastic firmware may drop messages sent too frequently.
-        
+
         Parameters:
             message_delay (float): Requested delay between consecutive sends, in seconds; the value is applied as provided and may trigger a warning if it is at or below MINIMUM_MESSAGE_DELAY.
         """
@@ -359,7 +359,7 @@ class MessageQueue:
     async def _process_queue(self):
         """
         Continuously processes queued messages in FIFO order, sending each when the connection is ready and the configured inter-message delay has elapsed.
-        
+
         Pulls queued QueuedMessage items, enforces connection/readiness checks and the configured inter-message delay, updates last-send timestamps after a send, and persists message mapping information when provided and the send result exposes an `id`. The coroutine runs until the queue is stopped or the task is cancelled; cancellation may drop an in-flight message (which will be logged).
         """
         logger.debug("Message queue processor started")

--- a/src/mmrelay/message_queue.py
+++ b/src/mmrelay/message_queue.py
@@ -82,9 +82,9 @@ class MessageQueue:
     def start(self, message_delay: float = DEFAULT_MESSAGE_DELAY):
         """
         Start the message queue processor and set the inter-message delay.
-        
+
         Activate the queue, apply the provided inter-message delay, ensure a single-worker executor exists for send operations, and schedule the background processor when an asyncio event loop is available. Logs a warning if the provided delay is less than or equal to MINIMUM_MESSAGE_DELAY.
-        
+
         Parameters:
             message_delay (float): Delay between consecutive sends in seconds; applied as provided and may trigger a warning if <= MINIMUM_MESSAGE_DELAY.
         """
@@ -359,7 +359,7 @@ class MessageQueue:
     async def _process_queue(self):
         """
         Process queued messages in FIFO order, sending each when the connection is ready and the configured inter-message delay has elapsed.
-        
+
         Runs until the queue is stopped or the task is cancelled. For each message, enforces connection/readiness checks and the configured inter-message delay, updates last-send timestamps after a successful send, and persists message mapping information when provided and the send result exposes an `id`. Cancellation may drop an in-flight message.
         """
         logger.debug("Message queue processor started")
@@ -628,7 +628,7 @@ def queue_message(
 def get_queue_status() -> dict:
     """
     Get a snapshot of the global message queue's current status.
-    
+
     Returns:
         status (dict): Dictionary containing status fields including:
             - running: whether the processor is active

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -72,15 +72,18 @@ class BasePlugin(ABC):
 
     def __init__(self, plugin_name=None) -> None:
         """
-        Initialize the plugin instance, setting its name, logger, configuration, mapped channels, and response delay.
-
+        Initialize plugin state including its name, logger, configuration, mapped channels, and response delay.
+        
         Parameters:
-            plugin_name (str, optional): Overrides the plugin's name. If not provided, uses the class-level `plugin_name` attribute.
-
+            plugin_name (str, optional): Overrides the class-level plugin_name attribute when provided.
+        
         Raises:
-            ValueError: If the plugin name is not set via parameter or class attribute.
-
-        Loads plugin-specific configuration from the global config, validates assigned channels, and determines the response delay, enforcing a minimum of 2.1 seconds. Logs a warning if deprecated configuration options are used or if channels are not mapped.
+            ValueError: If no plugin name is available from the parameter or the class attribute.
+        
+        Notes:
+            - Loads plugin configuration from the global `config` under "plugins", "community-plugins", or "custom-plugins".
+            - Maps Matrix rooms to Meshtastic channels and validates the plugin's configured channels, logging a warning for unmapped channels.
+            - Reads `meshtastic.message_delay` (or the deprecated `meshtastic.plugin_response_delay`) and enforces a minimum delay of MINIMUM_MESSAGE_DELAY; deprecated option emits a one-time warning and delays below the minimum are clamped.
         """
         # Allow plugin_name to be passed as a parameter for simpler initialization
         # This maintains backward compatibility while providing a cleaner API

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -176,7 +176,7 @@ class BasePlugin(ABC):
                 self.response_delay = delay
                 # Enforce minimum delay above firmware limit to prevent message dropping
                 if self.response_delay < MINIMUM_MESSAGE_DELAY:
-                    self.logger.warning(
+                    self.logger.debug(
                         f"{delay_key} of {self.response_delay}s is below minimum of {MINIMUM_MESSAGE_DELAY}s (above firmware limit). Using {MINIMUM_MESSAGE_DELAY}s."
                     )
                     self.response_delay = MINIMUM_MESSAGE_DELAY

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -180,8 +180,8 @@ class BasePlugin(ABC):
                 # Enforce minimum delay above firmware limit to prevent message dropping
                 if self.response_delay < MINIMUM_MESSAGE_DELAY:
                     # Only warn once per unique delay value to prevent spam
-                    warning_message = f"{delay_key} of {self.response_delay}s is below minimum of {MINIMUM_MESSAGE_DELAY}s (above firmware limit). Using {MINIMUM_MESSAGE_DELAY}s."
                     global _warned_delay_values
+                    warning_message = f"{delay_key} of {self.response_delay}s is below minimum of {MINIMUM_MESSAGE_DELAY}s (above firmware limit). Using {MINIMUM_MESSAGE_DELAY}s."
                     if self.response_delay not in _warned_delay_values:
                         self.logger.warning(warning_message)
                         _warned_delay_values.add(self.response_delay)

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -184,7 +184,7 @@ class BasePlugin(ABC):
                 # Enforce minimum delay above firmware limit to prevent message dropping
                 if self.response_delay < MINIMUM_MESSAGE_DELAY:
                     # Only warn once per unique delay value to prevent spam
-                    global _warned_delay_values, _plugins_low_delay_warned
+                    global _warned_delay_values, _plugins_low_delay_warned  # Track warning status across plugin instances
                     warning_message = f"{delay_key} of {self.response_delay}s is below minimum of {MINIMUM_MESSAGE_DELAY}s (above firmware limit). Using {MINIMUM_MESSAGE_DELAY}s."
 
                     if self.response_delay not in _warned_delay_values:
@@ -200,7 +200,8 @@ class BasePlugin(ABC):
                         self.logger.warning(warning_message)
                         _warned_delay_values.add(self.response_delay)
                     else:
-                        # Log additional instances at debug level for troubleshooting
+                        # Log additional instances at debug level to avoid spam
+                        # This ensures we only warn once per plugin while still providing visibility
                         self.logger.debug(warning_message)
                     self.response_delay = MINIMUM_MESSAGE_DELAY
 

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -174,7 +174,7 @@ class BasePlugin(ABC):
                 # Show deprecated warning only once globally
                 global _deprecated_warning_shown
                 if not _deprecated_warning_shown:
-                    self.logger.warning(
+                    plugins_logger.warning(
                         "Configuration option 'plugin_response_delay' is deprecated. "
                         "Please use 'message_delay' instead. Support for 'plugin_response_delay' will be removed in a future version."
                     )
@@ -197,8 +197,8 @@ class BasePlugin(ABC):
                             )
                             _plugins_low_delay_warned = True
 
-                        # Show per-plugin specific warning
-                        self.logger.warning(warning_message)
+                        # Show specific delay warning (global configuration issue)
+                        plugins_logger.warning(warning_message)
                         _warned_delay_values.add(self.response_delay)
                     else:
                         # Log additional instances at debug level to avoid spam

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -180,17 +180,14 @@ class BasePlugin(ABC):
                 # Enforce minimum delay above firmware limit to prevent message dropping
                 if self.response_delay < MINIMUM_MESSAGE_DELAY:
                     # Only warn once per unique delay value to prevent spam
+                    warning_message = f"{delay_key} of {self.response_delay}s is below minimum of {MINIMUM_MESSAGE_DELAY}s (above firmware limit). Using {MINIMUM_MESSAGE_DELAY}s."
                     global _warned_delay_values
                     if self.response_delay not in _warned_delay_values:
-                        self.logger.warning(
-                            f"{delay_key} of {self.response_delay}s is below minimum of {MINIMUM_MESSAGE_DELAY}s (above firmware limit). Using {MINIMUM_MESSAGE_DELAY}s."
-                        )
+                        self.logger.warning(warning_message)
                         _warned_delay_values.add(self.response_delay)
                     else:
                         # Log additional instances at debug level for troubleshooting
-                        self.logger.debug(
-                            f"{delay_key} of {self.response_delay}s is below minimum of {MINIMUM_MESSAGE_DELAY}s (above firmware limit). Using {MINIMUM_MESSAGE_DELAY}s."
-                        )
+                        self.logger.debug(warning_message)
                     self.response_delay = MINIMUM_MESSAGE_DELAY
 
     def start(self):

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -20,6 +20,7 @@ from mmrelay.db_utils import (
 )
 from mmrelay.log_utils import get_logger
 from mmrelay.message_queue import queue_message
+from mmrelay.plugin_loader import logger as plugins_logger
 
 # Global config variable that will be set from main.py
 config = None
@@ -190,7 +191,7 @@ class BasePlugin(ABC):
                     if self.response_delay not in _warned_delay_values:
                         # Show generic plugins warning on first occurrence
                         if not _plugins_low_delay_warned:
-                            self.logger.warning(
+                            plugins_logger.warning(
                                 f"One or more plugins have message_delay below {MINIMUM_MESSAGE_DELAY}s. "
                                 f"This may affect multiple plugins. Check individual plugin logs for details."
                             )

--- a/src/mmrelay/tools/__init__.py
+++ b/src/mmrelay/tools/__init__.py
@@ -1,28 +1,15 @@
 """Tools and resources for MMRelay."""
 
 import importlib.resources
-import pathlib
 
 
 def get_sample_config_path():
     """Get the path to the sample config file."""
-    try:
-        # For Python 3.10+
-        return str(
-            importlib.resources.files("mmrelay.tools").joinpath("sample_config.yaml")
-        )
-    except AttributeError:
-        # Fallback for older Python versions
-        return str(pathlib.Path(__file__).parent / "sample_config.yaml")
+    return str(
+        importlib.resources.files("mmrelay.tools").joinpath("sample_config.yaml")
+    )
 
 
 def get_service_template_path():
     """Get the path to the service template file."""
-    try:
-        # For Python 3.10+
-        return str(
-            importlib.resources.files("mmrelay.tools").joinpath("mmrelay.service")
-        )
-    except AttributeError:
-        # Fallback for older Python versions
-        return str(pathlib.Path(__file__).parent / "mmrelay.service")
+    return str(importlib.resources.files("mmrelay.tools").joinpath("mmrelay.service"))

--- a/src/mmrelay/tools/__init__.py
+++ b/src/mmrelay/tools/__init__.py
@@ -7,7 +7,7 @@ import pathlib
 def get_sample_config_path():
     """Get the path to the sample config file."""
     try:
-        # For Python 3.9+
+        # For Python 3.10+
         return str(
             importlib.resources.files("mmrelay.tools").joinpath("sample_config.yaml")
         )
@@ -19,7 +19,7 @@ def get_sample_config_path():
 def get_service_template_path():
     """Get the path to the service template file."""
     try:
-        # For Python 3.9+
+        # For Python 3.10+
         return str(
             importlib.resources.files("mmrelay.tools").joinpath("mmrelay.service")
         )

--- a/src/mmrelay/tools/__init__.py
+++ b/src/mmrelay/tools/__init__.py
@@ -4,12 +4,24 @@ import importlib.resources
 
 
 def get_sample_config_path():
-    """Get the path to the sample config file."""
+    """
+    Provide the filesystem path to the package's sample configuration file.
+    
+    Returns:
+        path (str): Path to `sample_config.yaml` located in the `mmrelay.tools` package.
+    """
     return str(
         importlib.resources.files("mmrelay.tools").joinpath("sample_config.yaml")
     )
 
 
 def get_service_template_path():
-    """Get the path to the service template file."""
+    """
+    Return the filesystem path to the mmrelay.service template bundled with the package.
+    
+    Locate the `mmrelay.service` resource inside the `mmrelay.tools` package and return its filesystem path as a string.
+    
+    Returns:
+        path (str): Filesystem path to the `mmrelay.service` template within the `mmrelay.tools` package.
+    """
     return str(importlib.resources.files("mmrelay.tools").joinpath("mmrelay.service"))

--- a/src/mmrelay/tools/__init__.py
+++ b/src/mmrelay/tools/__init__.py
@@ -6,7 +6,7 @@ import importlib.resources
 def get_sample_config_path():
     """
     Provide the filesystem path to the package's sample configuration file.
-    
+
     Returns:
         path (str): Path to `sample_config.yaml` located in the `mmrelay.tools` package.
     """
@@ -18,9 +18,9 @@ def get_sample_config_path():
 def get_service_template_path():
     """
     Return the filesystem path to the mmrelay.service template bundled with the package.
-    
+
     Locate the `mmrelay.service` resource inside the `mmrelay.tools` package and return its filesystem path as a string.
-    
+
     Returns:
         path (str): Filesystem path to the `mmrelay.service` template within the `mmrelay.tools` package.
     """

--- a/src/mmrelay/windows_utils.py
+++ b/src/mmrelay/windows_utils.py
@@ -131,16 +131,15 @@ def get_windows_error_message(error: Exception) -> str:
 
 def check_windows_requirements() -> Optional[str]:
     """
-    Return a multi-line warning string when common Windows environment issues are detected; otherwise None.
-
-    Performs Windows-only checks:
-    - Python version: warns if running on Python < 3.10.
-    - Virtual environment: warns if the process does not appear to be inside a venv/pipx.
-    - Current working directory length: warns if the cwd path length exceeds 200 characters.
-
+    Report Windows environment compatibility issues as a multi-line warning string.
+    
+    When running on Windows, performs these checks and accumulates user-facing warnings:
+    - Python version is older than 3.10.
+    - Process does not appear to be running inside a virtual environment (venv/pipx).
+    - Current working directory path length exceeds 200 characters.
+    
     Returns:
-        Optional[str]: A human-readable, multi-line warning message when one or more checks trigger;
-        returns None if running on a non-Windows platform or no issues are found.
+        Optional[str]: Multi-line warning message prefixed with "Windows compatibility warnings:" and bullet points for each detected issue; `None` if no issues are detected or when not running on Windows.
     """
     if not is_windows():
         return None

--- a/src/mmrelay/windows_utils.py
+++ b/src/mmrelay/windows_utils.py
@@ -134,7 +134,7 @@ def check_windows_requirements() -> Optional[str]:
     Return a multi-line warning string when common Windows environment issues are detected; otherwise None.
 
     Performs Windows-only checks:
-    - Python version: warns if running on Python < 3.9.
+    - Python version: warns if running on Python < 3.10.
     - Virtual environment: warns if the process does not appear to be inside a venv/pipx.
     - Current working directory length: warns if the cwd path length exceeds 200 characters.
 
@@ -148,10 +148,8 @@ def check_windows_requirements() -> Optional[str]:
     warnings = []
 
     # Check Python version for Windows compatibility
-    if sys.version_info < (3, 9):
-        warnings.append(
-            "Python 3.9+ is recommended on Windows for better compatibility"
-        )
+    if sys.version_info < (3, 10):
+        warnings.append("Python 3.10+ is required for better compatibility")
 
     # Check if running in a virtual environment
     if not hasattr(sys, "real_prefix") and not (

--- a/src/mmrelay/windows_utils.py
+++ b/src/mmrelay/windows_utils.py
@@ -132,12 +132,12 @@ def get_windows_error_message(error: Exception) -> str:
 def check_windows_requirements() -> Optional[str]:
     """
     Report Windows environment compatibility issues as a multi-line warning string.
-    
+
     When running on Windows, performs these checks and accumulates user-facing warnings:
     - Python version is older than 3.10.
     - Process does not appear to be running inside a virtual environment (venv/pipx).
     - Current working directory path length exceeds 200 characters.
-    
+
     Returns:
         Optional[str]: Multi-line warning message prefixed with "Windows compatibility warnings:" and bullet points for each detected issue; `None` if no issues are detected or when not running on Windows.
     """

--- a/src/mmrelay/windows_utils.py
+++ b/src/mmrelay/windows_utils.py
@@ -149,7 +149,7 @@ def check_windows_requirements() -> Optional[str]:
 
     # Check Python version for Windows compatibility
     if sys.version_info < (3, 10):
-        warnings.append("Python 3.10+ is recommended for better compatibility")
+        warnings.append("Python 3.10+ is required for this application")
 
     # Check if running in a virtual environment
     if not hasattr(sys, "real_prefix") and not (

--- a/src/mmrelay/windows_utils.py
+++ b/src/mmrelay/windows_utils.py
@@ -149,7 +149,7 @@ def check_windows_requirements() -> Optional[str]:
 
     # Check Python version for Windows compatibility
     if sys.version_info < (3, 10):
-        warnings.append("Python 3.10+ is required for better compatibility")
+        warnings.append("Python 3.10+ is recommended for better compatibility")
 
     # Check if running in a virtual environment
     if not hasattr(sys, "real_prefix") and not (

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -68,12 +68,11 @@ class TestBasePlugin(unittest.TestCase):
         """
         Prepare the test environment by mocking configuration and database functions for plugin tests.
         """
-        # Reset global warning state for clean test isolation
-        from mmrelay.plugins.base_plugin import (
-            _plugins_low_delay_warned,
-            _warned_delay_values,
-        )
+        # Reset global warning state for clean test isolation between test cases
+        import mmrelay.plugins.base_plugin as base_plugin_module
+        from mmrelay.plugins.base_plugin import _warned_delay_values
 
+        base_plugin_module._plugins_low_delay_warned = False
         _warned_delay_values.clear()
         _plugins_low_delay_warned = False
 

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -232,7 +232,7 @@ class TestBasePlugin(unittest.TestCase):
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay):
             # First plugin instance - should log WARNING (generic + specific)
-            with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm1:
+            with self.assertLogs("Plugins", level="WARNING") as cm1:
                 plugin1 = MockPlugin()
                 self.assertEqual(plugin1.response_delay, 2.1)
 
@@ -275,7 +275,7 @@ class TestBasePlugin(unittest.TestCase):
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay):
             # First plugin with low delay - should show generic + specific warning
-            with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm1:
+            with self.assertLogs("Plugins", level="WARNING") as cm1:
                 plugin1 = MockPlugin()
                 self.assertEqual(plugin1.response_delay, 2.1)
 
@@ -304,7 +304,7 @@ class TestBasePlugin(unittest.TestCase):
                 "meshtastic": {"message_delay": 1.0},  # Different below minimum
             }
             with patch("mmrelay.plugins.base_plugin.config", config_different_delay):
-                with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm3:
+                with self.assertLogs("Plugins", level="WARNING") as cm3:
                     plugin3 = MockPlugin()
                     self.assertEqual(plugin3.response_delay, 2.1)
 
@@ -333,23 +333,20 @@ class TestBasePlugin(unittest.TestCase):
         }
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay_1):
-            with self.assertLogs(
-                "Plugin:test_plugin", level="WARNING"
-            ) as cm1, self.assertLogs("Plugins", level="WARNING") as cm_generic:
+            with self.assertLogs("Plugins", level="WARNING") as cm_generic:
                 plugin1 = MockPlugin()
                 self.assertEqual(plugin1.response_delay, 2.1)
 
-                # Should have one generic warning (Plugins logger) + one specific warning (Plugin logger)
-                self.assertEqual(len(cm_generic.output), 1)
+                # Should have two warnings in Plugins logger: generic + specific delay
+                self.assertEqual(len(cm_generic.output), 2)
                 self.assertIn(
                     "One or more plugins have message_delay below 2.1s",
                     cm_generic.output[0],
                 )
-                self.assertEqual(len(cm1.output), 1)
-                self.assertIn("0.5s is below minimum", cm1.output[0])
+                self.assertIn("0.5s is below minimum", cm_generic.output[1])
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay_2):
-            with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm2:
+            with self.assertLogs("Plugins", level="WARNING") as cm2:
                 plugin2 = MockPlugin()
                 self.assertEqual(plugin2.response_delay, 2.1)
 

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -14,6 +14,7 @@ Tests the core plugin functionality including:
 """
 
 import asyncio
+import logging
 import os
 import sqlite3
 import sys
@@ -234,8 +235,6 @@ class TestBasePlugin(unittest.TestCase):
 
             # Second plugin instance with same delay - should NOT log additional warnings
             # but should log a debug message for troubleshooting.
-            import logging
-
             logger = logging.getLogger("Plugin:test_plugin")
 
             with patch.object(logger, "warning") as mock_warning:

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -68,6 +68,15 @@ class TestBasePlugin(unittest.TestCase):
         """
         Prepare the test environment by mocking configuration and database functions for plugin tests.
         """
+        # Reset global warning state for clean test isolation
+        from mmrelay.plugins.base_plugin import (
+            _plugins_low_delay_warned,
+            _warned_delay_values,
+        )
+
+        _warned_delay_values.clear()
+        _plugins_low_delay_warned = False
+
         # Mock the global config
         self.mock_config = {
             "plugins": {"test_plugin": {"active": True, "channels": [0, 1]}},
@@ -224,14 +233,16 @@ class TestBasePlugin(unittest.TestCase):
         }
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay):
-            # First plugin instance - should log WARNING
+            # First plugin instance - should log WARNING (generic + specific)
             with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm1:
                 plugin1 = MockPlugin()
                 self.assertEqual(plugin1.response_delay, 2.1)
 
-                # Should have one warning for first occurrence
-                self.assertEqual(len(cm1.output), 1)
-                self.assertIn("below minimum of 2.1s", cm1.output[0])
+                # Should have warnings: generic (if first test) + specific
+                self.assertGreaterEqual(len(cm1.output), 1)
+                self.assertTrue(
+                    any("below minimum of 2.1s" in msg for msg in cm1.output)
+                )
 
             # Second plugin instance with same delay - should NOT log additional warnings
             # but should log a debug message for troubleshooting.
@@ -253,14 +264,63 @@ class TestBasePlugin(unittest.TestCase):
                     # Verify the delay value is tracked in the global set
                     self.assertIn(0.5, _warned_delay_values)
 
+    def test_response_delay_generic_plugins_warning(self):
+        """
+        Test that a generic plugins warning is shown once when multiple plugins have low delay.
+        """
+        # Global state is reset in setUp() method
+
+        config_low_delay = {
+            "plugins": {"test_plugin": {"active": True}},
+            "meshtastic": {"message_delay": 0.5},  # Below minimum
+        }
+
+        with patch("mmrelay.plugins.base_plugin.config", config_low_delay):
+            # First plugin with low delay - should show generic + specific warning
+            with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm1:
+                plugin1 = MockPlugin()
+                self.assertEqual(plugin1.response_delay, 2.1)
+
+                # Should have warnings: generic (if first test) + specific
+                self.assertGreaterEqual(len(cm1.output), 1)
+                self.assertTrue(
+                    any(
+                        "message_delay of 0.5s is below minimum" in msg
+                        for msg in cm1.output
+                    )
+                )
+
+            # Second plugin with same low delay - should only show debug, no warnings
+            logger = logging.getLogger("Plugin:test_plugin")
+            with patch.object(logger, "warning") as mock_warning:
+                with patch.object(logger, "debug") as mock_debug:
+                    plugin2 = MockPlugin()
+                    self.assertEqual(plugin2.response_delay, 2.1)
+
+                    mock_warning.assert_not_called()
+                    mock_debug.assert_called_once()
+
+            # Third plugin with different low delay - should only show specific warning (generic already shown)
+            config_different_delay = {
+                "plugins": {"test_plugin": {"active": True}},
+                "meshtastic": {"message_delay": 1.0},  # Different below minimum
+            }
+            with patch("mmrelay.plugins.base_plugin.config", config_different_delay):
+                with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm3:
+                    plugin3 = MockPlugin()
+                    self.assertEqual(plugin3.response_delay, 2.1)
+
+                    # Should have only 1 warning: specific (generic already shown)
+                    self.assertEqual(len(cm3.output), 1)
+                    self.assertIn(
+                        "message_delay of 1.0s is below minimum", cm3.output[0]
+                    )
+
     def test_response_delay_different_values_log_warning(self):
         """
         Test that different low delay values each trigger a warning.
         """
-        from mmrelay.plugins.base_plugin import _warned_delay_values
-
-        # Clear the global set before testing
-        _warned_delay_values.clear()
+        # Global state is reset in setUp() method
 
         # Test with first low delay value
         config_low_delay_1 = {
@@ -279,20 +339,25 @@ class TestBasePlugin(unittest.TestCase):
                 plugin1 = MockPlugin()
                 self.assertEqual(plugin1.response_delay, 2.1)
 
-                # Should have one warning for 0.5s delay
-                self.assertEqual(len(cm1.output), 1)
-                self.assertIn("0.5s is below minimum", cm1.output[0])
+                # Should have two warnings: generic + specific for 0.5s delay
+                self.assertEqual(len(cm1.output), 2)
+                self.assertIn(
+                    "One or more plugins have message_delay below 2.1s", cm1.output[0]
+                )
+                self.assertIn("0.5s is below minimum", cm1.output[1])
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay_2):
             with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm2:
                 plugin2 = MockPlugin()
                 self.assertEqual(plugin2.response_delay, 2.1)
 
-                # Should have one warning for 1.0s delay (different value)
+                # Should have one warning for 1.0s delay (different value, generic already shown)
                 self.assertEqual(len(cm2.output), 1)
                 self.assertIn("1.0s is below minimum", cm2.output[0])
 
         # Both delay values should be tracked
+        from mmrelay.plugins.base_plugin import _warned_delay_values
+
         self.assertIn(0.5, _warned_delay_values)
         self.assertIn(1.0, _warned_delay_values)
 

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -74,7 +74,6 @@ class TestBasePlugin(unittest.TestCase):
 
         base_plugin_module._plugins_low_delay_warned = False
         _warned_delay_values.clear()
-        _plugins_low_delay_warned = False
 
         # Mock the global config
         self.mock_config = {

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -333,16 +333,20 @@ class TestBasePlugin(unittest.TestCase):
         }
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay_1):
-            with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm1:
+            with self.assertLogs(
+                "Plugin:test_plugin", level="WARNING"
+            ) as cm1, self.assertLogs("Plugins", level="WARNING") as cm_generic:
                 plugin1 = MockPlugin()
                 self.assertEqual(plugin1.response_delay, 2.1)
 
-                # Should have two warnings: generic + specific for 0.5s delay
-                self.assertEqual(len(cm1.output), 2)
+                # Should have one generic warning (Plugins logger) + one specific warning (Plugin logger)
+                self.assertEqual(len(cm_generic.output), 1)
                 self.assertIn(
-                    "One or more plugins have message_delay below 2.1s", cm1.output[0]
+                    "One or more plugins have message_delay below 2.1s",
+                    cm_generic.output[0],
                 )
-                self.assertIn("0.5s is below minimum", cm1.output[1])
+                self.assertEqual(len(cm1.output), 1)
+                self.assertIn("0.5s is below minimum", cm1.output[0])
 
         with patch("mmrelay.plugins.base_plugin.config", config_low_delay_2):
             with self.assertLogs("Plugin:test_plugin", level="WARNING") as cm2:

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -3514,10 +3514,10 @@ async def test_resolve_aliases_in_mapping_dict():
     async def mock_resolver(alias):
         """
         Resolve a Matrix room alias to a room ID for tests.
-        
+
         Parameters:
             alias (str): Matrix room alias to resolve (e.g. "#alias:matrix.org").
-        
+
         Returns:
             str: Resolved room ID for known aliases, otherwise returns the original `alias`.
         """

--- a/tests/test_message_queue_edge_cases.py
+++ b/tests/test_message_queue_edge_cases.py
@@ -78,14 +78,14 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_queue_overflow_handling(self):
         """
         Verify MessageQueue enforces its configured maximum capacity and rejects further enqueues when full.
-        
+
         Starts the queue, fills it until enqueue returns False or the configured MAX_QUEUE_SIZE is reached, then attempts one additional enqueue which must be rejected. Asserts that at least one message was accepted and that the final queue size does not exceed MAX_QUEUE_SIZE.
         """
 
         async def async_test():
             """
             Verify the message queue enforces its maximum capacity by filling it to its limit and asserting additional enqueue attempts are rejected.
-            
+
             Starts the queue, enqueues messages up to the configured MAX_QUEUE_SIZE (or until the queue refuses further enqueues), then asserts that an extra enqueue is rejected and that at least one message was accepted.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -222,7 +222,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_processor_import_error_handling(self, mock_logger):
         """
         Verify MessageQueue handles an ImportError raised during message processing without crashing.
-        
+
         Starts the queue, causes MessageQueue._should_send_message to raise ImportError while a message is processed, enqueues a message, waits for processing to occur, and asserts the queue remains in a stable running state and that an exception or error was logged.
         """
 
@@ -278,7 +278,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         async def async_test():
             """
             Verify the queue accepts and processes a message when the send function returns an object missing the `id` attribute.
-            
+
             Asserts that enqueueing the message succeeds and the processor handles the send result without raising an exception.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -323,7 +323,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_processor_task_cancellation(self):
         """
         Ensure the MessageQueue's internal processor task can be cancelled and completes.
-        
+
         Starts the queue and processor, cancels the internal `_processor_task`, awaits its completion while ignoring `asyncio.CancelledError`, and asserts the cancelled task reports as done.
         """
 
@@ -376,14 +376,14 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_rate_limiting_edge_cases(self):
         """
         Verify MessageQueue enforces the configured inter-send delay near the rate-limit boundary.
-        
+
         Starts the queue with a short message delay and uses a mocked wall-clock to simulate two enqueue events separated by less than the configured delay, asserting both enqueues succeed and processing occurs consistent with rate limiting.
         """
 
         async def async_test():
             """
             Verifies MessageQueue enforces the configured inter-send delay when messages are enqueued with controlled timing.
-            
+
             Starts the queue with TEST_MESSAGE_DELAY_LOW, mocks wall-clock time to simulate two enqueue events separated by less than the configured delay, and asserts both enqueues succeed while processing adheres to rate limiting.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -436,7 +436,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_concurrent_enqueue_operations(self):
         """
         Start the queue, perform concurrent enqueues from multiple threads, and assert at least one enqueue succeeded.
-        
+
         Starts the MessageQueue with a low message delay, launches five threads that each enqueue ten distinct messages concurrently, waits for all threads to finish, and asserts that at least one enqueue returned success.
         """
         self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -484,7 +484,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         async def async_test():
             """
             Test that a message with mapping_info set to None can be enqueued and processed by the MessageQueue.
-            
+
             Asserts that enqueue returns `True` for a message whose `mapping_info` is `None` and allows time for the queue processor to handle the message.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)

--- a/tests/test_message_queue_edge_cases.py
+++ b/tests/test_message_queue_edge_cases.py
@@ -78,14 +78,14 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_queue_overflow_handling(self):
         """
         Verify that the MessageQueue enforces its maximum capacity and rejects additional enqueues when full.
-        
+
         Starts the queue, fills it up to the configured maximum, attempts one additional enqueue which must be rejected, and asserts the final queue size is greater than zero and does not exceed MAX_QUEUE_SIZE.
         """
 
         async def async_test():
             """
             Verify the message queue enforces its maximum capacity by filling it to its limit and asserting additional enqueue attempts are rejected.
-            
+
             Starts the queue, fills it up to the configured MAX_QUEUE_SIZE (or the actual limit reached), then attempts one more enqueue which must be rejected. Asserts that at least one message was accepted and that the final queue size does not exceed the configured maximum.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -222,7 +222,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_processor_import_error_handling(self, mock_logger):
         """
         Ensure MessageQueue handles an ImportError raised during message processing without crashing.
-        
+
         Starts the queue, patches MessageQueue._should_send_message to raise ImportError while enqueuing a message, waits for processing, asserts the queue remains in a stable running state (boolean), and verifies the logger recorded an exception or error.
         """
 
@@ -278,7 +278,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         async def async_test():
             """
             Verify the queue accepts and processes a message when the send function returns an object missing the `id` attribute.
-            
+
             Asserts that enqueueing the message succeeds and allows the processor to handle the send result without raising an exception.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -323,14 +323,14 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_processor_task_cancellation(self):
         """
         Verify that the message queue's processor task can be cancelled and transitions to a completed state.
-        
+
         Starts the queue, ensures the processor is running, cancels the internal `_processor_task`, awaits its completion (handling `asyncio.CancelledError`), and asserts the task reports as done.
         """
 
         async def async_test():
             """
             Cancel the MessageQueue processor task and assert it terminates.
-            
+
             Starts the queue, ensures the internal processor task is running, cancels that task,
             awaits its completion (ignoring CancelledError), and asserts the task is done.
             """
@@ -383,7 +383,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         async def async_test():
             """
             Verify that MessageQueue enforces the configured inter-send delay when messages are enqueued with controlled timing.
-            
+
             Starts the queue with TEST_MESSAGE_DELAY_LOW, mocks wall-clock time to create two enqueue events separated by less than the configured delay, and asserts both enqueues succeed while processing occurs in a manner consistent with rate limiting.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -436,7 +436,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_concurrent_enqueue_operations(self):
         """
         Start the queue, spawn multiple threads that enqueue messages concurrently, and verify enqueues succeed.
-        
+
         Starts the MessageQueue with a low delay, launches five threads that each enqueue ten messages labeled by thread and index, waits for all threads to finish, and asserts that at least one enqueue operation returned success.
         """
         self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -484,7 +484,7 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
         async def async_test():
             """
             Verify a message with `mapping_info` set to None can be enqueued and processed by the queue.
-            
+
             The test starts the queue and its processor, enqueues a message with `mapping_info=None`, asserts the enqueue returned `True`, and waits briefly for processing.
             """
             self.queue.start(message_delay=TEST_MESSAGE_DELAY_LOW)
@@ -511,14 +511,14 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
     def test_runtime_warning_for_fast_messages(self):
         """
         Assert that a runtime warning is emitted when two messages are enqueued with inter-send time below MINIMUM_MESSAGE_DELAY.
-        
+
         Sets up a meshtastic client mock, starts the MessageQueue with a sub-minimum message_delay, enqueues two messages back-to-back, captures WARNING logs for the MessageQueue logger, and verifies the logs include indications that messages were sent below MINIMUM_MESSAGE_DELAY and "may be dropped".
         """
 
         async def async_test():
             """
             Verify that a WARNING is logged when messages are enqueued faster than the configured minimum inter-send delay.
-            
+
             Sets up a mock meshtastic client, starts the MessageQueue with a message_delay below MINIMUM_MESSAGE_DELAY, enqueues two messages in quick succession, drains the queue, and asserts that the captured WARNING logs include runtime-warning text indicating messages were sent below the minimum delay and may be dropped.
             """
             # Set up mock meshtastic client to allow message sending
@@ -543,10 +543,10 @@ class TestMessageQueueEdgeCases(unittest.TestCase):
             def mock_send(text):
                 """
                 Record the provided text and return a simple object containing a sequential `id`.
-                
+
                 Parameters:
                     text (str): The message text to record.
-                
+
                 Returns:
                     obj: An object with an `id` attribute equal to the number of times this function has been called (1-based).
                 """

--- a/tests/test_tools_init.py
+++ b/tests/test_tools_init.py
@@ -23,30 +23,6 @@ class TestToolsInit(unittest.TestCase):
         self.assertIsInstance(path, str)
         self.assertIn("mmrelay.service", path)
 
-    @patch("importlib.resources.files")
-    def test_get_sample_config_path_fallback(self, mock_files):
-        """Test get_sample_config_path fallback for older Python versions."""
-        # Simulate AttributeError to trigger fallback
-        mock_files.side_effect = AttributeError("files not available")
-
-        path = get_sample_config_path()
-        self.assertIsInstance(path, str)
-        self.assertIn("sample_config.yaml", path)
-        # Should use pathlib fallback
-        self.assertTrue(path.endswith("sample_config.yaml"))
-
-    @patch("importlib.resources.files")
-    def test_get_service_template_path_fallback(self, mock_files):
-        """Test get_service_template_path fallback for older Python versions."""
-        # Simulate AttributeError to trigger fallback
-        mock_files.side_effect = AttributeError("files not available")
-
-        path = get_service_template_path()
-        self.assertIsInstance(path, str)
-        self.assertIn("mmrelay.service", path)
-        # Should use pathlib fallback
-        self.assertTrue(path.endswith("mmrelay.service"))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tools_init.py
+++ b/tests/test_tools_init.py
@@ -10,14 +10,14 @@ class TestToolsInit(unittest.TestCase):
     """Test cases for tools/__init__.py functions."""
 
     def test_get_sample_config_path_modern_python(self):
-        """Test get_sample_config_path with modern Python (3.9+)."""
+        """Test get_sample_config_path with modern Python (3.10+)."""
         # This should work on modern Python versions
         path = get_sample_config_path()
         self.assertIsInstance(path, str)
         self.assertIn("sample_config.yaml", path)
 
     def test_get_service_template_path_modern_python(self):
-        """Test get_service_template_path with modern Python (3.9+)."""
+        """Test get_service_template_path with modern Python (3.10+)."""
         # This should work on modern Python versions
         path = get_service_template_path()
         self.assertIsInstance(path, str)

--- a/tests/test_tools_init.py
+++ b/tests/test_tools_init.py
@@ -1,7 +1,6 @@
 """Tests for mmrelay.tools module."""
 
 import unittest
-from unittest.mock import patch
 
 from mmrelay.tools import get_sample_config_path, get_service_template_path
 

--- a/tests/test_windows_utils.py
+++ b/tests/test_windows_utils.py
@@ -149,7 +149,7 @@ class TestCheckWindowsRequirements(unittest.TestCase):
         result = check_windows_requirements()
 
         self.assertIsNotNone(result)
-        self.assertIn("Python 3.10+ is recommended", result)
+        self.assertIn("Python 3.10+ is required", result)
 
     @patch("sys.platform", "win32")
     @patch("sys.version_info", (3, 12, 0))

--- a/tests/test_windows_utils.py
+++ b/tests/test_windows_utils.py
@@ -149,7 +149,7 @@ class TestCheckWindowsRequirements(unittest.TestCase):
         result = check_windows_requirements()
 
         self.assertIsNotNone(result)
-        self.assertIn("Python 3.10+ is required", result)
+        self.assertIn("Python 3.10+ is recommended", result)
 
     @patch("sys.platform", "win32")
     @patch("sys.version_info", (3, 12, 0))

--- a/tests/test_windows_utils.py
+++ b/tests/test_windows_utils.py
@@ -149,7 +149,7 @@ class TestCheckWindowsRequirements(unittest.TestCase):
         result = check_windows_requirements()
 
         self.assertIsNotNone(result)
-        self.assertIn("Python 3.9+ is recommended", result)
+        self.assertIn("Python 3.10+ is required", result)
 
     @patch("sys.platform", "win32")
     @patch("sys.version_info", (3, 12, 0))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all user-facing docs and Windows compatibility messages to require Python 3.10+.

* **Chores**
  * Raised the project's minimum supported Python to 3.10 in packaging/configuration.

* **Bug Fixes**
  * Reduced repeated low-delay warning spam by consolidating identical warnings and ensuring low delays are reported once; low inter-message delays are now enforced to the minimum to prevent excessive warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->