### PR TITLE
Mark messages as handled when plugin timeout occurs

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,7 +23,7 @@ lint:
     - actionlint@1.7.9
     - bandit@1.9.2
     - black@25.12.0
-    - checkov@3.2.495
+    - checkov@3.2.496
     - git-diff-check
     - isort@7.0.0
     - markdownlint@0.47.0

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1142,7 +1142,7 @@ def on_meshtastic_message(packet, interface):
                             plugin_timeout,
                             exc,
                         )
-                        found_matching_plugin = False
+                        found_matching_plugin = True
                     if found_matching_plugin:
                         logger.debug(f"Processed by plugin {plugin.plugin_name}")
                 except Exception:
@@ -1234,7 +1234,7 @@ def on_meshtastic_message(packet, interface):
                             plugin_timeout,
                             exc,
                         )
-                        found_matching_plugin = False
+                        found_matching_plugin = True
                     if found_matching_plugin:
                         logger.debug(
                             f"Processed {portnum} with plugin {plugin.plugin_name}"

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -839,12 +839,12 @@ async def reconnect():
 def on_meshtastic_message(packet, interface):
     """
     Route an incoming Meshtastic packet to configured Matrix rooms or installed plugins according to runtime configuration.
-    
+
     Processes a decoded Meshtastic packet and, depending on interaction settings and packet contents, will:
     - Relay reactions (emoji replies) and plain replies to the mapped Matrix event/room when enabled.
     - Relay ordinary text messages to all Matrix rooms mapped to the Meshtastic channel unless the message is a direct message to the relay node or a plugin handles it.
     - Dispatch non-text or otherwise unhandled packets to installed plugins, waiting up to the configured per‑plugin timeout for a handler to claim the message.
-    
+
     Behavior notes:
     - Respects interaction settings for reactions and replies.
     - Determines channel from packet or portnum and skips messages from unmapped channels.
@@ -852,7 +852,7 @@ def on_meshtastic_message(packet, interface):
     - Attempts to resolve sender longname/shortname from the database or the provided interface and falls back to sender ID.
     - Uses the provided interface to determine the relay node ID and node metadata.
     - Schedules Matrix relay coroutines in the event loop and applies a per-plugin timeout when awaiting plugin handlers.
-    
+
     Parameters:
         packet (dict): Decoded Meshtastic packet. Expected keys include 'decoded' (may contain 'text', 'replyId', 'portnum', and optional 'emoji'), 'fromId' or 'from' (sender id), 'to' (destination id), 'id' (packet id), and optional 'channel'.
         interface: Meshtastic interface used to resolve node information and the relay node id. Must provide .myInfo.my_node_num and a .nodes mapping used to enrich sender metadata.

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -899,6 +899,7 @@ def _run(
             )
             if delay:
                 time.sleep(delay)
+    raise RuntimeError("Should not reach here")
 
 
 def _run_git(

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -35,6 +35,16 @@ from mmrelay.meshtastic_utils import (
 class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     """Test cases for Meshtastic utilities edge cases and error handling."""
 
+    class _TimeoutFuture:
+        """Helper class to simulate a future that always times out."""
+
+        def __init__(self):
+            self.calls = []
+
+        def result(self, timeout=None):
+            self.calls.append(timeout)
+            raise ConcurrentTimeoutError("Plugin timeout")
+
     def setUp(self):
         """
         Resets global state variables in mmrelay.meshtastic_utils to ensure each test runs in isolation.
@@ -723,15 +733,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "!12345678": {"user": {"id": "!12345678", "longName": "TestNode"}}
         }
 
-        class TimeoutFuture:
-            def __init__(self):
-                self.calls = []
-
-            def result(self, timeout=None):
-                self.calls.append(timeout)
-                raise ConcurrentTimeoutError("Plugin timeout")
-
-        future = TimeoutFuture()
+        future = self._TimeoutFuture()
 
         plugin = MagicMock()
         plugin.plugin_name = "test_plugin"
@@ -800,15 +802,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
                 "!67890": {"user": {"id": "!67890", "longName": "TestNode"}}
             }
 
-            class TimeoutFuture:
-                def __init__(self):
-                    self.calls = []
-
-                def result(self, timeout=None):
-                    self.calls.append(timeout)
-                    raise ConcurrentTimeoutError("Plugin timeout")
-
-            future = TimeoutFuture()
+            future = self._TimeoutFuture()
 
             plugin = MagicMock()
             plugin.plugin_name = "test_plugin"
@@ -872,16 +866,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "!12345678": {"user": {"id": "!12345678", "longName": "TestNode"}}
         }
 
-        class TimeoutFuture:
-            def __init__(self):
-                self.calls = []
-
-            def result(self, timeout=None):
-                self.calls.append(timeout)
-                raise ConcurrentTimeoutError("Plugin timeout")
-
-        future = TimeoutFuture()
-
+        future = self._TimeoutFuture()
         plugin = MagicMock()
         plugin.plugin_name = "telemetry_plugin"
         plugin.handle_meshtastic_message = AsyncMock(return_value=True)

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -41,7 +41,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         def __init__(self):
             """
             Initialize the instance.
-            
+
             Creates an empty list `calls` used to record timeout values.
             """
             self.calls = []
@@ -49,12 +49,12 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         def result(self, timeout=None):
             """
             Simulate retrieving a future's result that always times out and records the provided timeout.
-            
+
             Appends the given `timeout` value to `self.calls` and then raises a ConcurrentTimeoutError to simulate a plugin timeout.
-            
+
             Parameters:
                 timeout (float | None): The timeout value passed when requesting the result; may be None.
-            
+
             Raises:
                 ConcurrentTimeoutError: Always raised with message "Plugin timeout".
             """
@@ -64,7 +64,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     def setUp(self):
         """
         Reset mmrelay.meshtastic_utils global state so each test runs in isolation.
-        
+
         Resets the following module-level variables to their default test values:
         - meshtastic_client -> None
         - reconnecting -> False
@@ -745,7 +745,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     def test_on_meshtastic_message_plugin_timeout_prevents_relay(self):
         """
         Ensure a plugin timeout prevents the message from being relayed to Matrix.
-        
+
         Verifies that when a plugin times out while processing an incoming Meshtastic message:
         - the plugin timeout is logged,
         - the Matrix relay is not invoked, and
@@ -857,7 +857,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     def test_on_meshtastic_message_non_text_plugin_timeout_prevents_relay(self):
         """
         Ensure a plugin timeout for non-text (telemetry) messages prevents relaying the message to Matrix.
-        
+
         Asserts that when a plugin handling a telemetry packet times out, a timeout warning is logged and the message is treated as handled (so it is not relayed to Matrix); also verifies a debug log indicating the plugin processed the telemetry message.
         """
         packet = {
@@ -914,7 +914,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     def test_on_meshtastic_message_non_text_plugin_no_match_continues(self):
         """
         Verify non-text message processing continues to subsequent plugins when an earlier plugin does not handle it.
-        
+
         Ensures that if a plugin's handle_meshtastic_message returns False for a non-text packet, the dispatcher continues to the next plugin, and when a later plugin handles the message the Matrix relay is not invoked.
         """
         packet = {
@@ -969,7 +969,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     def test_on_meshtastic_message_non_text_plugin_match_skips_remaining(self):
         """
         Ensure a non-text Meshtastic message handled by a plugin prevents remaining plugins from running.
-        
+
         Asserts that when the first plugin returns True for a non-text message (e.g., a POSITION_APP packet),
         subsequent plugins are not invoked, the Matrix relay is not called, and a debug message is emitted
         indicating the handling plugin's name.

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -356,7 +356,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
                 7.5,
                 timeout_exc,
             )
-            self.assertEqual(mock_submit_coro.call_count, 2)
+            self.assertEqual(mock_submit_coro.call_count, 1)
 
     def test_on_meshtastic_message_invalid_plugin_timeout_falls_back(self):
         """Ensure invalid plugin_timeout values log a warning and fall back to default."""
@@ -414,7 +414,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             patch(
                 "mmrelay.meshtastic_utils._submit_coro",
                 side_effect=[future, MagicMock()],
-            ),
+            ) as mock_submit_coro,
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", rooms),
             patch("mmrelay.meshtastic_utils.get_longname", return_value="Long"),
@@ -438,6 +438,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
                 5.0,
                 timeout_exc,
             )
+            self.assertEqual(mock_submit_coro.call_count, 1)
 
     def test_on_meshtastic_message_matrix_relay_failure(self):
         """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR changes plugin-timeout handling in the Meshtastic message processor so that when a plugin times out waiting for a result, the message is marked as "handled" by that plugin. Previously a timeout left the `found_matching_plugin` flag false, causing the message to be treated as unhandled and relayed to Matrix. The change sets the flag to true on timeout for both text and non-text message paths and adds tests covering these behaviors.

## Key Changes

**Fixes**
- Corrected timeout flag logic in on_meshtastic_message:
  - When a plugin times out (asyncio.TimeoutError or concurrent.futures.TimeoutError), `found_matching_plugin` is now set to True instead of False for text-message handling.
  - Applied the same correction for non-text message handling (telemetry/position/etc.), ensuring consistent behavior across message types.
  - As a result, messages where a plugin timed out are no longer relayed to Matrix (they are treated as handled by the plugin attempt).

**Tests**
- Added and expanded tests in tests/test_meshtastic_utils_edge_cases.py to cover:
  - Plugin timeout behavior preventing Matrix relay for both broadcast and direct messages.
  - Non-text message plugin interactions (telemetry/position) including timeouts, continuing when no match, and skipping subsequent plugins after a handled message.
  - Plugin exception handling and other edge cases related to Meshtastic connectivity and malformed packets.
- Introduced test helpers/mocks (e.g., timeout-failing futures / DummyFuture) and adjusted expectations where relay calls are reduced because of the corrected logic.

**Refactors / Misc**
- Minor test imports/patch adjustments (e.g., adding ANY from unittest.mock and exposing mock context managers) to support new tests.
- No public API or function signatures were changed.

## Breaking Changes / Migration Notes

- Behavioral change only: messages that previously would have been relayed to Matrix after a plugin timeout will now be treated as handled and will not be relayed. No code migration is required, but operators should be aware of the changed routing behavior if they relied on timeouts causing fallthrough to Matrix relay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->