### PR TITLE
docs(docker): update watchtower to maintained fork

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -28,9 +28,9 @@ lint:
     - isort@7.0.0
     - markdownlint@0.46.0
     - osv-scanner@2.3.0
-    - prettier@3.7.3
-    - ruff@0.14.7
-    - trufflehog@3.91.1
+    - prettier@3.7.4
+    - ruff@0.14.8
+    - trufflehog@3.91.2
     - yamllint@1.37.1
   # Remove map_plugin.py after staticmaps is updated and we're able to work on it again
   # For more info: https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/117

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -526,6 +526,7 @@ Look for messages like:
 - No manual intervention required
 - Cleans up old images to save space
 - Only updates MMRelay container (safe for other services)
+- Uses maintained fork (nickfedor/watchtower) that fixes Docker API compatibility issues
 
 **Built from source:**
 

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -2,4 +2,4 @@
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -34,10 +34,11 @@ services:
     # Optional: Watchtower for automatic updates (Recommended)
     # Uncomment to check for updates daily at 2 AM
     # Uses label-based filtering to update only labeled containers
+    # Note: Uses nicholas-fedor/watchtower fork (maintained, fixes Docker API issues)
 
   # Uncomment below to enable automatic updates:
   #watchtower:
-  #    image: containrrr/watchtower:latest
+  #    image: nickfedor/watchtower:latest
   #    container_name: watchtower-mmrelay
   #    restart: unless-stopped
   #    volumes:

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -34,7 +34,7 @@ services:
     # Optional: Watchtower for automatic updates (Recommended)
     # Uncomment to check for updates daily at 2 AM
     # Uses label-based filtering to update only labeled containers
-    # Note: Uses nicholas-fedor/watchtower fork (maintained, fixes Docker API issues)
+    # Note: Uses Watchtower fork https://github.com/nicholas-fedor/watchtower (maintained, fixes Docker API issues)
 
   # Uncomment below to enable automatic updates:
   #watchtower:


### PR DESCRIPTION
Switch to `nickfedor/watchtower` fork that fixes Docker API compatibility issues and is actively maintained, replacing the unmaintained `containrrr/watchtower` image.