### PR TITLE
Add type annotations and type-checking suppressions

### DIFF
--- a/.github/workflows/build-pyz-armv7.yml
+++ b/.github/workflows/build-pyz-armv7.yml
@@ -92,7 +92,7 @@ jobs:
             echo "✅ PYZ test passed"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: mmrelay-${{ env.FILE_VERSION }}-armv7
           path: dist/*.pyz

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -64,7 +64,7 @@ jobs:
           filepath: "/DAppVersion=${{ env.FILE_VERSION }} ./scripts/mmrelay.iss"
 
       - name: Upload installer as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: MMRelay_setup_${{ env.FILE_VERSION }}
           path: scripts/MMRelay_setup_${{ env.FILE_VERSION }}.exe

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 meshtastic>=2.7.4
 Pillow==12.0.0
 matrix-nio==0.25.2
-matplotlib==3.10.7
+matplotlib==3.10.8
 requests==2.32.5
 markdown==3.10
 bleach==6.3.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "meshtastic>=2.7.4",
         "Pillow==12.0.0",
         "matrix-nio==0.25.2",
-        "matplotlib==3.10.7",
+        "matplotlib==3.10.8",
         "requests==2.32.5",
         "markdown==3.10",
         "bleach==6.3.0",

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -26,12 +26,12 @@ import asyncio
 import logging
 import os
 import ssl
-from typing import Any
+from types import ModuleType
 
 try:
     import certifi
 except ImportError:
-    certifi: Any = None  # type: ignore[assignment]
+    certifi: ModuleType | None = None  # type: ignore[assignment,no-redef]
 
 # Import Matrix-related modules for logout functionality
 try:

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -30,7 +30,7 @@ import ssl
 try:
     import certifi
 except ImportError:
-    certifi = None
+    certifi: Module | None = None
 
 # Import Matrix-related modules for logout functionality
 try:

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -26,11 +26,12 @@ import asyncio
 import logging
 import os
 import ssl
+from typing import Any
 
 try:
     import certifi
 except ImportError:
-    certifi: Module | None = None
+    certifi: Any = None  # type: ignore[assignment]
 
 # Import Matrix-related modules for logout functionality
 try:

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -15,7 +15,7 @@ import threading
 from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Optional
+from typing import Any, Generator, Optional
 
 
 class DatabaseManager:
@@ -149,7 +149,7 @@ class DatabaseManager:
     # ------------------------------------------------------------------ #
 
     @contextmanager
-    def read(self) -> sqlite3.Cursor:
+    def read(self) -> Generator[sqlite3.Cursor, None, None]:
         """
         Provide a cursor for performing read-only database operations.
 
@@ -166,7 +166,7 @@ class DatabaseManager:
             cursor.close()
 
     @contextmanager
-    def write(self) -> sqlite3.Cursor:
+    def write(self) -> Generator[sqlite3.Cursor, None, None]:
         """
         Provide a context manager that yields a cursor for transactional write operations.
 

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -217,8 +217,12 @@ def _resolve_database_options() -> Tuple[bool, int, Dict[str, Any]]:
         busy_timeout_ms (int): Busy timeout in milliseconds to use for SQLite connections.
         extra_pragmas (dict): Mapping of pragma names to values, starting from DEFAULT_EXTRA_PRAGMAS and overridden by config-provided pragmas.
     """
-    database_cfg = config.get("database", {}) if isinstance(config, dict) else {}
-    legacy_cfg = config.get("db", {}) if isinstance(config, dict) else {}
+    database_cfg: dict[str, Any] = (
+        config.get("database", {}) if isinstance(config, dict) else {}
+    )
+    legacy_cfg: dict[str, Any] = (
+        config.get("db", {}) if isinstance(config, dict) else {}
+    )
 
     enable_wal = _parse_bool(
         database_cfg.get(

--- a/src/mmrelay/e2ee_utils.py
+++ b/src/mmrelay/e2ee_utils.py
@@ -184,7 +184,7 @@ def get_room_encryption_warnings(
     Returns:
         List[str]: Formatted warning lines (empty if no relevant warnings).
     """
-    warnings = []
+    warnings: list[str] = []
 
     if e2ee_status["overall_status"] == "ready":
         # No warnings needed when E2EE is fully ready
@@ -243,7 +243,7 @@ def format_room_list(rooms: Dict[str, Any], e2ee_status: Dict[str, Any]) -> List
     Returns:
         List[str]: One formatted line per room suitable for user display.
     """
-    room_lines = []
+    room_lines: list[str] = []
 
     # Handle invalid rooms input
     if not rooms or not hasattr(rooms, "items"):

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -248,7 +248,7 @@ def _configure_logger(logger: logging.Logger, *, args=None) -> logging.Logger:
         console_handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
     else:
         # Use standard handler without colors
-        console_handler: logging.Handler = logging.StreamHandler()
+        console_handler: logging.Handler = logging.StreamHandler()  # type: ignore[no-redef]
         console_handler.setFormatter(
             logging.Formatter(
                 fmt="%(asctime)s %(levelname)s:%(name)s:%(message)s",

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 import os
 from logging.handlers import RotatingFileHandler
-from typing import Dict, Set
+from typing import Any, Dict, Set
 
 # Import Rich components only when not running as a service
 try:
@@ -28,7 +28,7 @@ from mmrelay.constants.messages import (
 )
 
 # Initialize Rich console only if available
-console = Console() if RICH_AVAILABLE else None
+console = Console() if RICH_AVAILABLE else None  # type: ignore[name-defined]
 
 # Define custom log level styles - not used directly but kept for reference
 # Rich 14.0.0+ supports level_styles parameter, but we're using an approach
@@ -151,7 +151,7 @@ def _should_log_to_file(args) -> bool:
     Returns:
         bool: `True` if file logging should be enabled, `False` otherwise.
     """
-    logging_config = config.get("logging", {}) if config else {}
+    logging_config: dict[str, Any] = config.get("logging", {}) if config else {}
 
     # Default to True for better user experience unless explicitly disabled
     enabled = logging_config.get("log_to_file", True)
@@ -235,7 +235,7 @@ def _configure_logger(logger: logging.Logger, *, args=None) -> logging.Logger:
     # Add handler for console logging (with or without colors)
     if color_enabled and RICH_AVAILABLE:
         # Use Rich handler with colors
-        console_handler = RichHandler(
+        console_handler: logging.Handler = RichHandler(  # type: ignore[name-defined]
             rich_tracebacks=rich_tracebacks_enabled,
             console=console,
             show_time=True,
@@ -248,7 +248,7 @@ def _configure_logger(logger: logging.Logger, *, args=None) -> logging.Logger:
         console_handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
     else:
         # Use standard handler without colors
-        console_handler = logging.StreamHandler()
+        console_handler: logging.Handler = logging.StreamHandler()
         console_handler.setFormatter(
             logging.Formatter(
                 fmt="%(asctime)s %(levelname)s:%(name)s:%(message)s",

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -464,6 +464,6 @@ def run_main(args):
 if __name__ == "__main__":
     import sys
 
-    from mmrelay.cli import main
+    from mmrelay.cli import main as cli_main
 
-    sys.exit(main())
+    sys.exit(cli_main())

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -7,20 +7,7 @@ import threading
 import time
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import TYPE_CHECKING, Any, Awaitable, Coroutine, List
-
-# type: ignore[assignment]  # Suppress complex type issues with asyncio/concurrent.futures integration
-
-if TYPE_CHECKING:
-    # Type checking imports - these won't be executed at runtime
-    try:
-        from bleak.exc import BleakDBusError as BleakDBusErrorType
-        from bleak.exc import BleakError as BleakErrorType
-    except ImportError:
-        from typing import Type
-
-        BleakDBusErrorType = Type[Exception]
-        BleakErrorType = Type[Exception]
+from typing import Any, Awaitable, Coroutine, List
 
 import meshtastic
 import meshtastic.ble_interface
@@ -70,6 +57,9 @@ from mmrelay.db_utils import (
 from mmrelay.log_utils import get_logger
 from mmrelay.runtime_utils import is_running_as_service
 
+# type: ignore[assignment]  # Suppress complex type issues with asyncio/concurrent.futures integration
+
+
 # Maximum number of timeout retries when retries are configured as infinite.
 MAX_TIMEOUT_RETRIES_INFINITE = 5
 
@@ -78,10 +68,10 @@ try:
     from bleak.exc import BleakDBusError, BleakError
 except ImportError:
     # Define dummy exception classes if bleak is not available
-    class BleakDBusError(Exception):
+    class BleakDBusError(Exception):  # type: ignore[no-redef]
         pass
 
-    class BleakError(Exception):
+    class BleakError(Exception):  # type: ignore[no-redef]
         pass
 
 
@@ -264,7 +254,7 @@ def _wait_for_result(
         except TypeError:
             return result_future.result()
     else:
-        awaitable = _make_awaitable(result_future, loop=target_loop)
+        awaitable: Any = _make_awaitable(result_future, loop=target_loop)
 
     async def _runner():
         """

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -65,7 +65,7 @@ MAX_TIMEOUT_RETRIES_INFINITE = 5
 
 # Import BLE exceptions conditionally
 try:
-    from bleak.exc import BleakDBusError, BleakError
+    from bleak.exc import BleakDBusError, BleakError  # type: ignore[no-redef]
 except ImportError:
     # Define dummy exception classes if bleak is not available
     class BleakDBusError(Exception):  # type: ignore[no-redef]
@@ -246,7 +246,7 @@ def _wait_for_result(
 
     # Handle asyncio Future/Task instances
     if isinstance(result_future, asyncio.Future):
-        awaitable = result_future
+        awaitable: Awaitable[Any] = result_future
     elif hasattr(result_future, "result") and callable(result_future.result):
         # Generic future-like object with .result API (used by some tests)
         try:
@@ -254,7 +254,7 @@ def _wait_for_result(
         except TypeError:
             return result_future.result()
     else:
-        awaitable: Any = _make_awaitable(result_future, loop=target_loop)
+        awaitable = _make_awaitable(result_future, loop=target_loop)
 
     async def _runner():
         """

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -57,9 +57,6 @@ from mmrelay.db_utils import (
 from mmrelay.log_utils import get_logger
 from mmrelay.runtime_utils import is_running_as_service
 
-# type: ignore[assignment]  # Suppress complex type issues with asyncio/concurrent.futures integration
-
-
 # Maximum number of timeout retries when retries are configured as infinite.
 MAX_TIMEOUT_RETRIES_INFINITE = 5
 

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -13,13 +13,14 @@ import tempfile
 import threading
 import time
 from contextlib import contextmanager
+from types import ModuleType
 from typing import Any, NamedTuple
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
 try:
     import schedule
 except ImportError:
-    schedule = None
+    schedule: ModuleType | None = None  # type: ignore[assignment,no-redef]
 
 from mmrelay.config import get_app_path, get_base_dir
 from mmrelay.constants.plugins import (

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -67,7 +67,7 @@ try:
     _PLUGIN_DEPS_DIR = os.path.join(get_base_dir(), "plugins", "deps")
 except (OSError, RuntimeError, ValueError) as exc:  # pragma: no cover
     logger.debug("Unable to resolve base dir for plugin deps at import time: %s", exc)
-    _PLUGIN_DEPS_DIR = None
+    _PLUGIN_DEPS_DIR: str | None = None
 else:
     try:
         os.makedirs(_PLUGIN_DEPS_DIR, exist_ok=True)
@@ -75,7 +75,7 @@ else:
         logger.debug(
             f"Unable to create plugin dependency directory '{_PLUGIN_DEPS_DIR}': {exc}"
         )
-        _PLUGIN_DEPS_DIR = None
+        _PLUGIN_DEPS_DIR: str | None = None
     else:
         deps_path = os.fspath(_PLUGIN_DEPS_DIR)
         if deps_path not in sys.path:

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -63,11 +63,14 @@ _global_scheduler_thread = None
 _global_scheduler_stop_event = None
 
 
+# Plugin dependency directory (may not be set if base dir can't be resolved)
+_PLUGIN_DEPS_DIR: str | None = None
+
 try:
     _PLUGIN_DEPS_DIR = os.path.join(get_base_dir(), "plugins", "deps")
 except (OSError, RuntimeError, ValueError) as exc:  # pragma: no cover
     logger.debug("Unable to resolve base dir for plugin deps at import time: %s", exc)
-    _PLUGIN_DEPS_DIR: str | None = None
+    _PLUGIN_DEPS_DIR = None
 else:
     try:
         os.makedirs(_PLUGIN_DEPS_DIR, exist_ok=True)
@@ -75,7 +78,7 @@ else:
         logger.debug(
             f"Unable to create plugin dependency directory '{_PLUGIN_DEPS_DIR}': {exc}"
         )
-        _PLUGIN_DEPS_DIR: str | None = None
+        _PLUGIN_DEPS_DIR = None
     else:
         deps_path = os.fspath(_PLUGIN_DEPS_DIR)
         if deps_path not in sys.path:

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -32,7 +32,7 @@ def precision_bits_to_meters(bits: int) -> float | None:
 
 
 try:
-    import cairo  # type: ignore[import-untyped]
+    import cairo  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover - optional dependency
     cairo = None
 
@@ -411,10 +411,10 @@ class Plugin(BasePlugin):
         image_size = size_match.groups() if size_match else (None, None)
 
         try:
-            zoom = int(zoom)
+            zoom = int(zoom)  # type: ignore[arg-type]
         except (TypeError, ValueError):
             try:
-                zoom = int(self.config.get("zoom", 8))
+                zoom = int(self.config.get("zoom", 8))  # type: ignore[arg-type]
             except (TypeError, ValueError):
                 zoom = 8
 
@@ -422,7 +422,7 @@ class Plugin(BasePlugin):
             zoom = 8
 
         try:
-            image_size = (int(image_size[0]), int(image_size[1]))
+            image_size = (int(image_size[0]), int(image_size[1]))  # type: ignore[arg-type]
         except (TypeError, ValueError):
             width, height = 1000, 1000
             try:
@@ -468,7 +468,7 @@ class Plugin(BasePlugin):
             return True
 
         locations = []
-        for _node, info in meshtastic_client.nodes.items():
+        for _node, info in meshtastic_client.nodes.items():  # type: ignore[attr-defined]
             pos = info.get("position") if isinstance(info, dict) else None
             user = info.get("user") if isinstance(info, dict) else None
             if (

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -15,7 +15,7 @@ from mmrelay.plugins.base_plugin import BasePlugin
 class Plugin(BasePlugin):
     plugin_name = "weather"
     is_core_plugin = True
-    mesh_commands = ("weather", "hourly", "weekly")
+    mesh_commands = ("weather", "hourly", "daily")
 
     # No __init__ method needed with the simplified plugin system
     # The BasePlugin will automatically use the class-level plugin_name
@@ -35,13 +35,13 @@ class Plugin(BasePlugin):
         Normalize a mode/command string to one of the supported forecast modes.
 
         Returns:
-            str: One of "weather", "hourly", or "weekly". Unrecognized or empty input defaults to "weather".
+            str: One of "weather", "hourly", or "daily". Unrecognized or empty input defaults to "weather".
         """
         cmd = (mode or "weather").lower()
         if cmd == "hourly":
             return "hourly"
-        if cmd == "weekly":
-            return "weekly"
+        if cmd == "daily":
+            return "daily"
         return "weather"
 
     def generate_forecast(self, latitude, longitude, mode: str = "weather"):
@@ -51,12 +51,12 @@ class Plugin(BasePlugin):
         Supports multiple modes:
         - "weather": current conditions only (no future slots)
         - "hourly": current + compact near-term view (+3h, +6h, +12h)
-        - "weekly": daily summary for the next few days (up to 5)
+        - "daily": daily summary for the next few days (up to 5)
 
         Parameters:
             latitude (float): Latitude in decimal degrees.
             longitude (float): Longitude in decimal degrees.
-            mode (str): One of "weather", "hourly", or "weekly".
+            mode (str): One of "weather", "hourly", or "daily".
 
         Returns:
             str: A one-line forecast string on success. On recoverable failures returns one of:
@@ -72,7 +72,7 @@ class Plugin(BasePlugin):
 
         units = self.config.get("units", "metric")  # Default to metric
         temperature_unit = "°C" if units == "metric" else "°F"
-        daily_days = 5 if mode_key == "weekly" else 3
+        daily_days = 5 if mode_key == "daily" else 3
 
         hourly_config = {
             "weather": {
@@ -229,7 +229,7 @@ class Plugin(BasePlugin):
             }
 
             # Generate one-line weather forecast
-            if mode_key == "weekly":
+            if mode_key == "daily":
                 return self._build_daily_forecast(
                     data, units, temperature_unit, daily_days
                 )

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -86,7 +86,7 @@ class Plugin(BasePlugin):
             },
         }
         mode_offsets = hourly_config.get(mode_key, hourly_config["weather"])
-        offsets = mode_offsets["offsets"]
+        offsets = mode_offsets["offsets"]  # type: ignore[index]
 
         url = (
             f"https://api.open-meteo.com/v1/forecast?"
@@ -211,7 +211,7 @@ class Plugin(BasePlugin):
                     t, p, w, dflag, *rest = values
                     if t is not None:
                         t = t * 9 / 5 + 32
-                    forecast_hours[key] = (t, p, w, dflag, *rest)
+                    forecast_hours[key] = (t, p, w, dflag, *rest)  # type: ignore[arg-type]
 
             if current_temp is not None:
                 current_temp = round(current_temp, 1)
@@ -261,7 +261,7 @@ class Plugin(BasePlugin):
                     parts.append(f"Precip {precip_now}%")
                 return self._trim_to_max_bytes(" | ".join(parts))
 
-            slots = hourly_config.get(mode_key, hourly_config["weather"])["slots"]
+            slots = hourly_config.get(mode_key, hourly_config["weather"])["slots"]  # type: ignore[index]
             return self._build_hourly_forecast(
                 current_temp,
                 current_weather_code,

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -207,11 +207,13 @@ class Plugin(BasePlugin):
             if units == "imperial":
                 if current_temp is not None:
                     current_temp = current_temp * 9 / 5 + 32
+                imperial_forecasts = {}
                 for key, values in forecast_hours.items():
                     t, p, w, dflag, *rest = values
                     if t is not None:
                         t = t * 9 / 5 + 32
-                    forecast_hours[key] = (t, p, w, dflag, *rest)  # type: ignore[arg-type]
+                    imperial_forecasts[key] = (t, p, w, dflag, *rest)
+                forecast_hours = imperial_forecasts
 
             if current_temp is not None:
                 current_temp = round(current_temp, 1)

--- a/src/mmrelay/windows_utils.py
+++ b/src/mmrelay/windows_utils.py
@@ -39,14 +39,14 @@ def setup_windows_console() -> None:
     try:
         # Enable UTF-8 output on Windows
         if hasattr(sys.stdout, "reconfigure"):
-            sys.stdout.reconfigure(encoding="utf-8")
+            sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
         if hasattr(sys.stderr, "reconfigure"):
-            sys.stderr.reconfigure(encoding="utf-8")
+            sys.stderr.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
 
         # Enable ANSI color codes on Windows 10+
         import ctypes
 
-        kernel32 = ctypes.windll.kernel32
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
         ENABLE_VTP = 0x0004  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
         for handle in (-11, -12):  # STD_OUTPUT_HANDLE, STD_ERROR_HANDLE
             h = kernel32.GetStdHandle(handle)

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -285,14 +285,14 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         Test that the plugin's get_matrix_commands method returns the expected list of matrix commands.
         """
         commands = self.plugin.get_matrix_commands()
-        self.assertEqual(commands, ["weather", "hourly", "weekly"])
+        self.assertEqual(commands, ["weather", "hourly", "daily"])
 
     def test_get_mesh_commands(self):
         """
-        Test that the plugin's get_mesh_commands method returns the expected list of mesh commands.
+        Test that the plugin's get_mesh_commands method returns the expected list of mesh commands commands.
         """
         commands = self.plugin.get_mesh_commands()
-        self.assertEqual(commands, ["weather", "hourly", "weekly"])
+        self.assertEqual(commands, ["weather", "hourly", "daily"])
 
     def test_parse_mesh_command_requires_prefix(self):
         """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR applies broad, non-functional type-focused changes across the codebase to improve static typing and reduce spurious type-checker warnings. Most edits add or refine type annotations, introduce targeted # type: ignore comments for third-party or platform-specific APIs, and adjust some module-level imports; no intentional runtime behavior or public API signature changes were made. One defensive import-time change in plugin_loader attempts to resolve/create a plugins/deps directory and append it to sys.path when possible.

Key changes

Features
- plugin_loader.py
  - Adds module-private _PLUGIN_DEPS_DIR: str | None and best-effort logic to resolve/create a plugins/deps directory and append it to sys.path to make plugin dependencies importable; logs and leaves None if resolution/creation fails.

Refactors (type annotations and hinting)
- cli_utils.py
  - Added from types import ModuleType and annotated the certifi fallback: certifi: ModuleType | None = None with targeted type-ignore.
- db_runtime.py
  - Annotated DatabaseManager context managers to return Generator[sqlite3.Cursor, None, None] (added typing import Generator).
- db_utils.py
  - Added explicit local variable annotations: database_cfg and legacy_cfg as dict[str, Any].
- e2ee_utils.py
  - Annotated local lists: warnings and room_lines as list[str].
- log_utils.py
  - Imported Any and annotated logging configuration and handler variables (e.g., logging.Handler).
- main.py
  - Minor aliasing in the __main__ entry: import main as cli_main then call cli_main(); no behavioral change.
- meshtastic_utils.py
  - Replaced some TYPE_CHECKING stubs with runtime imports plus targeted type-ignore annotations; refined awaitable typing in _wait_for_result.
- plugins (map_plugin.py, weather_plugin.py)
  - Added localized type-ignore annotations around parsing and third-party import sites (zoom, image_size, offsets, forecast_hours, node iteration).
  - weather_plugin.py: changed mesh_commands third entry from "weekly" to "daily" (see tests below).
- windows_utils.py
  - Added type-ignore[attr-defined] on sys.stdout/stderr.reconfigure calls and kernel32 assignment to silence static checks.

Type-check suppression adjustments
- Added targeted # type: ignore comments where conditional or third-party imports and platform-specific APIs produce false positives (Bleak typings, cairo, certifi fallback, plugin imports, stdout/stderr reconfigure, etc.).

Import/structure and tooling updates
- Added typing imports (Any, Generator, ModuleType) as needed and simplified some TYPE_CHECKING-guarded stubs in favor of runtime imports with suppression.
- CI/workflow action bumps:
  - .github/workflows/*: upload-artifact steps updated from actions/upload-artifact@v5 → @v6 in several workflows.
  - Cache action bumped actions/cache@v4 → @v5 in test workflow.
- Dependency bumps:
  - requirements.txt and setup.py: matplotlib 3.10.7 → 3.10.8.

Tests
- tests/test_weather_plugin.py updated to expect ["weather", "hourly", "daily"] (replacing "weekly").

Breaking changes / migration notes

- No runtime-breaking changes expected. Most edits are type annotations and suppression only, and public APIs were not intentionally modified.
- One behavior-impact risk: plugin_loader now performs import-time filesystem/sys.path interaction to create/append plugins/deps when resolvable. This is defensive and logged on failure, but reviewers should be aware of the new import-time side effect.
- Tests updated to reflect weather plugin command change from "weekly" → "daily"; ensure callers/tests expecting "weekly" are updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->