### PR TITLE
chore(deps): update tools and add Watchtower support for automatic updates for prebuilt docker images

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.3
+      ref: v1.7.4
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -17,20 +17,20 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - dotenv-linter@3.3.0
+    - dotenv-linter@4.0.0
     - hadolint@2.14.0
     - taplo@0.10.0
     - actionlint@1.7.8
     - bandit@1.8.6
     - black@25.11.0
-    - checkov@3.2.492
+    - checkov@3.2.493
     - git-diff-check
     - isort@7.0.0
     - markdownlint@0.45.0
     - osv-scanner@2.2.4
     - prettier@3.6.2
-    - ruff@0.14.4
-    - trufflehog@3.90.13
+    - ruff@0.14.5
+    - trufflehog@3.91.0
     - yamllint@1.37.1
   # Remove map_plugin.py after staticmaps is updated and we're able to work on it again
   # For more info: https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/117

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -51,6 +51,18 @@ docker compose logs -f
 
 **That's it!** Your MMRelay is now running with the official prebuilt image.
 
+**Optional: Enable Automatic Updates**
+To keep MMRelay updated automatically, uncomment the Watchtower section in your docker-compose.yaml file:
+
+```bash
+# Edit the compose file to enable automatic updates
+nano docker-compose.yaml
+# Uncomment the watchtower section (lines at the bottom)
+docker compose up -d  # Restart to apply changes
+```
+
+This will check for updates daily at 2 AM and automatically restart with new versions.
+
 ```bash
 chmod 600 ~/.mmrelay/config.yaml
 ```
@@ -518,8 +530,15 @@ Look for messages like:
 
 **Prebuilt images:**
 
-- Pull latest: `docker compose pull && docker compose up -d`
-- Or use Watchtower for automatic updates (see sample-docker-compose-prebuilt.yaml)
+- **Automatic updates (Recommended):** Uncomment the Watchtower service in your docker-compose.yaml file to get daily updates at 2 AM
+- **Manual updates:** `docker compose pull && docker compose up -d`
+
+**Watchtower Benefits:**
+
+- Automatic security updates
+- No manual intervention required
+- Cleans up old images to save space
+- Only updates MMRelay container (safe for other services)
 
 **Built from source:**
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -55,9 +55,10 @@ docker compose logs -f
 To keep MMRelay updated automatically, uncomment the Watchtower section in your docker-compose.yaml file:
 
 ```bash
-# Edit the compose file to enable automatic updates
+# Optional: For automatic updates, edit the compose file and uncomment the watchtower section
 nano docker-compose.yaml
-# Uncomment the watchtower section (lines at the bottom)
+
+# Note: Do this before running 'docker compose up -d' for the first time
 docker compose up -d  # Restart to apply changes
 ```
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -30,43 +30,29 @@ You need Docker installed on your system. Follow the [official Docker installati
 **Most users should start here** - prebuilt images without cloning the repository:
 
 ```bash
-# 1. Create directories and get config
+# Create directories and download config
 mkdir -p ~/.mmrelay/data ~/.mmrelay/logs
 curl -Lo ~/.mmrelay/config.yaml https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/main/src/mmrelay/tools/sample_config.yaml
 
-# 2. Edit your config
+# Adjust permissions and edit the file
+chmod 600 ~/.mmrelay/config.yaml
 nano ~/.mmrelay/config.yaml
 
-# 3. Set up environment and get docker-compose file
-# The following commands set up your environment to prevent permission issues
+# Set up environment and get docker-compose file
 grep -q '^MMRELAY_HOME=' .env 2>/dev/null || echo 'MMRELAY_HOME=$HOME' >> .env
 grep -q '^UID=' .env 2>/dev/null || echo "UID=$(id -u)" >> .env
 grep -q '^GID=' .env 2>/dev/null || echo "GID=$(id -g)" >> .env
 curl -o docker-compose.yaml https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/main/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
-docker compose up -d
 
-# 4. View logs
+# Optional: Enable automatic updates before first startup
+nano docker-compose.yaml  # Uncomment the watchtower section
+
+# Start containers and view logs
+docker compose up -d
 docker compose logs -f
 ```
 
 **That's it!** Your MMRelay is now running with the official prebuilt image.
-
-**Optional: Enable Automatic Updates**
-To keep MMRelay updated automatically, uncomment the Watchtower section in your docker-compose.yaml file:
-
-```bash
-# Optional: For automatic updates, edit the compose file and uncomment the watchtower section
-nano docker-compose.yaml
-
-# Note: Do this before running 'docker compose up -d' for the first time
-docker compose up -d  # Restart to apply changes
-```
-
-This will check for updates daily at 2 AM and automatically restart with new versions.
-
-```bash
-chmod 600 ~/.mmrelay/config.yaml
-```
 
 ## Deployment Methods
 

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -2,4 +2,4 @@
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -28,3 +28,16 @@ services:
     # privileged: true # Alternative if apparmor=unconfined is not acceptable
 
     # Tip: For correct permissions and paths, ensure UID, GID, and MMRELAY_HOME are set in a .env file or exported
+
+  # Optional: Watchtower for automatic updates (Recommended)
+  # Uncomment to check for updates daily at 2 AM
+  # watchtower:
+  #   image: containrrr/watchtower:latest
+  #   container_name: watchtower-mmrelay
+  #   restart: unless-stopped
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   environment:
+  #     - WATCHTOWER_CLEANUP=true
+  #     - WATCHTOWER_SCHEDULE=0 2 * * *  # Daily at 2 AM
+  #   command: meshtastic-matrix-relay

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -44,5 +44,5 @@ services:
   #    - /var/run/docker.sock:/var/run/docker.sock
   #  environment:
   #    - WATCHTOWER_CLEANUP=true
-  #    - WATCHTOWER_SCHEDULE="0 2 * * *"  # Daily at 2 AM
+  #    - WATCHTOWER_SCHEDULE=0 2 * * *  # Daily at 2 AM
   #  command: --label-enable

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -5,6 +5,8 @@ services:
     restart: unless-stopped
     stop_grace_period: 30s
     user: "${UID:-1000}:${GID:-1000}"
+    labels:
+      - com.centurylinklabs.watchtower.enable=true # Enables automatic updates via Watchtower (if enabled, below)
     environment:
       - TZ=UTC # Set timezone (PYTHONUNBUFFERED and MPLCONFIGDIR are set in Dockerfile)
 
@@ -29,8 +31,11 @@ services:
 
     # Tip: For correct permissions and paths, ensure UID, GID, and MMRELAY_HOME are set in a .env file or exported
 
-  # Optional: Watchtower for automatic updates (Recommended)
-  # Uncomment to check for updates daily at 2 AM
+    # Optional: Watchtower for automatic updates (Recommended)
+    # Uncomment to check for updates daily at 2 AM
+    # Uses label-based filtering to update only labeled containers
+
+  # Uncomment below to enable automatic updates:
   # watchtower:
   #   image: containrrr/watchtower:latest
   #   container_name: watchtower-mmrelay
@@ -40,4 +45,4 @@ services:
   #   environment:
   #     - WATCHTOWER_CLEANUP=true
   #     - WATCHTOWER_SCHEDULE=0 2 * * *  # Daily at 2 AM
-  #   command: meshtastic-matrix-relay
+  #   command: --label-enable

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -36,13 +36,13 @@ services:
     # Uses label-based filtering to update only labeled containers
 
   # Uncomment below to enable automatic updates:
-  # watchtower:
-  #   image: containrrr/watchtower:latest
-  #   container_name: watchtower-mmrelay
-  #   restart: unless-stopped
-  #   volumes:
-  #     - /var/run/docker.sock:/var/run/docker.sock
-  #   environment:
-  #     - WATCHTOWER_CLEANUP=true
-  #     - WATCHTOWER_SCHEDULE="0 2 * * *"  # Daily at 2 AM
-  #   command: --label-enable
+  #watchtower:
+  #  image: containrrr/watchtower:latest
+  #  container_name: watchtower-mmrelay
+  #  restart: unless-stopped
+  #  volumes:
+  #    - /var/run/docker.sock:/var/run/docker.sock
+  #  environment:
+  #    - WATCHTOWER_CLEANUP=true
+  #    - WATCHTOWER_SCHEDULE="0 2 * * *"  # Daily at 2 AM
+  #  command: --label-enable

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -44,5 +44,5 @@ services:
   #     - /var/run/docker.sock:/var/run/docker.sock
   #   environment:
   #     - WATCHTOWER_CLEANUP=true
-  #     - WATCHTOWER_SCHEDULE=0 2 * * *  # Daily at 2 AM
+  #     - WATCHTOWER_SCHEDULE="0 2 * * *"  # Daily at 2 AM
   #   command: --label-enable


### PR DESCRIPTION
- Enhanced documentation with Watchtower automatic update instructions
- Added Watchtower service configuration to sample docker-compose file
- Updated trunk plugin from v1.7.3 to v1.7.4
- Bumped dotenv-linter, checkov, ruff, and trufflehog versions
- Bumped application version from 1.2.6 to 1.2.7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatic container updates via Watchtower, enabling daily automatic security updates at 2 AM.

* **Documentation**
  * Updated Docker documentation with instructions for enabling automatic updates and Watchtower benefits.

* **Chores**
  * Version bumped to 1.2.7.
  * Updated development tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->