### PR TITLE
Add CI trigger for review branches

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    branches:
+      - main
+      - develop
+      - "**review**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- Configure test-and-coverage workflow to run on PRs against branches containing 'review'
- Uses pattern '**review**' to match any branch with 'review' in the name
- Enables automated testing for review-focused development branches