### PR TITLE
refactor(markdown): protect bracket-prefixed content from markdown parsing

### DIFF
--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -675,15 +675,16 @@ def _add_truncated_vars(format_vars, prefix, text):
             logger.debug(f"  {prefix}{i} = '{truncated_value}'")
 
 
-_PREFIX_DEFINITION_PATTERN = re.compile(r"^\[([^\]]+)\]:(\s*)")
-_MARKDOWN_ESCAPE_PATTERN = re.compile(r"([*_`~\\])")
+_PREFIX_DEFINITION_PATTERN = re.compile(r"^\[(.+?)\]:(\s*)")
+# Escape underscores, asterisks, backticks, tildes, backslashes, and brackets inside prefixes
+_MARKDOWN_ESCAPE_PATTERN = re.compile(r"([*_`~\\\[\]])")
 
 
 def _escape_leading_prefix_for_markdown(message: str) -> tuple[str, bool]:
     """
     Escape a leading `[...]:` prefix so Markdown does not treat it as a link definition and preserves special characters.
 
-    Escapes Markdown-sensitive characters (underscore, asterisk, backtick, tilde, and backslash) inside the prefix as well as the opening bracket.
+    Escapes Markdown-sensitive characters (underscore, asterisk, backtick, tilde, backslash, and brackets) inside the prefix as well as the opening bracket.
     """
     match = _PREFIX_DEFINITION_PATTERN.match(message)
     if not match:

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -15,6 +15,7 @@ from mmrelay.matrix_utils import (
     _can_auto_create_credentials,
     _create_mapping_info,
     _display_room_channel_mappings,
+    _escape_leading_prefix_for_markdown,
     _get_detailed_matrix_error_message,
     _get_e2ee_error_message,
     _get_msgs_to_keep_config,
@@ -988,6 +989,35 @@ def test_add_truncated_vars_none_text():
     # Should convert None to empty string
     assert format_vars["display1"] == ""
     assert format_vars["display5"] == ""
+
+
+@pytest.mark.parametrize(
+    "name_part",
+    [
+        "Test_Node",
+        "_Name_",
+        "__Name__",
+        "*Name*",
+        "*_Name_*",
+        "Name_with_*_mix",
+        "Name~tilde",
+        "Name`code`",
+    ],
+)
+def test_escape_leading_prefix_for_markdown_with_markdown_chars(name_part):
+    """
+    Prefix-style messages containing markdown characters should render intact instead of being stripped or formatted.
+    """
+    original = f"[{name_part}/Mesh]: hello world"
+    safe = _escape_leading_prefix_for_markdown(original)
+
+    escaped_name = re.sub(r"([*_`~\\])", r"\\\1", name_part)
+    expected_prefix = f"\\[{escaped_name}/Mesh]:"
+    assert safe.startswith(expected_prefix)
+    assert safe.endswith("hello world")
+
+    unchanged = "No prefix here"
+    assert _escape_leading_prefix_for_markdown(unchanged) == unchanged
 
 
 # Prefix formatting function tests - converted from unittest.TestCase to standalone pytest functions

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -1012,11 +1012,21 @@ def test_escape_leading_prefix_for_markdown_with_markdown_chars(name_part):
     original = f"[{name_part}/Mesh]: hello world"
     safe = _escape_leading_prefix_for_markdown(original)
 
-    escaped_name = re.sub(r"([*_`~\\])", r"\\\1", name_part)
+    escape_map = {
+        "\\": "\\\\",
+        "*": "\\*",
+        "_": "\\_",
+        "`": "\\`",
+        "~": "\\~",
+    }
+    escaped_name = "".join(escape_map.get(ch, ch) for ch in name_part)
     expected_prefix = f"\\[{escaped_name}/Mesh]:"
     assert safe.startswith(expected_prefix)
     assert safe.endswith("hello world")
 
+
+def test_escape_leading_prefix_for_markdown_non_prefix():
+    """Non-prefix strings should remain unchanged."""
     unchanged = "No prefix here"
     assert _escape_leading_prefix_for_markdown(unchanged) == unchanged
 

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -1010,7 +1010,7 @@ def test_escape_leading_prefix_for_markdown_with_markdown_chars(name_part):
     Prefix-style messages containing markdown characters should render intact instead of being stripped or formatted.
     """
     original = f"[{name_part}/Mesh]: hello world"
-    safe = _escape_leading_prefix_for_markdown(original)
+    safe, escaped = _escape_leading_prefix_for_markdown(original)
 
     escape_map = {
         "\\": "\\\\",
@@ -1023,12 +1023,15 @@ def test_escape_leading_prefix_for_markdown_with_markdown_chars(name_part):
     expected_prefix = f"\\[{escaped_name}/Mesh]:"
     assert safe.startswith(expected_prefix)
     assert safe.endswith("hello world")
+    assert escaped
 
 
 def test_escape_leading_prefix_for_markdown_non_prefix():
     """Non-prefix strings should remain unchanged."""
     unchanged = "No prefix here"
-    assert _escape_leading_prefix_for_markdown(unchanged) == unchanged
+    processed, escaped = _escape_leading_prefix_for_markdown(unchanged)
+    assert processed == unchanged
+    assert escaped is False
 
 
 # Prefix formatting function tests - converted from unittest.TestCase to standalone pytest functions

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -1003,6 +1003,7 @@ def test_add_truncated_vars_none_text():
         "Name~tilde",
         "Name`code`",
         r"Name\with\slash",
+        "User[test]",
     ],
 )
 def test_escape_leading_prefix_for_markdown_with_markdown_chars(name_part):
@@ -1018,6 +1019,8 @@ def test_escape_leading_prefix_for_markdown_with_markdown_chars(name_part):
         "_": "\\_",
         "`": "\\`",
         "~": "\\~",
+        "[": "\\[",
+        "]": "\\]",
     }
     escaped_name = "".join(escape_map.get(ch, ch) for ch in name_part)
     expected_prefix = f"\\[{escaped_name}/Mesh]:"

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -1002,6 +1002,7 @@ def test_add_truncated_vars_none_text():
         "Name_with_*_mix",
         "Name~tilde",
         "Name`code`",
+        r"Name\with\slash",
     ],
 )
 def test_escape_leading_prefix_for_markdown_with_markdown_chars(name_part):


### PR DESCRIPTION
## Summary of Changes



This pull request enhances the Markdown processing within the `matrix_relay` function by introducing a new preprocessing step. The core change is the implementation of `_escape_leading_prefix_for_markdown`, which intelligently identifies and escapes leading bracket-prefixed patterns in messages. This prevents the Markdown parser from incorrectly interpreting these prefixes as link definitions, thereby preserving the intended message formatting and improving the overall robustness of Markdown rendering.

### Highlights

* **Protective Preprocessing for Markdown**: Introduced a new function `_escape_leading_prefix_for_markdown` to preprocess messages, specifically targeting bracket-prefixed content (e.g., `[Topic]:`) to prevent it from being misinterpreted as Markdown link definitions.
* **Enhanced Markdown Escaping**: The new function escapes Markdown-sensitive characters (like `*`, `_`, `` ` ``, `~`, `\`, `[`, `]`) within these leading prefixes, ensuring their literal display.
* **Integration into Message Relay**: The `matrix_relay` function now utilizes this escaping logic, applying it to messages before they undergo Markdown conversion, and updates the `has_markdown` check to account for the presence of such prefixes.
* **Comprehensive Test Coverage**: New parameterized tests have been added to validate the correct behavior of the `_escape_leading_prefix_for_markdown` function, covering various Markdown characters within prefixes and non-prefix scenarios.

<details>
<summary><b>Changelog</b></summary>

* **src/mmrelay/matrix_utils.py**
    * Added `_PREFIX_DEFINITION_PATTERN` and `_MARKDOWN_ESCAPE_PATTERN` regular expressions for identifying and escaping Markdown-sensitive characters in prefixes.
    * Implemented `_escape_leading_prefix_for_markdown` function to escape leading `[...]:` patterns and their internal Markdown characters. This function now returns a tuple indicating if a prefix was found and escaped.
    * Modified `matrix_relay` to call `_escape_leading_prefix_for_markdown` on incoming messages, using the `safe_message` for Markdown conversion and updating the `has_markdown` flag based on whether a prefix was detected.
    * Added a comment to the `ImportError` block.
* **tests/test_matrix_utils.py**
    * Imported the new `_escape_leading_prefix_for_markdown` function.
    * Added `test_escape_leading_prefix_for_markdown_with_markdown_chars` to verify correct escaping of various Markdown characters within prefixes.
    * Added `test_escape_leading_prefix_for_markdown_non_prefix` to confirm that messages without the specific prefix pattern are not altered.
</details>


Closes #366 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Markdown handling for messages beginning with a bracketed prefix so special Markdown characters in that prefix are safely escaped while the remainder of the message is preserved and rendered correctly.
  * Detection of Markdown content now accounts for leading bracketed prefixes to avoid misinterpretation.

* **Tests**
  * Added automated tests validating escaping behavior for leading-prefix cases and non-prefix strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->