### PR TITLE
ci(workflows): adjust review branch support for CI workflows

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -5,7 +5,7 @@ on:
   release:
     types: [published]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, "**-review"]
     paths:
       - .github/workflows/package-windows.yml
       - scripts/mmrelay.iss

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -2,12 +2,12 @@ name: Tests and Coverage
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, "**-review"]
   pull_request:
     branches:
       - main
       - develop
-      - "**review**"
+      - "**-review"
   workflow_dispatch:
 
 permissions:

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -2,4 +2,4 @@
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"


### PR DESCRIPTION
Enable CI/CD pipelines to run on feature branches ending with "-review" pattern by updating branch filters in GitHub Actions workflows. This allows for automated testing and coverage on review-specific branches.

Also bumps version to 1.2.6.