### PR TITLE
Enhance BLE connection reliability with timeout handling

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -27,13 +27,11 @@ lint:
     - git-diff-check
     - isort@7.0.0
     - markdownlint@0.47.0
-    - osv-scanner@2.3.1
-    - prettier@3.7.4
-    - ruff@0.14.10
+    - osv-scanner@2.3.2
+    - prettier@3.8.0
+    - ruff@0.14.11
     - trufflehog@3.92.4
-    - yamllint@1.37.1
-  # Remove map_plugin.py after staticmaps is updated and we're able to work on it again
-  # For more info: https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/117
+    - yamllint@1.38.0
   ignore:
     - linters: [ALL]
       paths:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -29,8 +29,8 @@ lint:
     - markdownlint@0.47.0
     - osv-scanner@2.3.2
     - prettier@3.8.0
-    - ruff@0.14.11
-    - trufflehog@3.92.4
+    - ruff@0.14.13
+    - trufflehog@3.92.5
     - yamllint@1.38.0
   ignore:
     - linters: [ALL]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -22,7 +22,7 @@ lint:
     - taplo@0.10.0
     - actionlint@1.7.10
     - bandit@1.9.2
-    - black@25.12.0
+    - black@26.1.0
     - checkov@3.2.497
     - git-diff-check
     - isort@7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ pytest-env==1.2.0
 pytest-timeout==2.4.0
 mypy==1.19.1
 pyright==1.1.407
-types-PyYAML  # Type stubs for PyYAML to enable strict type checking
+types-PyYAML==6.0.12.20250915  # Type stubs for PyYAML to enable strict type checking

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pytest-env==1.2.0
 pytest-timeout==2.4.0
 mypy==1.19.1
 pyright==1.1.407
+types-PyYAML  # Type stubs for PyYAML to enable strict type checking

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "dev": [
             "pyright==1.1.407",
             "mypy==1.19.1",
-            "types-PyYAML",
+            "types-PyYAML==6.0.12.20250915",
         ],
         "e2e": [
             "matrix-nio[e2e]==0.25.2",

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "dev": [
             "pyright==1.1.407",
             "mypy==1.19.1",
+            "types-PyYAML",
         ],
         "e2e": [
             "matrix-nio[e2e]==0.25.2",

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Mapping
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 # Import version from package
 from mmrelay import __version__
@@ -477,9 +477,7 @@ def _validate_e2ee_config(
         if store_path:
             expanded_path = os.path.expanduser(store_path)
             if not os.path.exists(expanded_path):
-                print(
-                    f"ℹ️  Note: E2EE store directory will be created: {expanded_path}"
-                )
+                print(f"Info: E2EE store directory will be created: {expanded_path}")
 
         print("✅ E2EE configuration is valid")
 

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -477,7 +477,9 @@ def _validate_e2ee_config(
         if store_path:
             expanded_path = os.path.expanduser(store_path)
             if not os.path.exists(expanded_path):
-                print(f"ℹ️  Note: E2EE store directory will be created: {expanded_path}")
+                print(
+                    f"ℹ️  Note: E2EE store directory will be created: {expanded_path}"
+                )
 
         print("✅ E2EE configuration is valid")
 

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Mapping
 from typing import Any
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 # Import version from package
 from mmrelay import __version__

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -6,8 +6,8 @@ import sys
 from typing import Any, cast
 
 import platformdirs
-import yaml
-from yaml.loader import SafeLoader
+import yaml  # type: ignore[import-untyped]
+from yaml.loader import SafeLoader  # type: ignore[import-untyped]
 
 # Import application constants
 from mmrelay.constants.app import APP_AUTHOR, APP_NAME
@@ -984,8 +984,8 @@ def get_meshtastic_config_value(
                 from mmrelay.cli_utils import msg_suggest_check_config
             except ImportError:
 
-                def msg_suggest_check_config():
-                    return ""  # type: ignore[assignment]
+                def msg_suggest_check_config() -> str:
+                    return ""
 
             logger.error(
                 f"Missing required configuration: meshtastic.{key}\n"

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -987,7 +987,7 @@ def get_meshtastic_config_value(
                 def msg_suggest_check_config() -> str:
                     """
                     Provide a fallback suggestion string for checking configuration when the real helper is unavailable.
-                    
+
                     Returns:
                         suggestion (str): An empty string indicating no suggestion is available.
                     """

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -985,6 +985,12 @@ def get_meshtastic_config_value(
             except ImportError:
 
                 def msg_suggest_check_config() -> str:
+                    """
+                    Provide a fallback suggestion string for checking configuration when the real helper is unavailable.
+                    
+                    Returns:
+                        suggestion (str): An empty string indicating no suggestion is available.
+                    """
                     return ""
 
             logger.error(

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -300,7 +300,7 @@ async def main(config: dict[str, Any]) -> None:
                 def _close_meshtastic() -> None:
                     """
                     Close and clean up the active Meshtastic client connection.
-                    
+
                     If a BLE interface is the active client, perform an explicit BLE disconnect to release the adapter.
                     Clears meshtastic_utils.meshtastic_client (and meshtastic_utils.meshtastic_iface when applicable).
                     Does nothing if no client is present.

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -334,9 +334,9 @@ async def main(config: dict[str, Any]) -> None:
                     # Best-effort cancellation; the underlying close may be
                     # stuck in BLE/DBus, but we cannot block shutdown.
                     future.cancel()
-                except Exception as e:  # noqa: BLE001 - shutdown must keep going
-                    meshtastic_logger.error(
-                        f"Unexpected error during Meshtastic client close: {e}"
+                except Exception:  # noqa: BLE001 - shutdown must keep going
+                    meshtastic_logger.exception(
+                        "Unexpected error during Meshtastic client close"
                     )
                 else:
                     meshtastic_logger.info("Meshtastic client closed successfully")

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -497,6 +497,7 @@ def run_main(args: Any) -> int:
         asyncio.run(main(config))
         return 0
     except KeyboardInterrupt:
+        meshtastic_utils.shutting_down = True
         logger.info("Interrupted by user. Exiting.")
         return 0
     except Exception:  # noqa: BLE001 — top-level guard to log and exit cleanly

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -299,10 +299,11 @@ async def main(config: dict[str, Any]) -> None:
 
                 def _close_meshtastic() -> None:
                     """
-                    Close the active Meshtastic client connection.
-
-                    Does nothing if no Meshtastic client is present in meshtastic_utils.meshtastic_client.
-                    Waits for close to complete before returning.
+                    Close and clean up the active Meshtastic client connection.
+                    
+                    If a BLE interface is the active client, perform an explicit BLE disconnect to release the adapter.
+                    Clears meshtastic_utils.meshtastic_client (and meshtastic_utils.meshtastic_iface when applicable).
+                    Does nothing if no client is present.
                     """
                     if meshtastic_utils.meshtastic_client:
                         if (

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -334,10 +334,12 @@ async def main(config: dict[str, Any]) -> None:
                     # Best-effort cancellation; the underlying close may be
                     # stuck in BLE/DBus, but we cannot block shutdown.
                     future.cancel()
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - shutdown must keep going
                     meshtastic_logger.error(
                         f"Unexpected error during Meshtastic client close: {e}"
                     )
+                else:
+                    meshtastic_logger.info("Meshtastic client closed successfully")
                 finally:
                     try:
                         # Do not wait for shutdown; if close hangs we still
@@ -346,8 +348,6 @@ async def main(config: dict[str, Any]) -> None:
                     except TypeError:
                         # cancel_futures is unsupported on older Python versions.
                         executor.shutdown(wait=False)
-
-                meshtastic_logger.info("Meshtastic client closed successfully")
             except concurrent.futures.TimeoutError:
                 meshtastic_logger.warning(
                     "Meshtastic client close timed out - forcing shutdown"

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -2950,17 +2950,10 @@ async def handle_matrix_reply(
         bool: `True` if a mapping was found and the reply was queued to Meshtastic, `False` otherwise.
     """
     # Look up the original message in the message map
-    from unittest.mock import Mock
-
-    if isinstance(get_message_map_by_matrix_event_id, Mock):
-        # Tests often patch this helper; calling it inline avoids hanging the
-        # event loop shutdown on a default executor thread.
-        orig = get_message_map_by_matrix_event_id(reply_to_event_id)
-    else:
-        loop = asyncio.get_running_loop()
-        orig = await loop.run_in_executor(
-            None, get_message_map_by_matrix_event_id, reply_to_event_id
-        )
+    loop = asyncio.get_running_loop()
+    orig = await loop.run_in_executor(
+        None, get_message_map_by_matrix_event_id, reply_to_event_id
+    )
     if not orig:
         logger.debug(
             f"Original message for Matrix reply not found in DB: {reply_to_event_id}"

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -114,7 +114,7 @@ try:
     NioRemoteTransportError = nio_exceptions.RemoteTransportError
     NioLoginError = nio_responses.LoginError
     NioLogoutError = nio_responses.LogoutError
-except ImportError:
+except (ImportError, AttributeError):
     # Fallback for test environments where nio imports might fail
     class _NioStubError(Exception):
         """Stub exception for nio errors in test mode"""

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -105,16 +105,15 @@ from mmrelay.message_queue import get_message_queue, queue_message
 # Import nio exception types with error handling for test environments.
 # matrix-nio is not marked py.typed in our env; keep import-untyped for mypy --strict.
 try:
-    from nio.exceptions import (
-        LocalProtocolError as NioLocalProtocolError,  # type: ignore[import-untyped]
-    )
-    from nio.exceptions import LocalTransportError as NioLocalTransportError
-    from nio.exceptions import RemoteProtocolError as NioRemoteProtocolError
-    from nio.exceptions import RemoteTransportError as NioRemoteTransportError
-    from nio.responses import (
-        LoginError as NioLoginError,  # type: ignore[import-untyped]
-    )
-    from nio.responses import LogoutError as NioLogoutError
+    import nio.exceptions as nio_exceptions  # type: ignore[import-untyped]
+    import nio.responses as nio_responses  # type: ignore[import-untyped]
+
+    NioLocalProtocolError = nio_exceptions.LocalProtocolError
+    NioLocalTransportError = nio_exceptions.LocalTransportError
+    NioRemoteProtocolError = nio_exceptions.RemoteProtocolError
+    NioRemoteTransportError = nio_exceptions.RemoteTransportError
+    NioLoginError = nio_responses.LoginError
+    NioLogoutError = nio_responses.LogoutError
 except ImportError:
     # Fallback for test environments where nio imports might fail
     class _NioStubError(Exception):

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -16,10 +16,10 @@ import meshtastic  # type: ignore[import-untyped]
 import meshtastic.ble_interface  # type: ignore[import-untyped]
 import meshtastic.serial_interface  # type: ignore[import-untyped]
 import meshtastic.tcp_interface  # type: ignore[import-untyped]
-import serial  # For serial port exceptions
-import serial.tools.list_ports  # Import serial tools for port listing
+import serial  # type: ignore[import-untyped]  # For serial port exceptions
+import serial.tools.list_ports  # type: ignore[import-untyped]  # Import serial tools for port listing
 from meshtastic.protobuf import mesh_pb2, portnums_pb2  # type: ignore[import-untyped]
-from pubsub import pub
+from pubsub import pub  # type: ignore[import-untyped]
 
 from mmrelay.config import get_meshtastic_config_value
 from mmrelay.constants.config import (
@@ -74,7 +74,7 @@ MAX_TIMEOUT_RETRIES_INFINITE = 5
 
 # Import BLE exceptions conditionally
 try:
-    from bleak.exc import BleakDBusError, BleakError  # type: ignore[misc,assignment]
+    from bleak.exc import BleakDBusError, BleakError
 except ImportError:
     BleakDBusError = Exception  # type: ignore[misc,assignment]
     BleakError = Exception  # type: ignore[misc,assignment]
@@ -952,7 +952,7 @@ def _get_portnum_name(portnum: Any) -> str:
 
     if isinstance(portnum, int):
         try:
-            return portnums_pb2.PortNum.Name(portnum)  # type: ignore[arg-type]
+            return portnums_pb2.PortNum.Name(portnum)  # type: ignore[no-any-return]
         except ValueError:
             return f"UNKNOWN (portnum={portnum})"
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -167,7 +167,12 @@ def _submit_coro(
 
         coro = _await_wrapper(coro)
     loop = loop or event_loop
-    if loop and isinstance(loop, asyncio.AbstractEventLoop) and not loop.is_closed():
+    if (
+        loop
+        and isinstance(loop, asyncio.AbstractEventLoop)
+        and not loop.is_closed()
+        and loop.is_running()
+    ):
         return asyncio.run_coroutine_threadsafe(coro, loop)
     # Fallback: schedule on a real loop if present; tests can override this.
     try:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1420,6 +1420,9 @@ def connect_meshtastic(
                     wait_time,
                 )
                 time.sleep(wait_time)
+            else:
+                logger.exception("Connection failed after %s attempts", attempts)
+                return None
         except Exception as e:
             if shutting_down:
                 logger.debug("Shutdown in progress. Aborting connection attempts.")

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1221,7 +1221,6 @@ def connect_meshtastic(
                                         "This may indicate a stale BlueZ connection or Bluetooth adapter issue."
                                     )
                                     meshtastic_iface = None
-                                    executor.shutdown(wait=False)
                                     raise TimeoutError(
                                         f"BLE connection attempt timed out for {ble_address}. "
                                         "Try: 1) Restarting BlueZ: 'sudo systemctl restart bluetooth', "
@@ -1273,7 +1272,6 @@ def connect_meshtastic(
                             # Don't use iface if connect() timed out - it may be in an inconsistent state
                             iface = None
                             meshtastic_iface = None
-                            executor.shutdown(wait=False)
                             raise TimeoutError(
                                 f"BLE connect() timed out for {ble_address}. "
                                 "BlueZ may be in a bad state. Try: "

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -210,7 +210,7 @@ def _submit_coro(
 def _clear_ble_future(done_future: Future[Any]) -> None:
     """
     Release the module's active BLE future reference if it matches the completed future.
-    
+
     If `done_future` is the currently tracked BLE executor future, clear the tracked
     future and its associated address; also remove the per-address timeout count.
     Parameters:
@@ -241,7 +241,7 @@ def _schedule_ble_future_cleanup(
     def _cleanup() -> None:
         """
         Clear a stale BLE worker future when it exceeds the watchdog timeout.
-        
+
         If the provided future is still running and remains the active BLE future, logs a warning including the watchdog duration, BLE address, and reason, then clears the stale future.
         """
         if future.done():
@@ -266,12 +266,12 @@ def _schedule_ble_future_cleanup(
 def _record_ble_timeout(ble_address: str) -> int:
     """
     Increment the recorded BLE timeout count for the given BLE address.
-    
+
     This operation is thread-safe.
-    
+
     Parameters:
         ble_address (str): BLE device address to record the timeout for.
-    
+
     Returns:
         int: The updated timeout count for the specified BLE address (1 or greater).
     """
@@ -283,12 +283,12 @@ def _record_ble_timeout(ble_address: str) -> int:
 def _maybe_reset_ble_executor(ble_address: str, timeout_count: int) -> None:
     """
     Reset the BLE worker executor when an address has reached the timeout threshold.
-    
+
     Recreates the module's BLE executor and clears any active BLE future/state for the given
     BLE address when `timeout_count` meets or exceeds the configured reset threshold. Performs a
     best-effort cancellation and cleanup of a possibly stuck BLE task and resets the per-address
     timeout counter to zero.
-    
+
     Parameters:
         ble_address (str): BLE device address associated with the observed timeouts.
         timeout_count (int): Number of consecutive timeouts recorded for that address.
@@ -324,9 +324,9 @@ def _maybe_reset_ble_executor(ble_address: str, timeout_count: int) -> None:
 def _scan_for_ble_address(ble_address: str, timeout: float) -> bool:
     """
     Performs a best-effort BLE scan to check whether a device with the given address is discoverable.
-    
+
     If the Bleak library is unavailable or an active asyncio event loop is running, the function does not perform a scan and returns `false`.
-    
+
     Returns:
         `true` if the device address was observed in a scan within the given timeout; `false` if the device was not observed, the scan failed, Bleak is unavailable, or scanning was skipped due to an active event loop.
     """
@@ -341,7 +341,7 @@ def _scan_for_ble_address(ble_address: str, timeout: float) -> bool:
     async def _scan() -> bool:
         """
         Determine whether the target BLE device is discoverable within the scan timeout.
-        
+
         Returns:
             bool: `True` if a device with the target BLE address is discovered within the timeout, `False` otherwise (including when BLE discovery errors occur).
         """
@@ -383,7 +383,7 @@ def _scan_for_ble_address(ble_address: str, timeout: float) -> bool:
 def _is_ble_discovery_error(error: Exception) -> bool:
     """
     Determine whether an exception represents a BLE discovery or connection completion failure.
-    
+
     Returns:
         True if the exception indicates a BLE discovery or connection completion failure, False otherwise.
     """
@@ -491,7 +491,7 @@ def _run_blocking_with_timeout(
     def _runner() -> None:
         """
         Execute the enclosing scope's action callable, record any raised Exception into the nonlocal `action_error`, and mark completion by calling `done_event.set()`.
-        
+
         This function does not return a value; its observable effects are writing to the nonlocal `action_error` (set to the caught Exception on error) and setting the `done_event` to signal completion.
         """
         nonlocal action_error
@@ -523,15 +523,15 @@ def _wait_for_result(
 ) -> Any:
     """
     Wait for and return the resolved value of a future-like or awaitable object, enforcing a timeout.
-    
+
     Parameters:
         result_future (Any): A concurrent.futures.Future, asyncio Future/Task, awaitable, or object exposing a callable `result(timeout)` method. If None, the function returns False.
         timeout (float): Maximum seconds to wait for the result.
         loop (asyncio.AbstractEventLoop | None): Optional event loop to use; if omitted, the function will use a running loop or create a temporary loop as needed.
-    
+
     Returns:
         Any: The value produced by the resolved future or awaitable. Returns `False` when `result_future` is `None` or when the function refuses to block the currently running event loop and instead schedules the awaitable to run in the background.
-    
+
     Raises:
         asyncio.TimeoutError: If awaiting an asyncio awaitable times out.
         concurrent.futures.TimeoutError: If a concurrent.futures.Future times out.
@@ -561,10 +561,10 @@ def _wait_for_result(
     async def _runner() -> Any:
         """
         Await the captured awaitable and enforce the captured timeout.
-        
+
         Returns:
             The result returned by the awaitable.
-        
+
         Raises:
             asyncio.TimeoutError: If the awaitable does not complete before the timeout expires.
         """
@@ -778,12 +778,12 @@ def _get_name_or_none(
 def _get_device_metadata(client: Any) -> dict[str, Any]:
     """
     Retrieve firmware version and raw metadata output from a Meshtastic client.
-    
+
     Attempts to call client.localNode.getMetadata() (when present), captures any console output produced, and extracts a firmware version string if available.
-    
+
     Parameters:
         client (Any): Meshtastic client object expected to expose localNode.getMetadata(); if absent, metadata retrieval is skipped.
-    
+
     Returns:
         dict: {
             "firmware_version" (str): Parsed firmware version or "unknown" when not found,
@@ -817,7 +817,7 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
             # critical error output if the worker outlives the timeout.
             """
             Invoke the client's getMetadata() while capturing its standard output.
-            
+
             Calls client.localNode.getMetadata() with stdout redirected into the module's
             output_capture to prevent metadata noise from polluting process stdout; stderr
             is left unchanged. While the call runs, the module-level redirect_active flag
@@ -872,10 +872,10 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
         def _finalize_metadata_capture(done_future: Future[Any]) -> None:
             """
             Finalize capture state for a completed metadata retrieval future.
-            
+
             If the provided future matches the module-level metadata future, clear that reference.
             Also close the shared output capture stream if it is still open.
-            
+
             Parameters:
                 done_future (concurrent.futures.Future | asyncio.Future): The future that has completed and triggered finalization.
             """
@@ -946,18 +946,18 @@ def _sanitize_ble_address(address: str) -> str:
 def _validate_ble_connection_address(interface: Any, expected_address: str) -> bool:
     """
     Validate that a BLE interface is connected to the configured device address.
-    
+
     Compares the configured address to the interface's connected address after normalizing
     (both addresses have separators removed and are lowercased). Works with both the
     official and forked Meshtastic interface shapes by attempting common attribute paths.
     This is a best-effort check: if the connected address cannot be determined the
     function returns `True` to avoid false negatives; it returns `False` only when a
     determinate mismatch is detected.
-    
+
     Parameters:
         interface (Any): BLE interface object whose connected address should be inspected.
         expected_address (str): Configured BLE device address to validate against.
-    
+
     Returns:
         bool: `True` if the connected device matches `expected_address` or the address
         cannot be determined, `False` if a definitive mismatch is found.
@@ -1030,7 +1030,7 @@ def _disconnect_ble_by_address(address: str) -> None:
         async def disconnect_stale_connection() -> None:
             """
             Perform a best-effort disconnect of a stale BlueZ BLE connection for the target address.
-            
+
             Attempts to detect whether the Bleak client for the configured address is connected and, if so, issues a bounded series of disconnect attempts with timeouts and short settle delays. All errors and timeouts are suppressed (logged at debug/warning levels) so this function never raises; a final cleanup disconnect is always attempted.
             """
             BLEAK_EXCEPTIONS = (
@@ -1259,7 +1259,7 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
                         ) -> None:
                             """
                             Call the provided disconnect callable and wait briefly if it returns an awaitable.
-                            
+
                             Parameters:
                                 method (Callable[[], Any]): A zero-argument callable that performs a disconnect. If omitted, a module-level
                                     default `disconnect_method` is used. If the callable returns an awaitable, this function will wait up to
@@ -1328,7 +1328,7 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
                         ) -> None:
                             """
                             Call a disconnection callable and, if it returns an awaitable, wait up to 2 seconds for it to complete.
-                            
+
                             Parameters:
                                 method (Callable[[], Any]): A synchronous or asynchronous disconnect callable to invoke. If it returns an awaitable, this function will wait up to 2.0 seconds for completion.
                             """
@@ -1369,7 +1369,7 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
             def _close_sync(method: Callable[[], Any] = close_method) -> None:
                 """
                 Invoke a close-like callable and, if it returns an awaitable, wait up to 5 seconds for it to complete.
-                
+
                 Parameters:
                     method (Callable[[], Any]): A zero-argument function that performs a close/teardown action. If the callable returns an awaitable, this function will wait up to 5.0 seconds for completion.
                 """
@@ -1730,10 +1730,10 @@ def connect_meshtastic(
                                 ) -> Any:
                                     """
                                     Create a BLEInterface configured for Meshtastic BLE connections.
-                                    
+
                                     Parameters:
                                         kwargs (dict): Keyword arguments forwarded to the Meshtastic BLEInterface constructor (e.g., `address`, `adapter`, `auto_reconnect`, `timeout`). Valid keys depend on the Meshtastic BLEInterface implementation.
-                                    
+
                                     Returns:
                                         BLEInterface: A newly constructed Meshtastic BLEInterface instance.
                                     """
@@ -1859,7 +1859,7 @@ def connect_meshtastic(
                         def connect_iface(iface_param: Any) -> None:
                             """
                             Establishes the given interface by invoking its no-argument `connect()` method.
-                            
+
                             Parameters:
                                 iface_param (Any): An interface-like object whose `connect()` method will be called to open the underlying connection.
                             """

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -911,11 +911,7 @@ def _disconnect_ble_by_address(address: str) -> None:
             _fire_and_forget(disconnect_stale_connection(), loop=loop)
             return
 
-        if (
-            event_loop
-            and getattr(event_loop, "is_running", None)
-            and event_loop.is_running()
-        ):
+        if event_loop and getattr(event_loop, "is_running", lambda: False)():
             logger.debug(
                 "Using global event loop, waiting for disconnect task for %s",
                 address,

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -973,11 +973,14 @@ def _disconnect_ble_by_address(address: str) -> None:
         )
         asyncio.run(disconnect_stale_connection())
         logger.debug(f"Stale connection disconnect completed for {address}")
-
     except ImportError:
         # Bleak is optional in some deployments; skip stale cleanup rather than
         # breaking startup when BLE support isn't installed.
         logger.debug("BleakClient not available for stale connection cleanup")
+    except Exception as e:  # noqa: BLE001 - disconnect cleanup must not block startup
+        # Other errors during best-effort disconnect (e.g., from future.result() or asyncio.run())
+        # are non-fatal; log and continue.
+        logger.debug(f"Error during BLE disconnect cleanup for {address}: {e}")
 
 
 def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -782,7 +782,6 @@ def _disconnect_ble_by_address(address: str) -> None:
                 )
                 if not future.done():
                     future.cancel()
-                asyncio.run(disconnect_stale_connection())
         except RuntimeError as e:
             # get_running_loop raises RuntimeError when no loop is running
             # Create a new event loop in this case

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -240,6 +240,9 @@ def _schedule_ble_future_cleanup(
     def _cleanup() -> None:
         if future.done():
             return
+        with _ble_executor_lock:
+            if _ble_future is not future:
+                return
         logger.warning(
             "BLE worker still running after %.0fs for %s; clearing stale future (%s)",
             _BLE_FUTURE_WATCHDOG_SECS,

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -399,7 +399,10 @@ def _wait_for_result(
         loop (asyncio.AbstractEventLoop | None): Optional event loop to use for awaiting; if omitted, a running loop will be used or a temporary loop will be created.
 
     Returns:
-        Any: The value produced by the resolved future/awaitable.
+        Any: The value produced by the resolved future/awaitable. Returns False
+        when no awaitable is provided (result_future is None) or when a potential
+        deadlock is detected and the awaitable is scheduled via _fire_and_forget
+        instead of blocking the running event loop.
 
     Raises:
         asyncio.TimeoutError: If awaiting the awaitable times out.

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1205,6 +1205,7 @@ def connect_meshtastic(
                                             f"BLE interface creation timed out after 90 seconds for {ble_address}. "
                                             "This may indicate a stale BlueZ connection or Bluetooth adapter issue."
                                         )
+                                        meshtastic_iface = None
                                         raise TimeoutError(
                                             f"BLE connection attempt timed out for {ble_address}. "
                                             "Try: 1) Restarting BlueZ: 'sudo systemctl restart bluetooth', "
@@ -1249,6 +1250,7 @@ def connect_meshtastic(
                                 )
                                 # Don't use iface if connect() timed out - it may be in an inconsistent state
                                 iface = None
+                                meshtastic_iface = None
                                 raise TimeoutError(
                                     f"BLE connect() timed out for {ble_address}. "
                                     "BlueZ may be in a bad state. Try: "

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -367,6 +367,10 @@ def _run_blocking_with_timeout(
     This is used for sync BLE operations in the official meshtastic library
     (notably BLEClient.disconnect/close), which can block indefinitely and
     prevent clean shutdown if executed on a non-daemon thread.
+
+    Raises:
+        TimeoutError: If the action does not finish before the timeout expires.
+        Exception: Any exception raised by the action is re-raised.
     """
     done_event = threading.Event()
     action_error: Exception | None = None
@@ -388,9 +392,10 @@ def _run_blocking_with_timeout(
     thread.start()
     if not done_event.wait(timeout=timeout):
         logger.warning("%s timed out after %.1fs", label, timeout)
-        return
+        raise TimeoutError(f"{label} timed out after {timeout:.1f}s")
     if action_error is not None:
         logger.debug("%s failed: %s", label, action_error)
+        raise action_error
 
 
 def _wait_for_result(

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1444,7 +1444,7 @@ def connect_meshtastic(
                                     logger.debug(
                                         f"BLE interface created successfully for {ble_address}"
                                     )
-                                except FuturesTimeoutError:
+                                except FuturesTimeoutError as err:
                                     # Use logger.exception so we retain the timeout context (TRY400),
                                     # but keep the raised exception concise (TRY003) and emit guidance
                                     # as separate log lines for operators.
@@ -1469,7 +1469,7 @@ def connect_meshtastic(
                                     meshtastic_iface = None
                                     raise TimeoutError(
                                         f"BLE connection attempt timed out for {ble_address}."
-                                    ) from None
+                                    ) from err
                             except Exception:
                                 # BLEInterface constructor failed - this is a critical error
                                 logger.exception("BLE interface creation failed")

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1013,11 +1013,13 @@ def connect_meshtastic(
         # Close previous connection if exists
         if meshtastic_client:
             try:
-                meshtastic_client.close()
+                if meshtastic_client is meshtastic_iface:
+                    _disconnect_ble_interface(meshtastic_iface, reason="reconnect")
+                    meshtastic_iface = None
+                else:
+                    meshtastic_client.close()
             except Exception as e:
                 logger.warning(f"Error closing previous connection: {e}")
-            if meshtastic_client is meshtastic_iface:
-                meshtastic_iface = None
             meshtastic_client = None
 
         # Check if config is available

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1579,7 +1579,7 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
         portnum = (
             decoded.get("portnum") if decoded and isinstance(decoded, dict) else None
         )
-        portnum_name = _get_portnum_name(portnum) or "UNKNOWN"
+        portnum_name = _get_portnum_name(portnum)
         details_map = {
             "from": packet.get("fromId") or packet.get("from"),
             "channel": packet.get("channel"),

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1162,7 +1162,7 @@ def _disconnect_ble_by_address(address: str) -> None:
             loop = None
             runtime_error = e
 
-        if loop:
+        if loop and loop.is_running():
             logger.debug(
                 "Found running event loop; scheduling disconnect task for %s",
                 address,

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -425,7 +425,12 @@ def _scan_for_ble_address(ble_address: str, timeout: float) -> bool:
                 try:
                     return await find_device(ble_address, timeout=timeout) is not None
                 except TypeError:
-                    return await find_device(ble_address) is not None
+                    return (
+                        await asyncio.wait_for(
+                            find_device(ble_address), timeout=timeout
+                        )
+                        is not None
+                    )
 
             devices = await BleakScanner.discover(timeout=timeout)
             return any(

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -74,7 +74,7 @@ MAX_TIMEOUT_RETRIES_INFINITE = 5
 
 # Import BLE exceptions conditionally
 try:
-    from bleak.exc import BleakDBusError, BleakError
+    from bleak.exc import BleakDBusError, BleakError  # type: ignore[misc,assignment]
 except ImportError:
     BleakDBusError = Exception  # type: ignore[misc,assignment]
     BleakError = Exception  # type: ignore[misc,assignment]
@@ -691,7 +691,9 @@ def _disconnect_ble_by_address(address: str) -> None:
                 is_connected_method = getattr(client, "is_connected", None)
 
                 if is_connected_method and callable(is_connected_method):
-                    connected_status = await is_connected_method()
+                    connected_status = await cast(
+                        Callable[[], Awaitable[bool]], is_connected_method
+                    )()
                 elif isinstance(is_connected_method, bool):
                     connected_status = is_connected_method
                 else:
@@ -944,7 +946,7 @@ def _get_portnum_name(portnum: Any) -> str:
 
     if isinstance(portnum, int):
         try:
-            return portnums_pb2.PortNum.Name(portnum)
+            return portnums_pb2.PortNum.Name(portnum)  # type: ignore[arg-type]
         except ValueError:
             return f"UNKNOWN (portnum={portnum})"
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -902,6 +902,8 @@ def _disconnect_ble_by_address(address: str) -> None:
                 BleakClientDBusError,
                 OSError,
                 RuntimeError,
+                # Bleak/DBus can raise these during teardown with malformed payloads
+                # or unexpected awaitable shapes; cleanup stays best-effort.
                 ValueError,
                 TypeError,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -641,6 +641,7 @@ def reset_meshtastic_globals():
             mu, "subscribed_to_connection_lost", False
         ),
         "_metadata_future": getattr(mu, "_metadata_future", None),
+        "_ble_future": getattr(mu, "_ble_future", None),
     }
 
     # Reset mutable globals to a clean state; keep logger and event_loop usable
@@ -652,6 +653,7 @@ def reset_meshtastic_globals():
     mu.subscribed_to_messages = False
     mu.subscribed_to_connection_lost = False
     mu._metadata_future = None
+    mu._ble_future = None
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -620,7 +620,7 @@ def reset_banner_flag():
 def reset_meshtastic_globals():
     """
     Temporarily reset key module-level state in mmrelay.meshtastic_utils for a test and restore it on teardown.
-    
+
     Saves the original values of attributes such as `config`, `meshtastic_client`, reconnect/shutdown flags and tasks,
     subscription flags, and internal futures; sets those attributes to clean defaults for the duration of the test,
     yields control to the test, and restores the saved values on teardown. The module's `logger` and `event_loop`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -640,6 +640,7 @@ def reset_meshtastic_globals():
         "subscribed_to_connection_lost": getattr(
             mu, "subscribed_to_connection_lost", False
         ),
+        "_metadata_future": getattr(mu, "_metadata_future", None),
     }
 
     # Reset mutable globals to a clean state; keep logger and event_loop usable
@@ -650,6 +651,7 @@ def reset_meshtastic_globals():
     mu.reconnect_task = None
     mu.subscribed_to_messages = False
     mu.subscribed_to_connection_lost = False
+    mu._metadata_future = None
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -619,13 +619,12 @@ def reset_banner_flag():
 @pytest.fixture
 def reset_meshtastic_globals():
     """
-    Reset and restore key globals in mmrelay.meshtastic_utils to ensure test isolation.
-
-    Saves the module-level state for attributes such as `config`, `meshtastic_client`,
-    reconnect-related flags and tasks, and subscription flags; sets those attributes
-    to a clean default state for the duration of a test, yields control to the
-    test, and restores the original values on teardown. The fixture intentionally
-    does not modify the module's logger or event loop references.
+    Temporarily reset key module-level state in mmrelay.meshtastic_utils for a test and restore it on teardown.
+    
+    Saves the original values of attributes such as `config`, `meshtastic_client`, reconnect/shutdown flags and tasks,
+    subscription flags, and internal futures; sets those attributes to clean defaults for the duration of the test,
+    yields control to the test, and restores the saved values on teardown. The module's `logger` and `event_loop`
+    are intentionally left unchanged.
     """
     import mmrelay.meshtastic_utils as mu
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,103 @@
+"""
+Test helper utilities shared across test modules.
+
+This module provides reusable test utilities to avoid code duplication
+and improve maintainability of the test suite.
+"""
+
+import asyncio
+import concurrent.futures
+
+
+class InlineExecutorLoop:
+    """
+    Wrap an event loop and execute run_in_executor calls inline for tests.
+
+    This shim simulates a running asyncio event loop for synchronous executor
+    execution in tests, making tests deterministic by avoiding actual threading.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        """
+        Store provided event loop for use by this wrapper.
+
+        Parameters:
+            loop (asyncio.AbstractEventLoop): The underlying event loop whose attributes
+                and non-overridden behavior are delegated to this shim.
+        """
+        self._loop = loop
+
+    def is_running(self) -> bool:
+        """
+        Report whether this executor loop should be treated as running.
+
+        Returns:
+            True if loop is considered running, False otherwise.
+        """
+        return True
+
+    def run_in_executor(self, _executor, func, *args):
+        """
+        Execute a callable synchronously and return a Future resolved with its outcome.
+
+        Parameters:
+            _executor: Ignored executor placeholder (kept for compatibility with
+                loop.run_in_executor signature).
+            func (callable): The function to execute.
+            *args: Positional arguments to pass to `func`.
+
+        Returns:
+            asyncio.Future: A Future that contains `func`'s return value or
+                exception raised by `func`.
+
+        Notes:
+            If `func` raises TimeoutError, ValueError, RuntimeError, TypeError,
+            or OSError, that exception is set on the returned Future.
+        """
+        fut = self._loop.create_future()
+        try:
+            result = func(*args)
+        except (
+            concurrent.futures.TimeoutError,
+            ValueError,
+            RuntimeError,
+            TypeError,
+            OSError,
+        ) as exc:
+            fut.set_exception(exc)
+        else:
+            fut.set_result(result)
+        return fut
+
+    def __getattr__(self, name: str):
+        """
+        Delegate attribute access to wrapped event loop.
+
+        Parameters:
+            name (str): Attribute name being accessed on this wrapper.
+
+        Returns:
+            The attribute value from underlying event loop corresponding to `name`.
+
+        Raises:
+            AttributeError: If attribute does not exist on the wrapped loop.
+        """
+        return getattr(self._loop, name)
+
+
+def inline_to_thread(func, *args, **kwargs):
+    """
+    Run given callable synchronously in the current thread and return its result.
+
+    This helper is used in tests to replace asyncio.to_thread, avoiding
+    actual threading for deterministic test behavior.
+
+    Parameters:
+        func (callable): The function to execute.
+        *args: Positional arguments to pass to `func`.
+        **kwargs: Keyword arguments to pass to `func`.
+
+    Returns:
+        The return value produced by calling `func(*args, **kwargs)`.
+    """
+    return func(*args, **kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2974,7 +2974,7 @@ class TestValidateE2eeConfig(unittest.TestCase):
         mock_validate_deps.assert_called_once()
         mock_expanduser.assert_called_once_with("~/.mmrelay/store")
         mock_print.assert_any_call(
-            "ℹ️  Note: E2EE store directory will be created: /home/user/.mmrelay/store"
+            "Info: E2EE store directory will be created: /home/user/.mmrelay/store"
         )
         mock_print.assert_any_call("✅ E2EE configuration is valid")
 

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -163,6 +163,7 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
                 # This will fail due to missing config, but we want to test the exception handling
                 meshtastic_utils.connect_meshtastic(force_connect=True)
 
+                mock_logger.warning.assert_called_once()
                 call_args = mock_logger.warning.call_args
                 self.assertEqual(
                     call_args[0][0], "Error closing previous connection: %s"

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -163,9 +163,12 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
                 # This will fail due to missing config, but we want to test the exception handling
                 meshtastic_utils.connect_meshtastic(force_connect=True)
 
-                mock_logger.warning.assert_called_with(
-                    "Error closing previous connection: Close error"
+                call_args = mock_logger.warning.call_args
+                self.assertEqual(
+                    call_args[0][0], "Error closing previous connection: %s"
                 )
+                self.assertEqual(call_args[0][1].args[0], "Close error")
+                self.assertTrue(call_args[1]["exc_info"])
 
 
 class TestMatrixUtilsCoverage(unittest.TestCase):

--- a/tests/test_db_runtime_security.py
+++ b/tests/test_db_runtime_security.py
@@ -552,20 +552,16 @@ class TestDatabaseManager(unittest.TestCase):
                         Returns:
                             int or None: The updated counter value after incrementing, or `None` if the row was not found.
                         """
-                        cursor.execute(
-                            """
+                        cursor.execute("""
                             CREATE TABLE IF NOT EXISTS counter (
                                 id INTEGER PRIMARY KEY CHECK (id = 1),
                                 count INTEGER DEFAULT 0
                             )
-                        """
-                        )
+                        """)
                         # Insert initial row if not exists
-                        cursor.execute(
-                            """
+                        cursor.execute("""
                             INSERT OR IGNORE INTO counter (id, count) VALUES (1, 0)
-                        """
-                        )
+                        """)
                         # Increment counter
                         cursor.execute(
                             "UPDATE counter SET count = count + 1 WHERE id = 1"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1767,13 +1767,10 @@ class TestMainAsyncFunction(unittest.TestCase):
         if "mmrelay.message_queue" in sys.modules:
             from mmrelay.message_queue import get_message_queue
 
-            try:
+            with contextlib.suppress(Exception):
                 queue = get_message_queue()
                 if hasattr(queue, "stop"):
                     queue.stop()
-            except Exception:
-                # Ignore errors during cleanup
-                pass
 
     def test_main_async_initialization_sequence(self):
         """Verify that the asynchronous main() startup sequence invokes database initialization, plugin loading, message-queue startup, and both Matrix and Meshtastic connection routines.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1544,6 +1544,8 @@ class TestMainAsyncFunction(unittest.TestCase):
             module.subscribed_to_connection_lost = False
             if hasattr(module, "_metadata_future"):
                 module._metadata_future = None
+            if hasattr(module, "_ble_future"):
+                module._ble_future = None
 
         # Reset matrix_utils globals
         if "mmrelay.matrix_utils" in sys.modules:
@@ -1776,6 +1778,12 @@ class TestMainAsyncFunction(unittest.TestCase):
         mock_matrix_client.add_event_callback = MagicMock()
         mock_matrix_client.close = AsyncMock()
 
+        async def _return_matrix_client(*_args, **_kwargs):
+            return mock_matrix_client
+
+        async def _noop(*_args, **_kwargs):
+            return None
+
         captured_signals = []
         real_get_running_loop = asyncio.get_running_loop
 
@@ -1802,15 +1810,14 @@ class TestMainAsyncFunction(unittest.TestCase):
             patch("mmrelay.main.start_message_queue"),
             patch(
                 "mmrelay.main.connect_matrix",
-                new_callable=AsyncMock,
-                return_value=mock_matrix_client,
+                side_effect=_return_matrix_client,
             ),
             patch("mmrelay.main.connect_meshtastic", return_value=None),
-            patch("mmrelay.main.join_matrix_room", new_callable=AsyncMock),
+            patch("mmrelay.main.join_matrix_room", side_effect=_noop),
             patch("mmrelay.main.get_message_queue") as mock_get_queue,
             patch(
                 "mmrelay.main.meshtastic_utils.check_connection",
-                new_callable=AsyncMock,
+                side_effect=_noop,
             ),
             patch("mmrelay.main.shutdown_plugins"),
             patch("mmrelay.main.stop_message_queue"),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1718,6 +1718,24 @@ class TestMainAsyncFunction(unittest.TestCase):
                 module._ble_future = None
             if hasattr(module, "_ble_future_address"):
                 module._ble_future_address = None
+            if hasattr(module, "_ble_timeout_counts"):
+                module._ble_timeout_counts = {}
+            if hasattr(module, "_metadata_executor"):
+                executor = module._metadata_executor
+                if executor is not None:
+                    try:
+                        executor.shutdown(wait=False, cancel_futures=True)
+                    except Exception:
+                        pass
+                module._metadata_executor = None
+            if hasattr(module, "_ble_executor"):
+                executor = module._ble_executor
+                if executor is not None:
+                    try:
+                        executor.shutdown(wait=False, cancel_futures=True)
+                    except Exception:
+                        pass
+                module._ble_executor = None
 
         # Reset matrix_utils globals
         if "mmrelay.matrix_utils" in sys.modules:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -162,16 +162,14 @@ class _CloseFutureBase(concurrent.futures.Future):
 class _TimeoutCloseFuture(_CloseFutureBase):
     """Future that raises TimeoutError immediately on result()."""
 
-    def result(self, timeout: float | None = None) -> None:
-        _ = timeout
+    def result(self, _timeout: float | None = None) -> None:
         raise concurrent.futures.TimeoutError()
 
 
 class _ErrorCloseFuture(_CloseFutureBase):
     """Future that raises an unexpected error on result()."""
 
-    def result(self, timeout: float | None = None) -> None:
-        _ = timeout
+    def result(self, _timeout: float | None = None) -> None:
         raise ValueError("boom")
 
 
@@ -222,7 +220,7 @@ class _ControlledExecutor:
         self.calls.append((wait, cancel_futures))
         if self.shutdown_typeerror and cancel_futures is True:
             # Simulate older Python versions that do not accept cancel_futures.
-            raise TypeError("cancel_futures unsupported")
+            raise TypeError()
 
 
 class TestMain(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -314,12 +314,8 @@ class _ControlledExecutor:
             return self.close_future
 
         future = concurrent.futures.Future()
-        try:
-            result = func(*args, **kwargs)
-        except Exception as exc:
-            future.set_exception(exc)
-        else:
-            future.set_result(result)
+        result = func(*args, **kwargs)
+        future.set_result(result)
         return future
 
     def shutdown(self, wait: bool = False, cancel_futures: bool = False) -> None:
@@ -1723,18 +1719,14 @@ class TestMainAsyncFunction(unittest.TestCase):
             if hasattr(module, "_metadata_executor"):
                 executor = module._metadata_executor
                 if executor is not None:
-                    try:
+                    with contextlib.suppress(TypeError, RuntimeError):
                         executor.shutdown(wait=False, cancel_futures=True)
-                    except Exception:
-                        pass
                 module._metadata_executor = None
             if hasattr(module, "_ble_executor"):
                 executor = module._ble_executor
                 if executor is not None:
-                    try:
+                    with contextlib.suppress(TypeError, RuntimeError):
                         executor.shutdown(wait=False, cancel_futures=True)
-                    except Exception:
-                        pass
                 module._ble_executor = None
 
         # Reset matrix_utils globals

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -719,7 +719,7 @@ class TestMain(unittest.TestCase):
         self.assertTrue(
             any(
                 "Unexpected error during Meshtastic client close" in str(call)
-                for call in mock_meshtastic_logger.error.call_args_list
+                for call in mock_meshtastic_logger.exception.call_args_list
             )
         )
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -636,6 +636,7 @@ class TestMain(unittest.TestCase):
         executor = _ControlledExecutor()
         with (
             patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
+            patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch(
                 "mmrelay.main.concurrent.futures.ThreadPoolExecutor",
                 return_value=executor,
@@ -820,6 +821,7 @@ class TestMain(unittest.TestCase):
         executor = _ControlledExecutor(submit_timeout=True)
         with (
             patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
+            patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch(
                 "mmrelay.main.concurrent.futures.ThreadPoolExecutor",
                 return_value=executor,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -162,14 +162,16 @@ class _CloseFutureBase(concurrent.futures.Future):
 class _TimeoutCloseFuture(_CloseFutureBase):
     """Future that raises TimeoutError immediately on result()."""
 
-    def result(self, _timeout: float | None = None) -> None:
+    def result(self, timeout: float | None = None) -> None:
+        _ = timeout
         raise concurrent.futures.TimeoutError()
 
 
 class _ErrorCloseFuture(_CloseFutureBase):
     """Future that raises an unexpected error on result()."""
 
-    def result(self, _timeout: float | None = None) -> None:
+    def result(self, timeout: float | None = None) -> None:
+        _ = timeout
         raise ValueError("boom")
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1905,15 +1905,14 @@ class TestMainAsyncFunction(unittest.TestCase):
             patch("mmrelay.main.start_message_queue"),
             patch(
                 "mmrelay.main.connect_matrix",
-                new_callable=AsyncMock,
-                return_value=mock_matrix_client,
+                side_effect=_make_async_return(mock_matrix_client),
             ),
             patch("mmrelay.main.connect_meshtastic", return_value=None),
-            patch("mmrelay.main.join_matrix_room", new_callable=AsyncMock),
+            patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
             patch("mmrelay.main.get_message_queue") as mock_get_queue,
             patch(
                 "mmrelay.main.meshtastic_utils.check_connection",
-                new_callable=AsyncMock,
+                side_effect=_async_noop,
             ),
             patch("mmrelay.main.shutdown_plugins"),
             patch("mmrelay.main.stop_message_queue"),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -296,7 +296,8 @@ class _ControlledExecutor:
             func (callable): The function or functools.partial to execute. Additional positional and keyword arguments are forwarded to the callable.
 
         Returns:
-            concurrent.futures.Future: Future containing the callable's result, or a Future with the exception set if the callable raised one.
+            concurrent.futures.Future: Future containing the callable's result. If the callable raises an exception,
+            it propagates to the caller (no Future is returned).
         """
         target = func
         if isinstance(func, functools.partial):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,10 +80,10 @@ def _mock_run_with_exception(coro: Any) -> None:
 def _mock_run_with_keyboard_interrupt(coro: Any) -> None:
     """
     Invoke _close_coro_if_possible on the given coroutine-like object and then raise KeyboardInterrupt.
-    
+
     Parameters:
         coro (Any): An awaitable or coroutine object; if it has a `close()` method, that method will be called.
-    
+
     Raises:
         KeyboardInterrupt: Always raised after attempting to close the coroutine.
     """
@@ -94,13 +94,14 @@ def _mock_run_with_keyboard_interrupt(coro: Any) -> None:
 def _make_async_return(value: Any):
     """
     Create an async function that always returns the provided value.
-    
+
     Parameters:
         value (Any): Value to be returned by the generated coroutine.
-    
+
     Returns:
         callable: An async function that ignores its arguments and returns `value` when awaited.
     """
+
     async def _async_return(*_args, **_kwargs):
         return value
 
@@ -110,13 +111,14 @@ def _make_async_return(value: Any):
 def _make_async_raise(exc: Exception):
     """
     Create an async callable that always raises the provided exception when awaited.
-    
+
     Parameters:
         exc (Exception): The exception instance to raise when the returned coroutine is awaited.
-    
+
     Returns:
         Callable[..., Coroutine]: An async function that, when called and awaited, raises `exc`.
     """
+
     async def _async_raise(*_args, **_kwargs):
         raise exc
 
@@ -126,7 +128,7 @@ def _make_async_raise(exc: Exception):
 async def _async_noop(*_args, **_kwargs) -> None:
     """
     Asynchronous no-op that accepts any positional and keyword arguments.
-    
+
     This coroutine performs no action and ignores all provided arguments.
     """
     return None
@@ -138,7 +140,7 @@ class _InlineExecutorLoop:
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         """
         Store the provided event loop for use by this wrapper.
-        
+
         Parameters:
             loop (asyncio.AbstractEventLoop): The underlying event loop that this wrapper will delegate to.
         """
@@ -147,15 +149,15 @@ class _InlineExecutorLoop:
     def run_in_executor(self, _executor, func, *args):
         """
         Execute a callable synchronously and return a Future resolved with its outcome.
-        
+
         Parameters:
             _executor: Ignored executor placeholder (kept for compatibility with loop.run_in_executor signature).
             func (callable): The function to execute.
             *args: Positional arguments to pass to `func`.
-        
+
         Returns:
             concurrent.futures.Future: A Future that contains `func`'s return value or the exception raised by `func`.
-            
+
         Notes:
             If `func` raises TimeoutError, ValueError, RuntimeError, TypeError, or OSError, that exception is set on the returned Future.
         """
@@ -177,10 +179,10 @@ class _InlineExecutorLoop:
     def __getattr__(self, name: str):
         """
         Delegate attribute access to the wrapped event loop.
-        
+
         Parameters:
             name (str): Attribute name being accessed on this wrapper.
-        
+
         Returns:
             The attribute value from the underlying event loop corresponding to `name`.
         """
@@ -190,12 +192,12 @@ class _InlineExecutorLoop:
 async def _inline_to_thread(func, *args, **kwargs):
     """
     Run the given callable synchronously in the current thread and return its result.
-    
+
     Parameters:
         func (callable): The function to execute.
         *args: Positional arguments to pass to `func`.
         **kwargs: Keyword arguments to pass to `func`.
-    
+
     Returns:
         The return value produced by calling `func(*args, **kwargs)`.
     """
@@ -208,7 +210,7 @@ class _ImmediateEvent:
     def __init__(self) -> None:
         """
         Initialize an ImmediateEvent representing an event that is always set.
-        
+
         Sets internal state so is_set() returns True and awaitable wait() completes immediately.
         """
         self._set = True
@@ -216,7 +218,7 @@ class _ImmediateEvent:
     def is_set(self) -> bool:
         """
         Indicates whether the event is set.
-        
+
         Returns:
             `True` if the event is set, `False` otherwise.
         """
@@ -231,7 +233,7 @@ class _ImmediateEvent:
     async def wait(self) -> None:
         """
         Return immediately without blocking, simulating an event that is already set.
-        
+
         This coroutine is a no-op used in tests to represent an event whose wait completes immediately.
         """
         return None
@@ -243,7 +245,7 @@ class _CloseFutureBase(concurrent.futures.Future):
     def __init__(self) -> None:
         """
         Initialize the instance and set up the cancel call tracker.
-        
+
         Tracks whether cancel() was invoked on this future via the `cancel_called` attribute.
         """
         super().__init__()
@@ -252,9 +254,9 @@ class _CloseFutureBase(concurrent.futures.Future):
     def cancel(self) -> bool:
         """
         Mark the future as cancelled and record that cancellation was attempted.
-        
+
         Sets the `cancel_called` attribute to True.
-        
+
         Returns:
             bool: `True` if the future was successfully cancelled, `False` otherwise.
         """
@@ -268,10 +270,10 @@ class _TimeoutCloseFuture(_CloseFutureBase):
     def result(self, _timeout: float | None = None) -> None:
         """
         Always raises a concurrent.futures.TimeoutError to simulate a timed-out close future.
-        
+
         Parameters:
             _timeout (float | None): Ignored timeout value.
-        
+
         Raises:
             concurrent.futures.TimeoutError: Always raised when called.
         """
@@ -284,10 +286,10 @@ class _ErrorCloseFuture(_CloseFutureBase):
     def result(self, _timeout: float | None = None) -> None:
         """
         Always raises a ValueError with message "boom".
-        
+
         Parameters:
             _timeout (float | None): Ignored; present for API compatibility.
-        
+
         Raises:
             ValueError: Always raised with message "boom".
         """
@@ -306,7 +308,7 @@ class _ControlledExecutor:
     ) -> None:
         """
         Create a ControlledExecutor used in tests to simulate and control task submission and shutdown behaviors.
-        
+
         Parameters:
             close_future_factory (Callable[[], concurrent.futures.Future] | None):
                 Factory that produces a preconfigured Future to return for close-related submissions; if None, submit executes synchronously.
@@ -314,7 +316,7 @@ class _ControlledExecutor:
                 If True, simulate a timeout condition when submitting close-related tasks.
             shutdown_typeerror (bool):
                 If True, simulate an executor.shutdown that raises a TypeError when called with cancel_futures=True (to model older Python behavior).
-        
+
         """
         self.close_future_factory = close_future_factory
         self.submit_timeout = submit_timeout
@@ -326,12 +328,12 @@ class _ControlledExecutor:
     def submit(self, func, *args, **kwargs):
         """
         Submit a callable to the controlled executor, execute it synchronously, and return a Future representing its outcome.
-        
+
         If the callable's name or qualified name contains "_close_meshtastic", the executor applies special close-related behavior: it raises concurrent.futures.TimeoutError when configured with submit_timeout, or returns a pre-created close future when a close_future_factory is provided.
-        
+
         Parameters:
             func (callable): The function or functools.partial to execute. Additional positional and keyword arguments are forwarded to the callable.
-        
+
         Returns:
             concurrent.futures.Future: Future containing the callable's result, or a Future with the exception set if the callable raised one.
         """
@@ -368,7 +370,7 @@ class _ControlledExecutor:
     def shutdown(self, wait: bool = False, cancel_futures: bool = False) -> None:
         """
         Record an executor shutdown request and optionally simulate a legacy TypeError when `cancel_futures` is used.
-        
+
         Parameters:
             wait (bool): Whether to wait for pending futures to complete.
             cancel_futures (bool): Whether to cancel pending futures; when the executor is configured
@@ -616,7 +618,7 @@ class TestMain(unittest.TestCase):
         def _patched_get_running_loop():
             """
             Wraps the real running event loop in an _InlineExecutorLoop when necessary to ensure run_in_executor calls execute inline in tests.
-            
+
             Returns:
                 An event loop object: the original loop if it is already an `_InlineExecutorLoop`, otherwise a new `_InlineExecutorLoop` that delegates to the real loop.
             """
@@ -674,7 +676,7 @@ class TestMain(unittest.TestCase):
         def _patched_get_running_loop():
             """
             Wraps the real running event loop in an _InlineExecutorLoop when necessary to ensure run_in_executor calls execute inline in tests.
-            
+
             Returns:
                 An event loop object: the original loop if it is already an `_InlineExecutorLoop`, otherwise a new `_InlineExecutorLoop` that delegates to the real loop.
             """
@@ -766,7 +768,7 @@ class TestMain(unittest.TestCase):
         def _patched_get_running_loop():
             """
             Provide an event loop wrapper that executes run_in_executor calls inline for testing.
-            
+
             Returns:
                 _InlineExecutorLoop: A wrapper around the real running event loop whose
                 run_in_executor executes functions synchronously (useful for deterministic tests).
@@ -815,10 +817,10 @@ class TestMain(unittest.TestCase):
         def _connect_meshtastic(*_args, **_kwargs):
             """
             Install the test Meshtastic interface into mmrelay.meshtastic_utils and return it.
-            
+
             This helper ignores any positional or keyword arguments. It assigns the module-level
             `mock_iface` to `mmrelay.meshtastic_utils.meshtastic_iface` and returns that object.
-            
+
             Returns:
                 mock_iface: The mock Meshtastic interface that was assigned.
             """
@@ -878,9 +880,9 @@ class TestMain(unittest.TestCase):
         def _connect_meshtastic(*_args, **_kwargs):
             """
             Install the provided mock Meshtastic interface into the mmrelay.meshtastic_utils module for tests.
-            
+
             Sets mmrelay.meshtastic_utils.meshtastic_client to the mock interface and mmrelay.meshtastic_utils.meshtastic_iface to None.
-            
+
             Returns:
                 The mock Meshtastic interface that was installed.
             """
@@ -980,7 +982,7 @@ class TestMain(unittest.TestCase):
     ):
         """
         Ensure main retries executor.shutdown without cancel_futures when a TypeError occurs.
-        
+
         Verifies that if ThreadPoolExecutor.shutdown raises a TypeError when invoked with
         cancel_futures=True, the shutdown sequence calls executor.shutdown a second time
         with cancel_futures=False.
@@ -1978,7 +1980,7 @@ class TestMainAsyncFunction(unittest.TestCase):
     def test_main_signal_handler_sets_shutdown_flag(self):
         """
         Ensure signal handlers set the shutdown flag and register a shutdown handler.
-        
+
         Patches asyncio.get_running_loop so the event loop's add_signal_handler is replaced with a synchronous invoker that captures and immediately calls the registered handler; runs main(config) and asserts the meshtastic shutdown flag is set and a signal handler was registered.
         """
         config = {
@@ -2059,9 +2061,9 @@ class TestMainAsyncFunction(unittest.TestCase):
         def _patched_get_running_loop():
             """
             Return the current running event loop with its signal-handler registration patched to capture signals.
-            
+
             The returned loop has its `add_signal_handler` replaced so that any registered signal is appended to the module-level `captured_signals` list, and a `_signal_capture_patched` attribute is set to avoid repeated patching.
-            
+
             Returns:
                 asyncio.AbstractEventLoop: The running event loop with signal registration patched.
             """
@@ -2071,7 +2073,7 @@ class TestMainAsyncFunction(unittest.TestCase):
                 def _fake_add_signal_handler(sig, _handler):
                     """
                     Record the given signal identifier by appending it to the module-level captured_signals list for testing.
-                    
+
                     Parameters:
                         sig: The signal identifier (e.g., an int or signal.Signals) to capture.
                         _handler: The signal handler callable (ignored).

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,14 +124,14 @@ class _CloseFutureBase(concurrent.futures.Future):
 class _TimeoutCloseFuture(_CloseFutureBase):
     """Future that raises TimeoutError immediately on result()."""
 
-    def result(self, timeout: float | None = None) -> None:
+    def result(self, _timeout: float | None = None) -> None:
         raise concurrent.futures.TimeoutError()
 
 
 class _ErrorCloseFuture(_CloseFutureBase):
     """Future that raises an unexpected error on result()."""
 
-    def result(self, timeout: float | None = None) -> None:
+    def result(self, _timeout: float | None = None) -> None:
         raise ValueError("boom")
 
 
@@ -160,12 +160,8 @@ class _ControlledExecutor:
                 return self.future
 
         future = concurrent.futures.Future()
-        try:
-            result = func(*args, **kwargs)
-        except Exception as exc:
-            future.set_exception(exc)
-        else:
-            future.set_result(result)
+        result = func(*args, **kwargs)
+        future.set_result(result)
         return future
 
     def shutdown(self, wait: bool = False, cancel_futures: bool = False) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -194,18 +194,17 @@ class _ControlledExecutor:
         target = func
         if isinstance(func, functools.partial):
             target = func.func
-        if self.close_future_factory is not None:
-            target_name = getattr(target, "__name__", "")
-            target_qualname = getattr(target, "__qualname__", "")
-            if (
-                "_close_meshtastic" in target_name
-                or "_close_meshtastic" in target_qualname
-            ):
-                if self.submit_timeout:
-                    raise concurrent.futures.TimeoutError()
-                if self.close_future is None:
-                    self.close_future = self.close_future_factory()
-                return self.close_future
+        target_name = getattr(target, "__name__", "")
+        target_qualname = getattr(target, "__qualname__", "")
+        is_close = "_close_meshtastic" in target_name or "_close_meshtastic" in (
+            target_qualname
+        )
+        if is_close and self.submit_timeout:
+            raise concurrent.futures.TimeoutError()
+        if is_close and self.close_future_factory is not None:
+            if self.close_future is None:
+                self.close_future = self.close_future_factory()
+            return self.close_future
 
         future = concurrent.futures.Future()
         try:

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import importlib
 import os
 import re
@@ -6036,7 +6037,13 @@ class _InlineExecutorLoop:
         fut = self._loop.create_future()
         try:
             result = func(*args)
-        except Exception as exc:
+        except (
+            concurrent.futures.TimeoutError,
+            ValueError,
+            RuntimeError,
+            TypeError,
+            OSError,
+        ) as exc:
             fut.set_exception(exc)
         else:
             fut.set_result(result)

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import concurrent.futures
 import importlib
 import os
 import re

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -6030,7 +6030,7 @@ class _InlineExecutorLoop:
     def __init__(self, loop):
         """
         Initialize the InlineExecutorLoop shim that simulates a running asyncio event loop for synchronous executor execution in tests.
-        
+
         Parameters:
             loop (asyncio.AbstractEventLoop): The underlying event loop whose attributes and non-overridden behavior are delegated to this shim.
         """
@@ -6039,7 +6039,7 @@ class _InlineExecutorLoop:
     def is_running(self):
         """
         Report whether this executor loop should be treated as running.
-        
+
         Returns:
             True if the loop is considered running, False otherwise.
         """
@@ -6048,12 +6048,12 @@ class _InlineExecutorLoop:
     def run_in_executor(self, _executor, func, *args):
         """
         Execute `func` synchronously with the provided `args` and return a Future resolved with the outcome.
-        
+
         Parameters:
             _executor: Ignored executor parameter kept for compatibility.
             func (callable): Function to invoke.
             *args: Positional arguments passed to `func`.
-        
+
         Returns:
             asyncio.Future: Future resolved with `func(*args)` result, or completed with the raised exception if `func` raises.
         """
@@ -6075,13 +6075,13 @@ class _InlineExecutorLoop:
     def __getattr__(self, name):
         """
         Delegate attribute access to the wrapped asyncio event loop.
-        
+
         Parameters:
             name (str): The attribute name being accessed.
-        
+
         Returns:
             The attribute value retrieved from the underlying loop.
-        
+
         Raises:
             AttributeError: If the attribute does not exist on the wrapped loop.
         """

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -6028,12 +6028,35 @@ async def test_connect_matrix_e2ee_missing_sqlite_store():
 
 class _InlineExecutorLoop:
     def __init__(self, loop):
+        """
+        Initialize the InlineExecutorLoop shim that simulates a running asyncio event loop for synchronous executor execution in tests.
+        
+        Parameters:
+            loop (asyncio.AbstractEventLoop): The underlying event loop whose attributes and non-overridden behavior are delegated to this shim.
+        """
         self._loop = loop
 
     def is_running(self):
+        """
+        Report whether this executor loop should be treated as running.
+        
+        Returns:
+            True if the loop is considered running, False otherwise.
+        """
         return True
 
     def run_in_executor(self, _executor, func, *args):
+        """
+        Execute `func` synchronously with the provided `args` and return a Future resolved with the outcome.
+        
+        Parameters:
+            _executor: Ignored executor parameter kept for compatibility.
+            func (callable): Function to invoke.
+            *args: Positional arguments passed to `func`.
+        
+        Returns:
+            asyncio.Future: Future resolved with `func(*args)` result, or completed with the raised exception if `func` raises.
+        """
         fut = self._loop.create_future()
         try:
             result = func(*args)
@@ -6050,6 +6073,18 @@ class _InlineExecutorLoop:
         return fut
 
     def __getattr__(self, name):
+        """
+        Delegate attribute access to the wrapped asyncio event loop.
+        
+        Parameters:
+            name (str): The attribute name being accessed.
+        
+        Returns:
+            The attribute value retrieved from the underlying loop.
+        
+        Raises:
+            AttributeError: If the attribute does not exist on the wrapped loop.
+        """
         return getattr(self._loop, name)
 
 

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -6032,8 +6032,15 @@ class _InlineExecutorLoop:
     def is_running(self):
         return True
 
-    async def run_in_executor(self, _executor, func, *args):
-        return func(*args)
+    def run_in_executor(self, _executor, func, *args):
+        fut = self._loop.create_future()
+        try:
+            result = func(*args)
+        except Exception as exc:
+            fut.set_exception(exc)
+        else:
+            fut.set_result(result)
+        return fut
 
     def __getattr__(self, name):
         return getattr(self._loop, name)

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -6025,6 +6025,20 @@ async def test_connect_matrix_e2ee_missing_sqlite_store():
         mock_logger.exception.assert_called_with("Missing E2EE dependency")
 
 
+class _InlineExecutorLoop:
+    def __init__(self, loop):
+        self._loop = loop
+
+    def is_running(self):
+        return True
+
+    async def run_in_executor(self, _executor, func, *args):
+        return func(*args)
+
+    def __getattr__(self, name):
+        return getattr(self._loop, name)
+
+
 @pytest.mark.asyncio
 async def test_handle_matrix_reply_success():
     """Test handle_matrix_reply processes reply successfully."""
@@ -6036,7 +6050,12 @@ async def test_handle_matrix_reply_success():
     mock_config = {"matrix_rooms": []}
 
     # Mock database lookup to return original message
+    loop = asyncio.get_running_loop()
     with (
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=_InlineExecutorLoop(loop),
+        ),
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id"
         ) as mock_db_lookup,
@@ -6089,7 +6108,12 @@ async def test_handle_matrix_reply_numeric_string_reply_id():
     mock_room_config = {"meshtastic_channel": 0}
     mock_config = {"matrix_rooms": []}
 
+    loop = asyncio.get_running_loop()
     with (
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=_InlineExecutorLoop(loop),
+        ),
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id"
         ) as mock_db_lookup,
@@ -6130,7 +6154,12 @@ async def test_handle_matrix_reply_unexpected_id_type_broadcasts():
     mock_room_config = {"meshtastic_channel": 0}
     mock_config = {"matrix_rooms": []}
 
+    loop = asyncio.get_running_loop()
     with (
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=_InlineExecutorLoop(loop),
+        ),
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id"
         ) as mock_db_lookup,
@@ -6172,7 +6201,12 @@ async def test_handle_matrix_reply_integer_id():
     mock_room_config = {"meshtastic_channel": 0}
     mock_config = {"matrix_rooms": []}
 
+    loop = asyncio.get_running_loop()
     with (
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=_InlineExecutorLoop(loop),
+        ),
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id"
         ) as mock_db_lookup,
@@ -6215,7 +6249,12 @@ async def test_handle_matrix_reply_original_not_found():
     mock_room_config = {"meshtastic_channel": 0}
     mock_config = {"matrix_rooms": []}
 
+    loop = asyncio.get_running_loop()
     with (
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=_InlineExecutorLoop(loop),
+        ),
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id"
         ) as mock_db_lookup,

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2349,6 +2349,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mu._metadata_future = None
         output_capture = Mock()
         output_capture.getvalue.return_value = "firmware_version: 2.3.15"
+        output_capture.closed = False
 
         timeout_future = Mock()
         timeout_future.result.side_effect = FuturesTimeoutError()
@@ -2376,9 +2377,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address when is_connected is a bool (True)."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
+        async def _noop(*_args, **_kwargs):
+            return None
+
         mock_client = Mock()
         mock_client.is_connected = True  # bool, not callable
-        mock_client.disconnect = Mock()
+        mock_client.disconnect = Mock(return_value=_noop())
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2394,9 +2398,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address when is_connected is a bool (False)."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
+        async def _noop(*_args, **_kwargs):
+            return None
+
         mock_client = Mock()
         mock_client.is_connected = False  # bool, not callable
-        mock_client.disconnect = Mock()
+        mock_client.disconnect = Mock(return_value=_noop())
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2479,7 +2486,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = True
-        mock_client.disconnect = Mock(return_value=None)
+        mock_client.disconnect = Mock(return_value=_noop())
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2538,12 +2545,15 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address logs when cleanup disconnect times out."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
+        async def _noop(*_args, **_kwargs):
+            return None
+
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_wait_for.side_effect = asyncio.TimeoutError()
 
         mock_client = Mock()
         mock_client.is_connected = False
-        mock_client.disconnect = Mock(return_value=None)
+        mock_client.disconnect = Mock(return_value=_noop())
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2547,12 +2547,17 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
 
-        self.assertTrue(
-            any(
-                "Error disconnecting stale connection to AA:BB:CC:DD:EE:FF" in str(call)
-                for call in mock_logger.debug.call_args_list
-            )
-        )
+        found = False
+        for call in mock_logger.debug.call_args_list:
+            args = call.args
+            if not args:
+                continue
+            if "Error disconnecting stale connection" in str(args[0]) and any(
+                arg == "AA:BB:CC:DD:EE:FF" for arg in args
+            ):
+                found = True
+                break
+        self.assertTrue(found)
 
     @patch("mmrelay.meshtastic_utils.asyncio.get_running_loop")
     @patch("mmrelay.meshtastic_utils.asyncio.wait_for")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1022,13 +1022,16 @@ class TestConnectionLossHandling(unittest.TestCase):
         )
 
 
+@pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestConnectMeshtasticEdgeCases(unittest.TestCase):
     """Test cases for edge cases in Meshtastic connection."""
 
+    @patch("mmrelay.meshtastic_utils.INFINITE_RETRIES", 1)
+    @patch("mmrelay.meshtastic_utils.time.sleep")
     @patch("mmrelay.meshtastic_utils.serial_port_exists")
     @patch("mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface")
     def test_connect_meshtastic_serial_port_not_exists(
-        self, mock_serial, mock_port_exists
+        self, mock_serial, mock_port_exists, _mock_sleep
     ):
         """
         Test that connect_meshtastic returns None and does not instantiate the serial interface when the specified serial port does not exist.
@@ -1044,8 +1047,10 @@ class TestConnectMeshtasticEdgeCases(unittest.TestCase):
         self.assertIsNone(result)
         mock_serial.assert_not_called()
 
+    @patch("mmrelay.meshtastic_utils.INFINITE_RETRIES", 1)
+    @patch("mmrelay.meshtastic_utils.time.sleep")
     @patch("mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface")
-    def test_connect_meshtastic_serial_exception(self, mock_serial):
+    def test_connect_meshtastic_serial_exception(self, mock_serial, _mock_sleep):
         """
         Test that connect_meshtastic returns None if an exception occurs during serial interface instantiation.
         """

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -96,6 +96,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         mmrelay.meshtastic_utils.shutting_down = False
         mmrelay.meshtastic_utils.reconnect_task = None
         mmrelay.meshtastic_utils._ble_future = None
+        mmrelay.meshtastic_utils._ble_future_address = None
 
     def test_on_meshtastic_message_basic(self):
         """
@@ -1138,6 +1139,7 @@ class TestConnectMeshtasticEdgeCases(unittest.TestCase):
         mu.reconnecting = False
         mu.shutting_down = False
         mu._ble_future = None
+        mu._ble_future_address = None
 
         result = connect_meshtastic(passed_config=config)
 
@@ -1311,12 +1313,14 @@ def reset_meshtastic_globals():
     mmrelay.meshtastic_utils.shutting_down = False
     mmrelay.meshtastic_utils.reconnecting = False
     mmrelay.meshtastic_utils._ble_future = None
+    mmrelay.meshtastic_utils._ble_future_address = None
     yield
     # Cleanup after test
     mmrelay.meshtastic_utils.meshtastic_client = None
     mmrelay.meshtastic_utils.shutting_down = False
     mmrelay.meshtastic_utils.reconnecting = False
     mmrelay.meshtastic_utils._ble_future = None
+    mmrelay.meshtastic_utils._ble_future_address = None
 
 
 @patch("mmrelay.meshtastic_utils.time.sleep")
@@ -2678,6 +2682,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             import mmrelay.meshtastic_utils as mu
 
             mu._ble_future = None
+            mu._ble_future_address = None
             # The function will retry 6 times (MAX_TIMEOUT_RETRIES_INFINITE = 5 + 1)
             # After all retries, it returns None (doesn't raise)
             result = connect_meshtastic(passed_config=config)
@@ -2785,6 +2790,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             import mmrelay.meshtastic_utils as mu
 
             mu._ble_future = None
+            mu._ble_future_address = None
             # The function will retry 6 times and return None (doesn't raise)
             result = connect_meshtastic(passed_config=config)
             self.assertIsNone(result)

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2401,7 +2401,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = True  # bool, not callable
-        mock_client.disconnect = Mock(return_value=_noop())
+        mock_client.disconnect = Mock(side_effect=_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2422,7 +2422,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = False  # bool, not callable
-        mock_client.disconnect = Mock(return_value=_noop())
+        mock_client.disconnect = Mock(side_effect=_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2448,7 +2448,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = object()
-        mock_client.disconnect = Mock(return_value=_noop())
+        mock_client.disconnect = Mock(side_effect=_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2473,7 +2473,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = True
-        mock_client.disconnect = Mock(return_value=_noop())
+        mock_client.disconnect = Mock(side_effect=_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2505,7 +2505,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = True
-        mock_client.disconnect = Mock(return_value=_noop())
+        mock_client.disconnect = Mock(side_effect=_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2542,7 +2542,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = True
-        mock_client.disconnect = Mock(return_value=_noop())
+        mock_client.disconnect = Mock(side_effect=_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2572,7 +2572,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = False
-        mock_client.disconnect = Mock(return_value=_noop())
+        mock_client.disconnect = Mock(side_effect=_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -2592,7 +2592,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         def _import_side_effect(name, *args, **kwargs):
             if name == "bleak":
-                raise ImportError("no bleak")
+                raise ImportError()
             return real_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=_import_side_effect):

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2392,7 +2392,9 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         timeout_future.done.return_value = False
         timeout_future.add_done_callback = Mock()
 
-        orig_stdout = object()
+        import sys
+
+        orig_stdout = sys.stdout
 
         redirect_active = threading.Event()
         redirect_active.set()
@@ -2413,6 +2415,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         timeout_future.result.side_effect = _raise_timeout
 
         mock_executor = Mock()
+        mock_executor._shutdown = False
         mock_executor.submit.return_value = timeout_future
 
         with (
@@ -2422,7 +2425,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             ),
             patch("mmrelay.meshtastic_utils._metadata_executor", mock_executor),
             patch("mmrelay.meshtastic_utils.sys.stdout", orig_stdout),
-            patch("mmrelay.meshtastic_utils.redirect_active", redirect_active),
         ):
             result = _get_device_metadata(mock_client)
 
@@ -2440,6 +2442,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
     @patch("mmrelay.meshtastic_utils.logger")
     def test_get_device_metadata_timeout_restores_stdio(self, _mock_logger):
         """Test _get_device_metadata restores stdio when timeout happens mid-redirect."""
+        import threading
         from concurrent.futures import TimeoutError as FuturesTimeoutError
 
         from mmrelay.meshtastic_utils import _get_device_metadata
@@ -2462,6 +2465,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         redirect_active.set()
 
         mock_executor = Mock()
+        mock_executor._shutdown = False
         mock_executor.submit.return_value = timeout_future
 
         with (
@@ -2469,7 +2473,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             patch("threading.Event", return_value=redirect_active),
             patch("mmrelay.meshtastic_utils._metadata_executor", mock_executor),
             patch("mmrelay.meshtastic_utils.sys.stdout", output_capture),
-            patch("mmrelay.meshtastic_utils.redirect_active", redirect_active),
         ):
             result = _get_device_metadata(mock_client)
 
@@ -2831,6 +2834,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mock_future.cancel = Mock(return_value=True)
 
         mock_executor = Mock()
+        mock_executor._shutdown = False
         mock_executor.submit.return_value = mock_future
 
         with patch("mmrelay.meshtastic_utils._ble_executor", mock_executor):
@@ -2946,6 +2950,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
                 return connect_future
 
         mock_executor = Mock()
+        mock_executor._shutdown = False
         mock_executor.submit.side_effect = submit_side_effect
 
         with patch("mmrelay.meshtastic_utils._ble_executor", mock_executor):

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2333,7 +2333,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         # even when is_connected is False
         mock_client.disconnect.assert_called()
 
-    @patch("mmrelay.meshtastic_utils.asyncio.run")
     @patch("mmrelay.meshtastic_utils.logger")
     @patch("mmrelay.meshtastic_utils.asyncio.get_running_loop")
     @patch("mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe")
@@ -2344,7 +2343,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mock_run_coroutine_threadsafe,
         mock_get_running_loop,
         mock_logger,
-        mock_run,
     ):
         """Test _disconnect_ble_by_address handles FuturesTimeoutError."""
         from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -2375,8 +2373,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         )
         # Verify future.cancel() was called
         mock_future.cancel.assert_called_once()
-        # Verify fallback disconnect via asyncio.run was called
-        mock_run.assert_called_once()
 
     def test_disconnect_ble_interface_none_input(self):
         """Test _disconnect_ble_interface returns early when iface is None."""

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -43,12 +43,28 @@ class _FakeEvent:
     """Threading.Event test double for metadata redirect behavior."""
 
     def is_set(self) -> bool:
+        """
+        Always reports the fake event as set.
+        
+        Returns:
+            bool: `True`, indicating the event is considered set.
+        """
         return True
 
     def set(self) -> None:
+        """
+        Mark the event as set so subsequent is_set() calls return True.
+        
+        Mimics threading.Event.set behavior for the test double.
+        """
         return None
 
     def clear(self) -> None:
+        """
+        No-op placeholder for clearing the object's internal state.
+        
+        This method currently performs no action and exists to be overridden or implemented to reset the instance's state.
+        """
         return None
 
 
@@ -1308,7 +1324,15 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
 
 @pytest.fixture
 def reset_meshtastic_globals():
-    """Reset global state for connection retry tests."""
+    """
+    Reset Meshtastic-related global state before a test and restore it afterward.
+    
+    This generator-style fixture clears the shared module-level variables used by
+    connection and BLE logic so tests run in a clean environment. It resets:
+    `meshtastic_client`, `shutting_down`, `reconnecting`, `_ble_future`,
+    `_ble_future_address`, and `_metadata_future`. The fixture yields once to run
+    the test and then performs the same resets as cleanup.
+    """
     import mmrelay.meshtastic_utils
 
     mmrelay.meshtastic_utils.meshtastic_client = None
@@ -2327,6 +2351,16 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         def _raise_timeout(*_args, **_kwargs):
             # Simulate a worker redirecting stdout before the timeout hits.
+            """
+            Simulate a worker that redirects stdout and then triggers a futures timeout.
+            
+            This test helper replaces mu.sys.stdout with the provided mock_output to mimic a worker
+            redirecting standard output and then raises FuturesTimeoutError to simulate a timeout
+            condition.
+            
+            Raises:
+                FuturesTimeoutError: Indicates the simulated timeout.
+            """
             mu.sys.stdout = mock_output
             raise FuturesTimeoutError()
 
@@ -2401,6 +2435,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         async def _noop(*_args, **_kwargs):
+            """
+            Asynchronous no-op that ignores all positional and keyword arguments.
+            
+            Returns:
+                None: Always returns None.
+            """
             return None
 
         mock_client = Mock()
@@ -2418,10 +2458,20 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
     def test_disconnect_ble_by_address_is_connected_bool_false(
         self, mock_bleak, _mock_logger
     ):
-        """Test _disconnect_ble_by_address when is_connected is a bool (False)."""
+        """
+        Verify _disconnect_ble_by_address invokes the client's disconnect as a best-effort cleanup when the client's is_connected attribute indicates the device is not connected.
+        
+        Asserts that disconnect is called from the cleanup path even if the client reports it is not connected (and is_connected is not callable).
+        """
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         async def _noop(*_args, **_kwargs):
+            """
+            Asynchronous no-op that ignores all positional and keyword arguments.
+            
+            Returns:
+                None: Always returns None.
+            """
             return None
 
         mock_client = Mock()
@@ -2445,6 +2495,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         async def _noop(*_args, **_kwargs):
+            """
+            Asynchronous no-op that ignores all positional and keyword arguments.
+            
+            Returns:
+                None: Always returns None.
+            """
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -2470,6 +2526,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         async def _noop(*_args, **_kwargs):
+            """
+            Asynchronous no-op that ignores all positional and keyword arguments.
+            
+            Returns:
+                None: Always returns None.
+            """
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -2501,6 +2563,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         async def _noop(*_args, **_kwargs):
+            """
+            Asynchronous no-op that ignores all positional and keyword arguments.
+            
+            Returns:
+                None: Always returns None.
+            """
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -2535,6 +2603,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         async def _noop(*_args, **_kwargs):
+            """
+            Asynchronous no-op that ignores all positional and keyword arguments.
+            
+            Returns:
+                None: Always returns None.
+            """
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -2574,6 +2648,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         async def _noop(*_args, **_kwargs):
+            """
+            Asynchronous no-op that ignores all positional and keyword arguments.
+            
+            Returns:
+                None: Always returns None.
+            """
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -2600,6 +2680,20 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         real_import = builtins.__import__
 
         def _import_side_effect(name, *args, **kwargs):
+            """
+            Simulate an import hook that raises ImportError for the "bleak" module and otherwise performs a normal import.
+            
+            Parameters:
+                name (str): The module name to import; when equal to "bleak" an ImportError is raised.
+                *args: Positional arguments forwarded to the real import function.
+                **kwargs: Keyword arguments forwarded to the real import function.
+            
+            Returns:
+                module: The imported module object returned by the underlying import.
+            
+            Raises:
+                ImportError: If `name` is exactly "bleak".
+            """
             if name == "bleak":
                 raise ImportError()
             return real_import(name, *args, **kwargs)
@@ -2786,6 +2880,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         call_count = [0]
 
         def submit_side_effect(_func, *_args, **_kwargs):
+            """
+            Test helper used as a side-effect function to simulate a two-stage submission flow.
+            
+            Increments the shared call_count[0] each time it is invoked and, on the first invocation, returns the precreated interface_future; on subsequent invocations, returns the connect_future. The provided positional and keyword arguments are ignored.
+            """
             call_count[0] += 1
             if call_count[0] == 1:
                 # First call: interface creation

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1113,8 +1113,10 @@ class TestConnectMeshtasticEdgeCases(unittest.TestCase):
 
         self.assertIsNone(result)
 
+    @patch("mmrelay.meshtastic_utils.INFINITE_RETRIES", 1)
+    @patch("mmrelay.meshtastic_utils.time.sleep")
     @patch("mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface")
-    def test_connect_meshtastic_ble_exception(self, mock_ble):
+    def test_connect_meshtastic_ble_exception(self, mock_ble, _mock_sleep):
         """
         Test that connect_meshtastic returns None when the BLE interface raises an exception during connection.
         """
@@ -1123,6 +1125,14 @@ class TestConnectMeshtasticEdgeCases(unittest.TestCase):
         config = {
             "meshtastic": {"connection_type": "ble", "ble_address": "AA:BB:CC:DD:EE:FF"}
         }
+
+        import mmrelay.meshtastic_utils as mu
+
+        mu.meshtastic_client = None
+        mu.meshtastic_iface = None
+        mu.reconnecting = False
+        mu.shutting_down = False
+        mu._ble_future = None
 
         result = connect_meshtastic(passed_config=config)
 
@@ -2742,6 +2752,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mock_iface = Mock()
         mock_iface.getMyNodeInfo.return_value = {"num": 123}
         mock_iface.connect = Mock()  # Has connect() method to trigger connect() path
+        mock_iface.auto_reconnect = False
 
         interface_future = Mock()
         interface_future.result = Mock(return_value=mock_iface)

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2297,9 +2297,12 @@ class TestUncoveredMeshtasticUtils(unittest.TestCase):
             connect_meshtastic(config, force_connect=True)
 
             # Should log warning about close error but continue
-            mock_logger.warning.assert_called_with(
-                "Error closing previous connection: Close error"
-            )
+            assert mock_logger.warning.called
+            args = mock_logger.warning.call_args
+            assert args[0][0] == "Error closing previous connection: %s"
+            assert isinstance(args[0][1], Exception)
+            assert str(args[0][1]) == "Close error"
+            assert args[1].get("exc_info") is True
 
     @patch("mmrelay.meshtastic_utils.reconnecting", True)
     @patch(

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -114,6 +114,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         mmrelay.meshtastic_utils._ble_future = None
         mmrelay.meshtastic_utils._ble_future_address = None
         mmrelay.meshtastic_utils._metadata_future = None
+        mmrelay.meshtastic_utils._ble_timeout_counts = {}
 
     def test_on_meshtastic_message_basic(self):
         """
@@ -1158,6 +1159,7 @@ class TestConnectMeshtasticEdgeCases(unittest.TestCase):
         mu._ble_future = None
         mu._ble_future_address = None
         mu._metadata_future = None
+        mu._ble_timeout_counts = {}
 
         result = connect_meshtastic(passed_config=config)
 
@@ -1341,6 +1343,7 @@ def reset_meshtastic_globals():
     mmrelay.meshtastic_utils._ble_future = None
     mmrelay.meshtastic_utils._ble_future_address = None
     mmrelay.meshtastic_utils._metadata_future = None
+    mmrelay.meshtastic_utils._ble_timeout_counts = {}
     yield
     # Cleanup after test
     mmrelay.meshtastic_utils.meshtastic_client = None
@@ -1349,6 +1352,7 @@ def reset_meshtastic_globals():
     mmrelay.meshtastic_utils._ble_future = None
     mmrelay.meshtastic_utils._ble_future_address = None
     mmrelay.meshtastic_utils._metadata_future = None
+    mmrelay.meshtastic_utils._ble_timeout_counts = {}
 
 
 @patch("mmrelay.meshtastic_utils.time.sleep")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2299,7 +2299,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
     @patch("mmrelay.meshtastic_utils.logger")
     @patch("bleak.BleakClient")
     def test_disconnect_ble_by_address_is_connected_bool_true(
-        self, mock_bleak, mock_logger
+        self, mock_bleak, _mock_logger
     ):
         """Test _disconnect_ble_by_address when is_connected is a bool (True)."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
@@ -2317,7 +2317,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
     @patch("mmrelay.meshtastic_utils.logger")
     @patch("bleak.BleakClient")
     def test_disconnect_ble_by_address_is_connected_bool_false(
-        self, mock_bleak, mock_logger
+        self, mock_bleak, _mock_logger
     ):
         """Test _disconnect_ble_by_address when is_connected is a bool (False)."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
@@ -2384,7 +2384,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
     @patch("mmrelay.meshtastic_utils.logger")
     @patch("mmrelay.meshtastic_utils.time")
     def test_connect_meshtastic_ble_interface_creation_timeout(
-        self, mock_time, mock_logger
+        self, _mock_time, mock_logger
     ):
         """Test connect_meshtastic handles BLEInterface creation timeout."""
         from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -2421,13 +2421,13 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             # Verify timeout error was logged 6 times (once per attempt)
             error_calls = [
                 call
-                for call in mock_logger.error.call_args_list
+                for call in mock_logger.exception.call_args_list
                 if "timed out after 90 seconds" in str(call)
             ]
             self.assertEqual(len(error_calls), 6)
 
             # Verify that last error call contains BLE address
-            last_error_call = error_calls[-1][0][0]
+            last_error_call = str(error_calls[-1])
             self.assertIn("AA:BB:CC:DD:EE:FF", last_error_call)
 
             # Verify final abort was logged after max retries (using logger.exception)
@@ -2449,7 +2449,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.logger")
     @patch("mmrelay.meshtastic_utils.time")
-    def test_connect_meshtastic_ble_connect_timeout(self, mock_time, mock_logger):
+    def test_connect_meshtastic_ble_connect_timeout(self, _mock_time, mock_logger):
         """Test connect_meshtastic handles BLE connect() timeout."""
         from concurrent.futures import TimeoutError as FuturesTimeoutError
 
@@ -2481,7 +2481,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         # Track which submit call we're handling
         call_count = [0]
 
-        def submit_side_effect(func, *args, **kwargs):
+        def submit_side_effect(_func, *_args, **_kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
                 # First call: interface creation
@@ -2505,7 +2505,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             # Verify connect() timeout error was logged on first attempt
             connect_timeout_calls = [
                 call
-                for call in mock_logger.error.call_args_list
+                for call in mock_logger.exception.call_args_list
                 if "connect() call timed out after 30 seconds" in str(call)
             ]
             self.assertEqual(len(connect_timeout_calls), 1)
@@ -2514,7 +2514,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             # (because meshtastic_iface is set to None after connect timeout)
             interface_timeout_calls = [
                 call
-                for call in mock_logger.error.call_args_list
+                for call in mock_logger.exception.call_args_list
                 if "timed out after 90 seconds" in str(call)
             ]
             self.assertEqual(len(interface_timeout_calls), 5)

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -97,6 +97,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         mmrelay.meshtastic_utils.reconnect_task = None
         mmrelay.meshtastic_utils._ble_future = None
         mmrelay.meshtastic_utils._ble_future_address = None
+        mmrelay.meshtastic_utils._metadata_future = None
 
     def test_on_meshtastic_message_basic(self):
         """
@@ -1140,6 +1141,7 @@ class TestConnectMeshtasticEdgeCases(unittest.TestCase):
         mu.shutting_down = False
         mu._ble_future = None
         mu._ble_future_address = None
+        mu._metadata_future = None
 
         result = connect_meshtastic(passed_config=config)
 
@@ -1314,6 +1316,7 @@ def reset_meshtastic_globals():
     mmrelay.meshtastic_utils.reconnecting = False
     mmrelay.meshtastic_utils._ble_future = None
     mmrelay.meshtastic_utils._ble_future_address = None
+    mmrelay.meshtastic_utils._metadata_future = None
     yield
     # Cleanup after test
     mmrelay.meshtastic_utils.meshtastic_client = None
@@ -1321,6 +1324,7 @@ def reset_meshtastic_globals():
     mmrelay.meshtastic_utils.reconnecting = False
     mmrelay.meshtastic_utils._ble_future = None
     mmrelay.meshtastic_utils._ble_future_address = None
+    mmrelay.meshtastic_utils._metadata_future = None
 
 
 @patch("mmrelay.meshtastic_utils.time.sleep")
@@ -2688,6 +2692,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
             mu._ble_future = None
             mu._ble_future_address = None
+            mu._metadata_future = None
             # The function will retry 6 times (MAX_TIMEOUT_RETRIES_INFINITE = 5 + 1)
             # After all retries, it returns None (doesn't raise)
             result = connect_meshtastic(passed_config=config)
@@ -2796,6 +2801,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
             mu._ble_future = None
             mu._ble_future_address = None
+            mu._metadata_future = None
             # The function will retry 6 times and return None (doesn't raise)
             result = connect_meshtastic(passed_config=config)
             self.assertIsNone(result)

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2260,6 +2260,7 @@ class TestUncoveredMeshtasticUtils(unittest.TestCase):
         )
 
 
+@pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
     """Test cases for uncovered code paths in meshtastic_utils.py."""
 

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -45,7 +45,7 @@ class _FakeEvent:
     def is_set(self) -> bool:
         """
         Always reports the fake event as set.
-        
+
         Returns:
             bool: `True`, indicating the event is considered set.
         """
@@ -54,7 +54,7 @@ class _FakeEvent:
     def set(self) -> None:
         """
         Mark the event as set so subsequent is_set() calls return True.
-        
+
         Mimics threading.Event.set behavior for the test double.
         """
         return None
@@ -62,7 +62,7 @@ class _FakeEvent:
     def clear(self) -> None:
         """
         No-op placeholder for clearing the object's internal state.
-        
+
         This method currently performs no action and exists to be overridden or implemented to reset the instance's state.
         """
         return None
@@ -1326,7 +1326,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
 def reset_meshtastic_globals():
     """
     Reset Meshtastic-related global state before a test and restore it afterward.
-    
+
     This generator-style fixture clears the shared module-level variables used by
     connection and BLE logic so tests run in a clean environment. It resets:
     `meshtastic_client`, `shutting_down`, `reconnecting`, `_ble_future`,
@@ -2353,11 +2353,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             # Simulate a worker redirecting stdout before the timeout hits.
             """
             Simulate a worker that redirects stdout and then triggers a futures timeout.
-            
+
             This test helper replaces mu.sys.stdout with the provided mock_output to mimic a worker
             redirecting standard output and then raises FuturesTimeoutError to simulate a timeout
             condition.
-            
+
             Raises:
                 FuturesTimeoutError: Indicates the simulated timeout.
             """
@@ -2437,7 +2437,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         async def _noop(*_args, **_kwargs):
             """
             Asynchronous no-op that ignores all positional and keyword arguments.
-            
+
             Returns:
                 None: Always returns None.
             """
@@ -2460,7 +2460,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
     ):
         """
         Verify _disconnect_ble_by_address invokes the client's disconnect as a best-effort cleanup when the client's is_connected attribute indicates the device is not connected.
-        
+
         Asserts that disconnect is called from the cleanup path even if the client reports it is not connected (and is_connected is not callable).
         """
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
@@ -2468,7 +2468,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         async def _noop(*_args, **_kwargs):
             """
             Asynchronous no-op that ignores all positional and keyword arguments.
-            
+
             Returns:
                 None: Always returns None.
             """
@@ -2497,7 +2497,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         async def _noop(*_args, **_kwargs):
             """
             Asynchronous no-op that ignores all positional and keyword arguments.
-            
+
             Returns:
                 None: Always returns None.
             """
@@ -2528,7 +2528,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         async def _noop(*_args, **_kwargs):
             """
             Asynchronous no-op that ignores all positional and keyword arguments.
-            
+
             Returns:
                 None: Always returns None.
             """
@@ -2565,7 +2565,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         async def _noop(*_args, **_kwargs):
             """
             Asynchronous no-op that ignores all positional and keyword arguments.
-            
+
             Returns:
                 None: Always returns None.
             """
@@ -2605,7 +2605,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         async def _noop(*_args, **_kwargs):
             """
             Asynchronous no-op that ignores all positional and keyword arguments.
-            
+
             Returns:
                 None: Always returns None.
             """
@@ -2650,7 +2650,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         async def _noop(*_args, **_kwargs):
             """
             Asynchronous no-op that ignores all positional and keyword arguments.
-            
+
             Returns:
                 None: Always returns None.
             """
@@ -2682,15 +2682,15 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _import_side_effect(name, *args, **kwargs):
             """
             Simulate an import hook that raises ImportError for the "bleak" module and otherwise performs a normal import.
-            
+
             Parameters:
                 name (str): The module name to import; when equal to "bleak" an ImportError is raised.
                 *args: Positional arguments forwarded to the real import function.
                 **kwargs: Keyword arguments forwarded to the real import function.
-            
+
             Returns:
                 module: The imported module object returned by the underlying import.
-            
+
             Raises:
                 ImportError: If `name` is exactly "bleak".
             """
@@ -2882,7 +2882,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def submit_side_effect(_func, *_args, **_kwargs):
             """
             Test helper used as a side-effect function to simulate a two-stage submission flow.
-            
+
             Increments the shared call_count[0] each time it is invoked and, on the first invocation, returns the precreated interface_future; on subsequent invocations, returns the connect_future. The provided positional and keyword arguments are ignored.
             """
             call_count[0] += 1

--- a/tests/test_meshtastic_utils_async_helpers.py
+++ b/tests/test_meshtastic_utils_async_helpers.py
@@ -12,7 +12,7 @@ class _DummyLoop:
     def is_running(self):
         """
         Indicates that this dummy loop is always considered running.
-        
+
         Returns:
             True, since the dummy loop is always treated as running.
         """
@@ -21,10 +21,10 @@ class _DummyLoop:
     def create_task(self, _coro):
         """
         Simulate scheduling a coroutine by closing it and returning a MagicMock representing the created task.
-        
+
         Parameters:
             _coro: A coroutine object which will be closed.
-        
+
         Returns:
             MagicMock: A mock object standing in for the scheduled task.
         """
@@ -35,10 +35,10 @@ class _DummyLoop:
 def _make_threadsafe_runner(result_value):
     """
     Create a fake thread-safe runner that closes a coroutine and returns a mock future.
-    
+
     Parameters:
         result_value: Value that the returned mock future's `result()` method will return.
-    
+
     Returns:
         A callable with signature `(coro, _loop)` that closes `coro` and returns a MagicMock whose `result()` returns `result_value`.
     """
@@ -138,7 +138,7 @@ def test_wait_for_result_running_loop_threadsafe():
 def test_wait_for_result_running_loop_not_running():
     """
     Verifies that _wait_for_result executes a coroutine on a loop returned by get_running_loop when that loop is not running and returns the coroutine's result.
-    
+
     Patches asyncio.get_running_loop to return a newly created (not running) event loop, calls _wait_for_result with a coroutine that returns "sync-loop", and asserts the observed result is "sync-loop".
     """
     loop = asyncio.new_event_loop()

--- a/tests/test_meshtastic_utils_async_helpers.py
+++ b/tests/test_meshtastic_utils_async_helpers.py
@@ -10,14 +10,38 @@ class _DummyLoop:
         return False
 
     def is_running(self):
+        """
+        Indicates that this dummy loop is always considered running.
+        
+        Returns:
+            True, since the dummy loop is always treated as running.
+        """
         return True
 
     def create_task(self, _coro):
+        """
+        Simulate scheduling a coroutine by closing it and returning a MagicMock representing the created task.
+        
+        Parameters:
+            _coro: A coroutine object which will be closed.
+        
+        Returns:
+            MagicMock: A mock object standing in for the scheduled task.
+        """
         _coro.close()
         return MagicMock()
 
 
 def _make_threadsafe_runner(result_value):
+    """
+    Create a fake thread-safe runner that closes a coroutine and returns a mock future.
+    
+    Parameters:
+        result_value: Value that the returned mock future's `result()` method will return.
+    
+    Returns:
+        A callable with signature `(coro, _loop)` that closes `coro` and returns a MagicMock whose `result()` returns `result_value`.
+    """
     result_future = MagicMock()
     result_future.result.return_value = result_value
 
@@ -112,6 +136,11 @@ def test_wait_for_result_running_loop_threadsafe():
 
 
 def test_wait_for_result_running_loop_not_running():
+    """
+    Verifies that _wait_for_result executes a coroutine on a loop returned by get_running_loop when that loop is not running and returns the coroutine's result.
+    
+    Patches asyncio.get_running_loop to return a newly created (not running) event loop, calls _wait_for_result with a coroutine that returns "sync-loop", and asserts the observed result is "sync-loop".
+    """
     loop = asyncio.new_event_loop()
     try:
         with patch(

--- a/tests/test_meshtastic_utils_async_helpers.py
+++ b/tests/test_meshtastic_utils_async_helpers.py
@@ -12,6 +12,10 @@ class _DummyLoop:
     def is_running(self):
         return True
 
+    def create_task(self, _coro):
+        _coro.close()
+        return MagicMock()
+
 
 def _make_threadsafe_runner(result_value):
     result_future = MagicMock()
@@ -97,13 +101,14 @@ def test_wait_for_result_running_loop_threadsafe():
             patch(
                 "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
                 side_effect=_make_threadsafe_runner("running"),
-            ),
+            ) as mock_threadsafe,
         ):
             result = _wait_for_result(future, timeout=0.1)
     finally:
         loop.close()
 
-    assert result == "running"
+    assert result is False
+    mock_threadsafe.assert_not_called()
 
 
 def test_wait_for_result_running_loop_not_running():

--- a/tests/test_plugin_loader_edge_cases.py
+++ b/tests/test_plugin_loader_edge_cases.py
@@ -105,13 +105,11 @@ class TestPluginLoaderEdgeCases(unittest.TestCase):
             # Create a plugin file with failing initialization
             plugin_file = os.path.join(temp_dir, "failing_plugin.py")
             with open(plugin_file, "w") as f:
-                f.write(
-                    """
+                f.write("""
 class Plugin:
     def __init__(self):
         raise Exception("Initialization failed")
-"""
-                )
+""")
 
             with patch("mmrelay.plugin_loader.logger") as mock_logger:
                 plugins = load_plugins_from_directory(temp_dir)
@@ -127,13 +125,11 @@ class Plugin:
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_file = os.path.join(temp_dir, "dependency_plugin.py")
             with open(plugin_file, "w") as f:
-                f.write(
-                    """
+                f.write("""
 import nonexistent_module
 class Plugin:
     pass
-"""
-                )
+""")
 
             # Mock environment to force pip usage instead of pipx
             with patch.dict(
@@ -184,14 +180,12 @@ class Plugin:
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_file = os.path.join(temp_dir, "dependency_plugin.py")
             with open(plugin_file, "w") as f:
-                f.write(
-                    """
+                f.write("""
 import missing_dependency
 class Plugin:
     def __init__(self):
         self.plugin_name = "dependency_plugin"
-"""
-                )
+""")
 
             missing_module = "missing_dependency"
             sys.modules.pop(missing_module, None)
@@ -240,13 +234,11 @@ class Plugin:
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_file = os.path.join(temp_dir, "dependency_plugin.py")
             with open(plugin_file, "w") as f:
-                f.write(
-                    """
+                f.write("""
 import nonexistent_module
 class Plugin:
     pass
-"""
-                )
+""")
 
             with patch("subprocess.run") as mock_run:
                 mock_run.return_value.returncode = 1  # Failed installation

--- a/tests/test_setup_utils.py
+++ b/tests/test_setup_utils.py
@@ -827,9 +827,7 @@ ExecStart=%h/meshtastic-matrix-relay/.pyenv/bin/python %h/meshtastic-matrix-rela
     
     [Install]
     WantedBy=default.target
-    """.format(
-            sys.executable
-        )
+    """.format(sys.executable)
 
         # Mock template path and acceptable executables
         with (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR refactors BLE connect/reply/disconnect and shutdown handling to improve reliability, prevent hangs, and make behavior more testable and deterministic. It moves blocking BLE work off the event loop, enforces timeouts with per-address backoff and recovery (including recreating executors after repeated failures), hardens disconnect/teardown paths (supporting sync and async disconnects and avoiding event-loop blocking), and expands tests and test helpers to exercise shutdown and connection edge cases.

## Key changes

Features & improvements
- Executors & timeouts
  - Added shared single-worker executors and locks for BLE and metadata tasks (_get_ble_executor, _get_metadata_executor) and a _shutdown_shared_executors helper registered with atexit to control threads and enable orderly shutdown.
  - _run_blocking_with_timeout runs blocking BLE actions in daemon worker threads with enforced timeouts (raises TimeoutError on timeout) and a configurable timeout_log_level (default WARNING).
  - connect_meshtastic coordinates BLE task state (_ble_future, _ble_future_address), avoids submitting new BLE tasks while shutting down, returns early when futures are already done, and guards interface creation/connect with timeouts.
  - Per-address timeout counting (_record_ble_timeout) with backoff and _maybe_reset_ble_executor to rebuild BLE executors after persistent timeouts to recover from blocked workers.
  - Meshtastic close is performed via a single-worker ThreadPoolExecutor with a 10s timeout, explicit cancellation on timeout, and a TypeError fallback for older Python versions.

- Lifecycle, disconnect & discovery
  - _disconnect_ble_interface and _disconnect_ble_by_address support both synchronous and asynchronous disconnect methods; blocking disconnects are executed off the event loop when invoked on the loop.
  - Added _clear_ble_future and _schedule_ble_future_cleanup watchdogs to clear stale BLE futures and schedule delayed cleanup of potentially stuck tasks.
  - Added _scan_for_ble_address and pre-scan logic before reconnect retries, and _is_ble_discovery_error to classify discovery/connection failures.
  - On address changes, previous interfaces are cleanly disconnected; stale futures are cleared on reconnect and optional scans are performed before retrying.

- Error handling & logging
  - Timers are cancelled on future completion; asyncio.TimeoutError is converted/handled as TimeoutError where appropriate and action exceptions are re-raised for caller handling.
  - Logging adjusted: parameterized messages, include exc_info where useful, and reduce disconnect noise during shutdown (use DEBUG during shutdown).
  - During shutdown, pending BLE and metadata futures are explicitly cancelled and atexit handlers are unregistered to avoid interpreter hangs; connect_meshtastic raises TimeoutError if invoked while shutting down to reuse retry logic.

Fixes & robustness
- Prevents event-loop deadlocks by offloading blocking operations to worker threads and refining wait/result handling.
- Reduces thread/resource leakage by sharing executors and recreating them after persistent failure patterns.
- Adds explicit cancellation of pending BLE and metadata futures during shutdown to avoid interpreter/interpreter-exit hangs.
- Clears stale state on reconnects and uses pre-scan/backoff logic to improve reconnect reliability.

Refactors & typing
- Centralized ThreadPoolExecutor usage with module-level guards, locks, and explicit shutdown logic.
- Added type annotations and selective # type: ignore for untyped imports; pinned types-PyYAML in requirements/setup for dev typing support.
- matrix_utils now resolves nio exceptions at runtime via importlib with a test stub fallback instead of direct per-name imports.
- Tightened some internal helper signatures (e.g., _get_packet_details) and clarified global-state management.

Tests
- Expanded tests and deterministic test helpers to avoid hanging tests and to exercise shutdown/connection edge cases:
  - Added InlineExecutorLoop, inline_to_thread, controlled executors/futures, and async helper factories for deterministic behavior.
  - New tests cover metadata timeouts and stdout restoration, BLE connect/disconnect timeouts and recovery, absent Bleak backend paths, shutdown races (including executor.shutdown TypeError fallback), signal registration, and global-state resets.
  - Fixtures updated to reset new internal globals (_metadata_future, _ble_future, _ble_future_address).

Breaking changes & migration notes
- No intended public API signature changes.
- Internal behavior changes callers/tests should be aware of:
  - Module-level BLE/metadata futures and executors may be cancelled or recreated on timeouts/failures; code or tests that inspect these internals should tolerate None or different executor/future objects.
  - Shutdown now runs close() in an executor with a timeout and may raise TimeoutError or cancel futures; callers/tests that assumed synchronous close timing should accommodate possible timeout/cancellation.
  - Tests or tooling relying on prior synchronous BLE timing may need updating to account for offloading and enforced timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->