### PR TITLE
Add portnum helper and enhance non-text message logging

### DIFF
--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -883,35 +883,34 @@ def _get_packet_details(
     """
     details = {}
 
-    if decoded and isinstance(decoded, dict):
-        if portnum_name == "TELEMETRY_APP":
-            telemetry = decoded.get("telemetry", {})
-            if telemetry and isinstance(telemetry, dict):
-                if "deviceMetrics" in telemetry:
-                    metrics = telemetry["deviceMetrics"]
-                    if isinstance(metrics, dict):
-                        batt = metrics.get("batteryLevel")
-                        voltage = metrics.get("voltage")
-                        if batt is not None:
-                            details["batt"] = f"{batt}%"
-                        if voltage is not None:
-                            details["voltage"] = f"{voltage:.2f}V"
-                elif "environmentMetrics" in telemetry:
-                    metrics = telemetry["environmentMetrics"]
-                    if isinstance(metrics, dict):
-                        temp = metrics.get("temperature")
-                        humidity = metrics.get("relativeHumidity")
-                        if temp is not None:
-                            details["temp"] = f"{temp:.1f}°C"
-                        if humidity is not None:
-                            details["humidity"] = f"{humidity:.0f}%"
+    if decoded and isinstance(decoded, dict) and portnum_name == "TELEMETRY_APP":
+        telemetry = decoded.get("telemetry", {})
+        if telemetry and isinstance(telemetry, dict):
+            if "deviceMetrics" in telemetry:
+                metrics = telemetry["deviceMetrics"]
+                if isinstance(metrics, dict):
+                    batt = metrics.get("batteryLevel")
+                    voltage = metrics.get("voltage")
+                    if batt is not None:
+                        details["batt"] = f"{batt}%"
+                    if voltage is not None:
+                        details["voltage"] = f"{voltage:.2f}V"
+            elif "environmentMetrics" in telemetry:
+                metrics = telemetry["environmentMetrics"]
+                if isinstance(metrics, dict):
+                    temp = metrics.get("temperature")
+                    humidity = metrics.get("relativeHumidity")
+                    if temp is not None:
+                        details["temp"] = f"{temp:.1f}°C"
+                    if humidity is not None:
+                        details["humidity"] = f"{humidity:.0f}%"
 
     signal_info = []
     rssi = packet.get("rxRssi")
-    if rssi is not None and rssi != 0:
+    if rssi is not None:
         signal_info.append(f"RSSI:{rssi}")
     snr = packet.get("rxSnr")
-    if snr is not None and snr != 0:
+    if snr is not None:
         signal_info.append(f"SNR:{snr:.1f}")
     if signal_info:
         details["signal"] = " ".join(signal_info)

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -880,26 +880,21 @@ def _get_packet_details(
     details = {}
 
     if decoded and isinstance(decoded, dict) and portnum_name == "TELEMETRY_APP":
-        telemetry = decoded.get("telemetry", {})
-        if telemetry and isinstance(telemetry, dict):
-            if "deviceMetrics" in telemetry:
-                metrics = telemetry["deviceMetrics"]
-                if isinstance(metrics, dict):
-                    batt = metrics.get("batteryLevel")
-                    voltage = metrics.get("voltage")
-                    if batt is not None:
-                        details["batt"] = f"{batt}%"
-                    if voltage is not None:
-                        details["voltage"] = f"{voltage:.2f}V"
-            elif "environmentMetrics" in telemetry:
-                metrics = telemetry["environmentMetrics"]
-                if isinstance(metrics, dict):
-                    temp = metrics.get("temperature")
-                    humidity = metrics.get("relativeHumidity")
-                    if temp is not None:
-                        details["temp"] = f"{temp:.1f}°C"
-                    if humidity is not None:
-                        details["humidity"] = f"{humidity:.0f}%"
+        if (telemetry := decoded.get("telemetry")) and isinstance(telemetry, dict):
+            if (metrics := telemetry.get("deviceMetrics")) and isinstance(
+                metrics, dict
+            ):
+                if (batt := metrics.get("batteryLevel")) is not None:
+                    details["batt"] = f"{batt}%"
+                if (voltage := metrics.get("voltage")) is not None:
+                    details["voltage"] = f"{voltage:.2f}V"
+            elif (metrics := telemetry.get("environmentMetrics")) and isinstance(
+                metrics, dict
+            ):
+                if (temp := metrics.get("temperature")) is not None:
+                    details["temp"] = f"{temp:.1f}°C"
+                if (humidity := metrics.get("relativeHumidity")) is not None:
+                    details["humidity"] = f"{humidity:.0f}%"
 
     signal_info = []
     rssi = packet.get("rxRssi")

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1476,16 +1476,13 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
             decoded.get("portnum") if decoded and isinstance(decoded, dict) else None
         )
         portnum_name = _get_portnum_name(portnum)
-        sender = packet.get("fromId") or packet.get("from")
-        packet_id = packet.get("id")
-        channel = packet.get("channel")
+        details_map = {
+            "from": packet.get("fromId") or packet.get("from"),
+            "channel": packet.get("channel"),
+            "id": packet.get("id"),
+        }
         details = [f"type={portnum_name}"]
-        if sender is not None:
-            details.append(f"from={sender}")
-        if channel is not None:
-            details.append(f"channel={channel}")
-        if packet_id is not None:
-            details.append(f"id={packet_id}")
+        details.extend(f"{k}={v}" for k, v in details_map.items() if v is not None)
         logger.debug(f"Received non-text Meshtastic message: {', '.join(details)}")
 
     # Check if config is available

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mmrelay.meshtastic_utils import (
     _get_device_metadata,
+    _get_portnum_name,
     _resolve_plugin_timeout,
     check_connection,
     connect_meshtastic,

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -747,11 +747,11 @@ class TestGetPacketDetails(unittest.TestCase):
         self.assertEqual(result["signal"], "RSSI:-64 SNR:6.0")
 
     def test_get_packet_details_with_zero_signal(self):
-        """Test with zero signal values (should be ignored)."""
+        """Test with zero signal values (should still be logged)."""
         decoded = {}
         packet = {"from": 123, "rxRssi": 0, "rxSnr": 0.0}
         result = _get_packet_details(decoded, packet, "TELEMETRY_APP")
-        self.assertNotIn("signal", result)
+        self.assertEqual(result["signal"], "RSSI:0 SNR:0.0")
 
     def test_get_packet_details_with_relay_info(self):
         """Test with relay node information."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR improves logging for non-text Meshtastic messages and extends test coverage. It adds a helper to map Meshtastic portnum values to readable names and extracts structured packet details (telemetry, signal, relay, priority) so non-text messages are logged with richer, machine-friendly metadata while keeping existing text vs non-text processing behavior. Tests and minor docstring updates were also added.

## Key Changes

**Features**
- Added _get_portnum_name(portnum) in mmrelay/meshtastic_utils.py to resolve numeric or string portnum values to human-readable names, returning explicit UNKNOWN variants for None, empty strings, unknown integers, or unsupported types.
- Added _get_packet_details(decoded, packet, portnum_name) to build a structured details map for logging containing:
  - Telemetry: battery, voltage, temperature, humidity (when present in decoded payload).
  - Signal: RSSI and SNR.
  - Relay node and priority.
- Non-text logging now logs type={portnum_name} and a consolidated details_map (from, channel, id plus packet details) for clearer, machine-friendly output.
- Added docstrings/clarifications for related functions (minor documentation updates).

**Fixes**
- Ensure zero-valued signal metrics (e.g., RSSI = 0, SNR = 0) are included in packet-details logging; tests added/updated to verify inclusion.

**Refactors / Enhancements**
- Refactored non-text message logging in on_meshtastic_message to:
  - Resolve portnum once via _get_portnum_name.
  - Merge structured packet details from _get_packet_details into a single details_map.
  - Replace a generic non-text message log with a single structured debug line listing type and key=value pairs.
- Centralized packet detail extraction/formatting for consistent logging and easier testing.

**Tests**
- Added comprehensive unit tests for _get_portnum_name and _get_packet_details covering None/empty inputs, telemetry fields, signal info (including zero values), relay info, priority, and non-telemetry cases.
- Updated existing tests to assert the new logging format for non-text messages and to verify PortNum.Name resolution is used.

## Breaking Changes / Migration
- None. Message processing and behavior remain backward compatible; only the logging format for non-text Meshtastic messages changed (tests and log expectations were updated accordingly).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->