### PR TITLE
feat(config): add connection timeout configuration for meshtastic interfaces

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -5,6 +5,7 @@ reviews:
   profile: chill
   request_changes_workflow: false
   high_level_summary: true
+  high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) A overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."
   poem: true
   review_status: false
   collapse_walkthrough: false

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -598,6 +598,12 @@ _MESHTASTIC_ENV_VAR_MAPPINGS = [
         "type": "float",
         "min_value": 2.0,
     },
+    {
+        "env_var": "MMRELAY_MESHTASTIC_CONNECTION_TIMEOUT",
+        "config_key": "connection_timeout",
+        "type": "int",
+        "min_value": 1,
+    },
 ]
 
 _LOGGING_ENV_VAR_MAPPINGS = [

--- a/src/mmrelay/constants/network.py
+++ b/src/mmrelay/constants/network.py
@@ -21,6 +21,7 @@ CONFIG_KEY_CONNECTION_TYPE = "connection_type"
 
 # Connection retry and timing
 DEFAULT_BACKOFF_TIME = 10  # seconds
+DEFAULT_CONNECTION_TIMEOUT = 60  # seconds
 DEFAULT_RETRY_ATTEMPTS = 1
 INFINITE_RETRIES = 0  # 0 means infinite retries
 MINIMUM_MESSAGE_DELAY = 2.0  # Minimum delay for message queue fallback

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -7,7 +7,7 @@ import threading
 import time
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import TYPE_CHECKING, Any, Awaitable, List
+from typing import TYPE_CHECKING, Any, Awaitable
 
 # type: ignore[assignment]  # Suppress complex type issues with asyncio/concurrent.futures integration
 
@@ -88,19 +88,12 @@ except ImportError:
 
 # Global config variable that will be set from config.py
 config = None
-
-# Do not import plugin_loader here to avoid circular imports
-
-# Initialize matrix rooms configuration
-matrix_rooms: List[dict] = []
-
-# Initialize logger for Meshtastic
-logger = get_logger(name="Meshtastic")
-
-
-# Global variables for the Meshtastic connection and event loop management
 meshtastic_client = None
+meshtastic_iface = None  # BLE interface instance for process lifetime
 event_loop = None  # Will be set from main.py
+
+# Initialize logger
+logger = get_logger(__name__)
 
 meshtastic_lock = (
     threading.Lock()
@@ -443,7 +436,7 @@ def connect_meshtastic(passed_config=None, force_connect=False):
     Returns:
         The connected Meshtastic client instance on success, or None if connection cannot be established or shutdown is in progress.
     """
-    global meshtastic_client, shutting_down, reconnecting, config, matrix_rooms
+    global meshtastic_client, meshtastic_iface, shutting_down, reconnecting, config, matrix_rooms
     if shutting_down:
         logger.debug("Shutdown in progress. Not attempting to connect.")
         return None

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -7,7 +7,7 @@ import threading
 import time
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import TYPE_CHECKING, Any, Awaitable
+from typing import TYPE_CHECKING, Any, Awaitable, List
 
 # type: ignore[assignment]  # Suppress complex type issues with asyncio/concurrent.futures integration
 
@@ -91,6 +91,7 @@ config = None
 meshtastic_client = None
 meshtastic_iface = None  # BLE interface instance for process lifetime
 event_loop = None  # Will be set from main.py
+matrix_rooms: List[dict] = []  # Will be populated from config
 
 # Initialize logger
 logger = get_logger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -633,6 +633,7 @@ def reset_meshtastic_globals():
     original_values = {
         "config": getattr(mu, "config", None),
         "meshtastic_client": getattr(mu, "meshtastic_client", None),
+        "meshtastic_iface": getattr(mu, "meshtastic_iface", None),
         "reconnecting": getattr(mu, "reconnecting", False),
         "shutting_down": getattr(mu, "shutting_down", False),
         "reconnect_task": getattr(mu, "reconnect_task", None),
@@ -642,9 +643,10 @@ def reset_meshtastic_globals():
         ),
     }
 
-    # Reset mutable globals to a clean state; keep logger and event_loop usable
+    # Reset mutable globals to a clean state; keep logger and event loop usable
     mu.config = None
     mu.meshtastic_client = None
+    mu.meshtastic_iface = None
     mu.reconnecting = False
     mu.shutting_down = False
     mu.reconnect_task = None

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1054,11 +1054,13 @@ def reset_meshtastic_globals():
     import mmrelay.meshtastic_utils
 
     mmrelay.meshtastic_utils.meshtastic_client = None
+    mmrelay.meshtastic_utils.meshtastic_iface = None
     mmrelay.meshtastic_utils.shutting_down = False
     mmrelay.meshtastic_utils.reconnecting = False
     yield
     # Cleanup after test
     mmrelay.meshtastic_utils.meshtastic_client = None
+    mmrelay.meshtastic_utils.meshtastic_iface = None
     mmrelay.meshtastic_utils.shutting_down = False
     mmrelay.meshtastic_utils.reconnecting = False
 

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -429,7 +429,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         result = connect_meshtastic(passed_config=config)
 
         self.assertEqual(result, mock_client)
-        mock_serial.assert_called_once_with("/dev/ttyUSB0")
+        mock_serial.assert_called_once_with("/dev/ttyUSB0", timeout=60)
 
     @patch("mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface")
     @patch("mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface")
@@ -463,7 +463,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         result = connect_meshtastic(passed_config=config)
 
         self.assertEqual(result, mock_client)
-        mock_tcp.assert_called_once_with(hostname="192.168.1.100")
+        mock_tcp.assert_called_once_with(hostname="192.168.1.100", timeout=60)
 
     @patch("mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface")
     @patch("mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface")
@@ -503,6 +503,8 @@ class TestMeshtasticUtils(unittest.TestCase):
             noProto=False,
             debugOut=None,
             noNodes=False,
+            auto_reconnect=False,
+            timeout=60,
         )
 
     @patch("mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -498,14 +498,20 @@ class TestMeshtasticUtils(unittest.TestCase):
         result = connect_meshtastic(passed_config=config)
 
         self.assertEqual(result, mock_client)
-        mock_ble.assert_called_once_with(
-            address="AA:BB:CC:DD:EE:FF",
-            noProto=False,
-            debugOut=None,
-            noNodes=False,
-            auto_reconnect=False,
-            timeout=60,
-        )
+        # Check that BLEInterface was called with correct parameters
+        mock_ble.assert_called_once()
+        call_kwargs = mock_ble.call_args[1]
+
+        # Verify required parameters
+        self.assertEqual(call_kwargs["address"], "AA:BB:CC:DD:EE:FF")
+        self.assertEqual(call_kwargs["noProto"], False)
+        self.assertEqual(call_kwargs["debugOut"], None)
+        self.assertEqual(call_kwargs["noNodes"], False)
+        self.assertEqual(call_kwargs["timeout"], 60)
+
+        # auto_reconnect should be present if supported, but not required
+        if "auto_reconnect" in call_kwargs:
+            self.assertEqual(call_kwargs["auto_reconnect"], False)
 
     @patch("mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface")
     @patch("mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface")

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -120,7 +120,11 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         Simulates a BLE connection attempt where the device cannot be found, verifying that connect_meshtastic handles the error gracefully and logs the failure.
         """
         config = {
-            "meshtastic": {"connection_type": "ble", "ble_address": "00:11:22:33:44:55"}
+            "meshtastic": {
+                "connection_type": "ble",
+                "ble_address": "00:11:22:33:44:55",
+                "retries": 1,  # Limit retries to avoid infinite loop in test
+            }
         }
 
         # Import the actual BLE exception types from the module

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -125,7 +125,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         with patch(
             "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
-            side_effect=ConnectionRefusedError("Device not found"),
+            side_effect=Exception(
+                "Device not found"
+            ),  # Use generic Exception since both BLEError and ConnectionRefusedError are possible
         ):
             with patch("time.sleep"):  # Speed up test
                 with (

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -123,11 +123,14 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "meshtastic": {"connection_type": "ble", "ble_address": "00:11:22:33:44:55"}
         }
 
+        # Import the actual BLE exception types from the module
+        import mmrelay.meshtastic_utils as mu
+
+        ble_exceptions = (mu.BleakError, mu.BleakDBusError)
+
         with patch(
             "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
-            side_effect=Exception(
-                "Device not found"
-            ),  # Use generic Exception since both BLEError and ConnectionRefusedError are possible
+            side_effect=mu.BleakError("Device not found"),
         ):
             with patch("time.sleep"):  # Speed up test
                 with (

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -130,8 +130,6 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         # Import the actual BLE exception types from the module
         import mmrelay.meshtastic_utils as mu
 
-        ble_exceptions = (mu.BleakError, mu.BleakDBusError)
-
         with patch(
             "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
             side_effect=mu.BleakError("Device not found"),


### PR DESCRIPTION
Adds a new configuration option MMRELAY_MESHTASTIC_CONNECTION_TIMEOUT that allows setting a timeout for all meshtastic interface connections (serial, BLE, and TCP).

The change includes:
- New config option in config.py
- Default constant in network.py
- Implementation in meshtastic_utils.py to use the timeout
- Updated tests to verify timeout parameter is passed correctly

This improves connection reliability by preventing indefinite hangs during connection attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment variable to configure Meshtastic connection timeout (default 60s).
  * Connection timeout applied consistently to Serial, BLE and TCP connections.
  * BLE interface is persisted and reused across connections and is recreated when the device address changes.

* **Tests**
  * Tests updated to enforce and verify timeout behavior and broaden BLE error coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->