### PR TITLE
Documentation updates, type annotations, and BLE improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 
 ## Documentation
 
-MMRelay supports multiple deployment methods including Docker, pip installation, and standalone executables. For complete setup instructions and all deployment options, see:
+MMRelay supports multiple deployment methods including pipx, Docker, and Kubernetes. For complete setup instructions and all deployment options, see:
 
 - [Installation Instructions](docs/INSTRUCTIONS.md) - Setup and configuration guide
 - [Docker Guide](docs/DOCKER.md) - Docker deployment methods
+- [Kubernetes Guide](docs/KUBERNETES.md) - Kubernetes deployment guide
 - [What's New in v1.2](docs/WHATS_NEW_1.2.md) - New features and improvements
 - [E2EE Setup Guide](docs/E2EE.md) - Matrix End-to-End Encryption configuration
 

--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -189,6 +189,14 @@ Precedence at startup:
 
 These environment variables can override config.yaml settings:
 
+#### Matrix Authentication (Container Deployments)
+
+The `MMRELAY_MATRIX_*` variables (HOMESERVER, BOT_USER_ID, PASSWORD, ACCESS_TOKEN) are for containerized deployments where credentials are injected via Secrets or environment variables.
+
+- **Kubernetes**: Use Kubernetes Secrets with the manifest generator (recommended)
+- **Docker**: Use `mmrelay auth login` or environment variables
+- **All other deployments**: Use `mmrelay auth login`
+
 #### Meshtastic Connection Settings
 
 - **`MMRELAY_MESHTASTIC_CONNECTION_TYPE`**: Connection method (`tcp`, `serial`, or `ble`)

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -152,81 +152,33 @@ MMRelay uses a single configuration file: `~/.mmrelay/config.yaml`. All settings
 
 ## Matrix Authentication
 
-MMRelay requires Matrix authentication to connect to your Matrix homeserver. There are two approaches, with the auth system being strongly recommended for security and functionality.
+MMRelay requires Matrix authentication. Use the auth system for secure authentication with E2EE support.
 
 ### Auth System (`mmrelay auth login`)
 
-The auth system provides E2EE support and persistent device identity.
+Run this on your host system (not in Docker):
 
 ```bash
-# Run this on your host system (not in Docker)
 mmrelay auth login
 ```
 
-**What this does:**
+This creates `~/.mmrelay/credentials.json` with:
 
-- Creates `~/.mmrelay/credentials.json` with secure session credentials
-- Generates a persistent device ID for your MMRelay instance
-- Sets up encryption key storage for E2EE support
-- Establishes proper Matrix session lifecycle
+- E2EE support for encrypted rooms
+- Persistent device identity (no "new device" notifications)
+- Automatic token refresh and key management
+- Matrix 2.0 / MAS (Authentication Service) compatibility
 
-**Features:**
-
-- **E2EE Support**: Provides encrypted room participation
-- **Persistent Device Identity**: Same device across restarts, no "new device" notifications
-- **Automatic Key Management**: Handles encryption keys, sharing, and storage
-- **Convenience**: No manual token capture from browser sessions required
-- **Secure Storage**: Credentials stored with restricted file permissions (600 on Unix systems)
-
-### Password-based Authentication (Non-Interactive)
-
-Alternative authentication method for Docker deployments where interactive authentication isn't possible. This method uses a password in config.yaml for automatic credential creation.
-
-```yaml
-# In your config.yaml file
-matrix:
-  homeserver: https://matrix.example.org
-  password: your_matrix_password  # Your Matrix account password
-  bot_user_id: @yourbot:example.org
-```
-
-**How it works:**
-
-1. **Add password to config.yaml** as shown above
-2. **Remove or comment out** any `access_token` line if present
-3. **Start the container** - MMRelay will automatically:
-   - Log in to Matrix using your password
-   - Create `credentials.json` with secure session tokens
-   - Enable E2EE support if configured
-   - Continue normal operation
-
-**This method is ideal for:**
-
-- Docker deployments without interactive terminals
-- Automated deployments and CI/CD pipelines
-- Users who haven't cloned the repository
-- Environments without Python installed locally
-
-**Security Note:** The password is only used once during initial setup to create `credentials.json`. For enhanced security, remove the `password` field from your `config.yaml` after the first successful startup. On SSO/OIDC-only homeservers (password logins disabled), this method will fail — use the auth system method instead.
-
-**Docker Compose tip:**
-
-```yaml
-volumes:
-  # For SELinux systems, add :Z
-  - ${MMRELAY_HOME:-$HOME}/.mmrelay/config.yaml:/app/config.yaml:ro,Z
-  - ${MMRELAY_HOME:-$HOME}/.mmrelay:/app/data:Z
-  # Non-SELinux:
-  # - ${MMRELAY_HOME:-$HOME}/.mmrelay/config.yaml:/app/config.yaml:ro
-  # - ${MMRELAY_HOME:-$HOME}/.mmrelay:/app/data
-```
+The `credentials.json` file is automatically mounted to `/app/data/credentials.json` in the container.
 
 ### Authentication Precedence
 
 MMRelay checks for authentication in this order:
 
-1. **`credentials.json`** (from auth system) - full features
-2. **`config.yaml` matrix section (password-based)** - automatic credential creation; E2EE supported when dependencies are available
+1. **`credentials.json`** (from `mmrelay auth login`) - recommended
+2. **`config.yaml` matrix section (password)** - fallback; password in config file automatically creates credentials.json
+
+> **Note**: For security and full functionality, use `mmrelay auth login`. The password-based method in `config.yaml` is available as a fallback option.
 
 ## Make Commands Reference
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -71,7 +71,7 @@ That's it! MMRelay will automatically encrypt messages for encrypted rooms and d
 
 **E2EE is not available on Windows** due to technical limitations with the required cryptographic libraries. The `python-olm` library requires native C libraries that are difficult to compile and install on Windows systems.
 
-**Windows users can still use MMRelay** for regular (unencrypted) Matrix communication. Use `mmrelay auth login` to create credentials on Windows (recommended; E2EE not available). Alternatively, use password-based automatic authentication in `config.yaml` (MMRelay will create credentials.json on startup and is compatible with Matrix 2.0/MAS). After the first successful start, remove the password from the config and restrict file permissions.
+**Windows users can still use MMRelay** for regular (unencrypted) Matrix communication. Use `mmrelay auth login` to create credentials.
 
 ## The `auth login` Command
 
@@ -212,18 +212,7 @@ The `credentials.json` file contains:
 **Solutions**:
 
 - **Use Linux or macOS** for full E2EE support
-- **On Windows**: `mmrelay auth login` still works for regular Matrix communication (recommended)
-- **Alternative**: Configure password-based authentication in `config.yaml`:
-  ```yaml
-  matrix:
-    homeserver: https://your-matrix-server.org
-    password: your_matrix_password
-    bot_user_id: @yourbot:your-matrix-server.org
-  ```
-
-This method automatically creates a secure credentials.json and is compatible with Matrix 2.0/MAS. Use `mmrelay auth login` for the most secure interactive setup.
-
-**Security**: After the first successful start, remove the password from config and restrict file permissions.
+- **On Windows**: `mmrelay auth login` works for regular Matrix communication
 
 **Note**: Credentials created with `mmrelay auth login` on Windows will work with E2EE if you later use them on Linux/macOS.
 

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -91,24 +91,10 @@ This interactive command will:
 - **Linux/macOS**: Full E2EE support with automatic encryption
 - **Windows**: Regular Matrix communication (E2EE not available due to library limitations)
 
-**Alternative Method**: Password-based automatic authentication:
-
-```yaml
-matrix:
-  homeserver: https://your-matrix-server.org
-  password: your_matrix_password
-  bot_user_id: @yourbot:your-matrix-server.org
-```
-
-This method automatically creates a secure credentials.json on startup and is compatible with Matrix 2.0/MAS. However, `mmrelay auth login` is still recommended for the most secure setup.
-
-**Security note:** After the first successful start, remove the `password` from your config and restrict permissions.
-On Linux/macOS: `chmod 600 ~/.mmrelay/config.yaml`. On Windows: use file Properties → Security to restrict access to your user.
-
 ### Configuration Tips
 
 - Review the comments in the sample configuration file for detailed explanations
-- **Always use `mmrelay auth login` for Matrix authentication** (standard method, required for E2EE)
+- **Use `mmrelay auth login` for Matrix authentication** (required for E2EE)
 - Configure your Meshtastic connection details in the config file
 - For advanced setups, check the plugin configuration options
 - For advanced features like message prefix customization, debug logging, and environment variable overrides, see the [Advanced Configuration Guide](ADVANCED_CONFIGURATION.md)
@@ -235,6 +221,35 @@ make logs     # View logs
 ```
 
 For detailed Docker commands, configuration options, connection types, and troubleshooting, see the [Docker Guide](DOCKER.md).
+
+## Kubernetes
+
+> **Note**: Kubernetes deployment is currently in testing and development. This feature is subject to change while we refine it based on user feedback.
+
+MMRelay officially supports Kubernetes deployment with a built-in manifest generator.
+
+### Quick Kubernetes Setup
+
+```bash
+# Generate Kubernetes manifests interactively
+mmrelay k8s generate-manifests
+
+# Review and customize the generated ConfigMap
+nano k8s/mmrelay-configmap.yaml
+
+# If you chose to generate a Secret manifest, review it:
+nano k8s/mmrelay-secret-credentials.yaml
+# Or create the Secret directly with kubectl create secret
+
+# Deploy to your cluster
+kubectl apply -f k8s/
+
+# Check status
+kubectl get pods -l app=mmrelay
+kubectl logs -f deployment/mmrelay
+```
+
+For detailed Kubernetes deployment instructions, authentication methods, storage configuration, and troubleshooting, see the [Kubernetes Guide](KUBERNETES.md).
 
 ## Development
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,6 @@
+{
+  "venvPath": ".",
+  "venv": "venv",
+  "include": ["src", "scripts"],
+  "exclude": ["tests"]
+}

--- a/scripts/debug_e2ee.py
+++ b/scripts/debug_e2ee.py
@@ -14,6 +14,7 @@ Usage:
 import asyncio
 import sys
 from pathlib import Path
+from typing import Any
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -32,8 +33,8 @@ class E2EEDebugger:
     """E2EE debugging utility"""
 
     def __init__(self):
-        self.config = None
-        self.client = None
+        self.config: dict[str, Any] | None = None
+        self.client: Any | None = None
 
     async def connect_and_diagnose(self):
         """Connect to Matrix and perform comprehensive E2EE diagnosis"""
@@ -80,22 +81,26 @@ class E2EEDebugger:
 
     async def diagnose_client_state(self):
         """Diagnose Matrix client E2EE state"""
+        if self.client is None:
+            print("❌ No Matrix client available for diagnostics")
+            return
+        client = self.client
         print("\n🔍 CLIENT E2EE STATE DIAGNOSIS")
         print("-" * 40)
 
         # Basic client info
         print("📊 Basic Client Information:")
-        print(f"   User ID: {getattr(self.client, 'user_id', 'None')}")
-        print(f"   Device ID: {getattr(self.client, 'device_id', 'None')}")
+        print(f"   User ID: {getattr(client, 'user_id', 'None')}")
+        print(f"   Device ID: {getattr(client, 'device_id', 'None')}")
         print(
-            f"   Access Token: {'***' if getattr(self.client, 'access_token', None) else 'None'}"
+            f"   Access Token: {'***' if getattr(client, 'access_token', None) else 'None'}"
         )
-        print(f"   Store Path: {getattr(self.client, 'store_path', 'None')}")
+        print(f"   Store Path: {getattr(client, 'store_path', 'None')}")
 
         # E2EE configuration
         print("\n🔐 E2EE Configuration:")
-        if hasattr(self.client, "config") and self.client.config:
-            config = self.client.config
+        if hasattr(client, "config") and client.config:
+            config = client.config
             print(
                 f"   Encryption Enabled: {getattr(config, 'encryption_enabled', 'Unknown')}"
             )
@@ -108,18 +113,16 @@ class E2EEDebugger:
         # E2EE capabilities
         print("\n🛠️  E2EE Capabilities:")
         print(
-            f"   Should Upload Keys: {getattr(self.client, 'should_upload_keys', 'Unknown')}"
+            f"   Should Upload Keys: {getattr(client, 'should_upload_keys', 'Unknown')}"
         )
-        print(f"   Has OLM: {hasattr(self.client, 'olm')}")
+        print(f"   Has OLM: {hasattr(client, 'olm')}")
 
-        if hasattr(self.client, "olm") and self.client.olm:
-            print(f"   OLM Account: {bool(getattr(self.client.olm, 'account', None))}")
-            print(
-                f"   Device Store: {bool(getattr(self.client, 'device_store', None))}"
-            )
+        if hasattr(client, "olm") and client.olm:
+            print(f"   OLM Account: {bool(getattr(client.olm, 'account', None))}")
+            print(f"   Device Store: {bool(getattr(client, 'device_store', None))}")
 
         # Store information
-        store_path = getattr(self.client, "store_path", None)
+        store_path = getattr(client, "store_path", None)
         if store_path:
             store_exists = Path(store_path).exists()
             print(f"   Store Directory Exists: {store_exists}")
@@ -129,19 +132,23 @@ class E2EEDebugger:
 
     async def diagnose_room_encryption(self):
         """Diagnose room encryption state"""
+        if self.client is None:
+            print("❌ No Matrix client available for diagnostics")
+            return
+        client = self.client
         print("\n🏠 ROOM ENCRYPTION DIAGNOSIS")
         print("-" * 40)
 
-        rooms = getattr(self.client, "rooms", {})
+        rooms = getattr(client, "rooms", {})
         print(f"📊 Room Summary: {len(rooms)} total rooms")
 
         if not rooms:
             print("⚠️  No rooms found - performing sync to populate rooms...")
             try:
                 await asyncio.wait_for(
-                    self.client.sync(timeout=10000, full_state=True), timeout=15.0
+                    client.sync(timeout=10000, full_state=True), timeout=15.0
                 )
-                rooms = getattr(self.client, "rooms", {})
+                rooms = getattr(client, "rooms", {})
                 print(f"   After sync: {len(rooms)} rooms found")
             except Exception as e:
                 print(f"   Sync failed: {e}")
@@ -186,10 +193,14 @@ class E2EEDebugger:
 
     async def test_message_parameters(self):
         """Test message sending parameter logic"""
+        if self.client is None:
+            print("❌ No Matrix client available for diagnostics")
+            return
+        client = self.client
         print("\n📤 MESSAGE SENDING PARAMETER TEST")
         print("-" * 40)
 
-        rooms = getattr(self.client, "rooms", {})
+        rooms = getattr(client, "rooms", {})
         if not rooms:
             print("❌ No rooms available for testing")
             return

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -962,7 +962,7 @@ def check_config(args: argparse.Namespace | None = None) -> bool:
                     if not isinstance(matrix_section, dict):
                         print("Error: 'matrix' section must be a mapping (YAML object)")
                         return False
-                    required_matrix_fields = (
+                    required_matrix_fields: list[str] = (
                         []
                     )  # No fields required from config when using credentials.json
                 else:

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -26,6 +26,7 @@ import asyncio
 import os
 import ssl
 from types import ModuleType
+from typing import Any, cast
 
 try:
     import certifi
@@ -421,14 +422,14 @@ def _handle_matrix_error(
         exception, "status_code"
     ):
         if (
-            hasattr(exception, "errcode") and exception.errcode == "M_FORBIDDEN"
-        ) or exception.status_code == 401:
+            hasattr(exception, "errcode") and exception.errcode == "M_FORBIDDEN"  # type: ignore[attr-defined]
+        ) or exception.status_code == 401:  # type: ignore[attr-defined]
             error_category = "credentials"
-        elif exception.status_code in [500, 502, 503]:
+        elif exception.status_code in [500, 502, 503]:  # type: ignore[attr-defined]
             error_category = "server"
         else:
             error_category = "other"
-            error_detail = str(exception.status_code)
+            error_detail = str(exception.status_code)  # type: ignore[attr-defined]
     # Handle network/transport exceptions
     elif isinstance(
         exception,
@@ -572,7 +573,7 @@ async def logout_matrix_bot(password: str) -> bool:
             ssl_context = _create_ssl_context()
 
             # Create a temporary client to fetch user_id
-            temp_client = AsyncClient(homeserver, ssl=ssl_context)
+            temp_client = AsyncClient(homeserver, ssl=ssl_context)  # type: ignore[arg-type]
             temp_client.access_token = access_token
 
             # Fetch user_id using whoami
@@ -582,7 +583,7 @@ async def logout_matrix_bot(password: str) -> bool:
             )
 
             if hasattr(whoami_response, "user_id"):
-                user_id = whoami_response.user_id
+                user_id = whoami_response.user_id  # type: ignore[assignment]
                 logger.info(f"Successfully fetched user_id: {user_id}")
                 print(f"✅ Successfully fetched user_id: {user_id}")
 
@@ -627,6 +628,14 @@ async def logout_matrix_bot(password: str) -> bool:
         else:
             print("❌ Local cleanup completed with some errors.")
         return success
+    assert homeserver is not None
+    assert user_id is not None
+    assert access_token is not None
+    assert device_id is not None
+    homeserver_str = cast(str, homeserver)
+    user_id_str = cast(str, user_id)
+    access_token_str = cast(str, access_token)
+    device_id_str = cast(str, device_id)
 
     logger.info(f"Verifying password for {user_id}...")
     print(f"🔐 Verifying password for {user_id}...")
@@ -642,7 +651,8 @@ async def logout_matrix_bot(password: str) -> bool:
 
         # Create a temporary client to verify the password
         # We'll try to login with the password to verify it's correct
-        temp_client = AsyncClient(homeserver, user_id, ssl=ssl_context)
+        ssl_param = cast(Any, ssl_context) if ssl_context is not None else None
+        temp_client = AsyncClient(homeserver_str, user_id_str, ssl=ssl_param)
 
         try:
             # Attempt login with the provided password
@@ -697,11 +707,11 @@ async def logout_matrix_bot(password: str) -> bool:
         print("🚪 Logging out from Matrix server...")
         main_client = None
         try:
-            main_client = AsyncClient(homeserver, user_id, ssl=ssl_context)
+            main_client = AsyncClient(homeserver_str, user_id_str, ssl=ssl_param)
             main_client.restore_login(
-                user_id=user_id,
-                device_id=device_id,
-                access_token=access_token,
+                user_id=user_id_str,
+                device_id=device_id_str,
+                access_token=access_token_str,
             )
 
             # Logout from the server (invalidates the access token)

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -29,7 +29,10 @@ from mmrelay.constants.messages import (
 )
 
 # Initialize Rich console only if available
-console = Console() if RICH_AVAILABLE else None
+if RICH_AVAILABLE:
+    console = Console()  # type: ignore[name-defined]
+else:
+    console = None
 
 # Define custom log level styles - not used directly but kept for reference
 # Rich 14.0.0+ supports level_styles parameter, but we're using an approach
@@ -251,7 +254,7 @@ def _configure_logger(
     if not _cli_mode:
         if color_enabled and RICH_AVAILABLE:
             # Use Rich handler with colors
-            console_handler: logging.Handler = RichHandler(
+            console_handler: logging.Handler = RichHandler(  # type: ignore[name-defined]
                 rich_tracebacks=rich_tracebacks_enabled,
                 console=console,
                 show_time=True,

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -8,7 +8,7 @@ import concurrent.futures
 import functools
 import signal
 import sys
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import ClientError
 
@@ -154,14 +154,21 @@ async def main(config: dict[str, Any]) -> None:
     # Register the message callback for Matrix
     matrix_logger.info("Listening for inbound Matrix messages...")
     matrix_client.add_event_callback(
-        on_room_message,
-        (RoomMessageText, RoomMessageNotice, RoomMessageEmote, ReactionEvent),
+        cast(Any, on_room_message),
+        cast(
+            Any,
+            (RoomMessageText, RoomMessageNotice, RoomMessageEmote, ReactionEvent),
+        ),
     )
     # Add E2EE callbacks - MegolmEvent only goes to decryption failure handler
     # Successfully decrypted messages will be converted to RoomMessageText etc. by matrix-nio
-    matrix_client.add_event_callback(on_decryption_failure, (MegolmEvent,))
+    matrix_client.add_event_callback(
+        cast(Any, on_decryption_failure), cast(Any, (MegolmEvent,))
+    )
     # Add RoomMemberEvent callback to track room-specific display name changes
-    matrix_client.add_event_callback(on_room_member, (RoomMemberEvent,))
+    matrix_client.add_event_callback(
+        cast(Any, on_room_member), cast(Any, (RoomMemberEvent,))
+    )
 
     # Set up shutdown event
     shutdown_event = asyncio.Event()

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -132,44 +132,6 @@ async def main(config: dict[str, Any]) -> None:
     )
     start_message_queue(message_delay=message_delay)
 
-    # Connect to Meshtastic
-    meshtastic_utils.meshtastic_client = await asyncio.to_thread(
-        connect_meshtastic, passed_config=config
-    )
-
-    # Connect to Matrix
-    matrix_client = await connect_matrix(passed_config=config)
-
-    # Check if Matrix connection was successful
-    if matrix_client is None:
-        # The error is logged by connect_matrix, so we can just raise here.
-        raise ConnectionError(
-            "Failed to connect to Matrix. Cannot continue without Matrix client."
-        )
-
-    # Join the rooms specified in the config.yaml
-    for room in matrix_rooms:
-        await join_matrix_room(matrix_client, room["id"])
-
-    # Register the message callback for Matrix
-    matrix_logger.info("Listening for inbound Matrix messages...")
-    matrix_client.add_event_callback(
-        cast(Any, on_room_message),
-        cast(
-            Any,
-            (RoomMessageText, RoomMessageNotice, RoomMessageEmote, ReactionEvent),
-        ),
-    )
-    # Add E2EE callbacks - MegolmEvent only goes to decryption failure handler
-    # Successfully decrypted messages will be converted to RoomMessageText etc. by matrix-nio
-    matrix_client.add_event_callback(
-        cast(Any, on_decryption_failure), cast(Any, (MegolmEvent,))
-    )
-    # Add RoomMemberEvent callback to track room-specific display name changes
-    matrix_client.add_event_callback(
-        cast(Any, on_room_member), cast(Any, (RoomMemberEvent,))
-    )
-
     # Set up shutdown event
     shutdown_event = asyncio.Event()
 
@@ -208,6 +170,62 @@ async def main(config: dict[str, Any]) -> None:
     else:
         # On Windows, we can't use add_signal_handler, so we'll handle KeyboardInterrupt
         pass
+
+    # Connect to Meshtastic
+    meshtastic_utils.meshtastic_client = await asyncio.to_thread(
+        connect_meshtastic, passed_config=config
+    )
+
+    # Connect to Matrix (retry until connected or shutdown)
+    matrix_client = None
+    matrix_retry_delay = 10
+    while not shutdown_event.is_set():
+        try:
+            matrix_client = await connect_matrix(passed_config=config)
+            if matrix_client is None:
+                raise ConnectionError(
+                    "Failed to connect to Matrix. Cannot continue without Matrix client."
+                )
+            break
+        except ConnectionError as exc:
+            matrix_logger.error("Matrix connection failed: %s", exc)
+        except Exception:
+            matrix_logger.exception("Matrix connection failed")
+
+        if shutdown_event.is_set():
+            break
+
+        matrix_logger.info(
+            "Retrying Matrix connection in %s seconds...", matrix_retry_delay
+        )
+        await asyncio.sleep(matrix_retry_delay)
+
+    if matrix_client is None:
+        shutdown()
+        return
+
+    # Join the rooms specified in the config.yaml
+    for room in matrix_rooms:
+        await join_matrix_room(matrix_client, room["id"])
+
+    # Register the message callback for Matrix
+    matrix_logger.info("Listening for inbound Matrix messages...")
+    matrix_client.add_event_callback(
+        cast(Any, on_room_message),
+        cast(
+            Any,
+            (RoomMessageText, RoomMessageNotice, RoomMessageEmote, ReactionEvent),
+        ),
+    )
+    # Add E2EE callbacks - MegolmEvent only goes to decryption failure handler
+    # Successfully decrypted messages will be converted to RoomMessageText etc. by matrix-nio
+    matrix_client.add_event_callback(
+        cast(Any, on_decryption_failure), cast(Any, (MegolmEvent,))
+    )
+    # Add RoomMemberEvent callback to track room-specific display name changes
+    matrix_client.add_event_callback(
+        cast(Any, on_room_member), cast(Any, (RoomMemberEvent,))
+    )
 
     # Start connection health monitoring using getMetadata() heartbeat
     # This provides proactive connection detection for all interface types

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -1263,6 +1263,7 @@ async def connect_matrix(
             )
     # Check if we can automatically create credentials from config.yaml
     elif _can_auto_create_credentials(matrix_section):
+        matrix_section = cast(dict[str, Any], matrix_section)
         logger.info(
             "No credentials.json found, but config.yaml has password field. Attempting automatic login..."
         )

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -441,7 +441,11 @@ def _scan_for_ble_address(ble_address: str, timeout: float) -> bool:
             find_device = getattr(BleakScanner, "find_device_by_address", None)
             if callable(find_device):
                 try:
-                    result = await find_device(ble_address, timeout=timeout)  # type: ignore[misc]
+                    coro: Coroutine[Any, Any, Any] = cast(
+                        Coroutine[Any, Any, Any],
+                        find_device(ble_address, timeout=timeout),
+                    )
+                    result = await coro
                     return result is not None
                 except TypeError:
                     return False
@@ -1639,7 +1643,7 @@ def _get_node_display_name(
                     user = node.get("user")
                     if user and isinstance(user, dict):
                         if short_name := user.get("shortName"):
-                            return short_name
+                            return cast(str, short_name)
 
     from mmrelay.db_utils import get_longname, get_shortname
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1631,7 +1631,7 @@ def _get_portnum_name(portnum: Any) -> str:
 
 
 def _get_node_display_name(
-    from_id: int | str, interface: Any, fallback: str = ""
+    from_id: int | str, interface: Any, fallback: str | None = None
 ) -> str:
     """
     Get a human-readable display name for a Meshtastic node.
@@ -1642,7 +1642,7 @@ def _get_node_display_name(
     Parameters:
         from_id: Meshtastic node identifier (int or str)
         interface: Meshtastic interface with nodes mapping
-        fallback: Optional fallback string if no name found
+        fallback: Optional fallback string if no name found; when None, uses the node ID
 
     Returns:
         str: Node display name or node ID if no name available

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -502,30 +502,15 @@ def _is_ble_discovery_error(error: Exception) -> bool:
     if "Timed out waiting for connection completion" in message:
         return True
 
-    def _is_type_or_tuple(candidate: object) -> bool:
-        if isinstance(candidate, type):
-            return True
-        if isinstance(candidate, tuple):
-            return all(isinstance(item, type) for item in candidate)
-        return False
-
     ble_interface = getattr(meshtastic.ble_interface, "BLEInterface", None)
     ble_error_type = getattr(ble_interface, "BLEError", None)
-    if (
-        ble_error_type
-        and _is_type_or_tuple(ble_error_type)
-        and isinstance(error, ble_error_type)
-    ):
+    if ble_error_type and isinstance(error, ble_error_type):
         return True
 
     mesh_interface = getattr(meshtastic, "mesh_interface", None)
     mesh_interface_class = getattr(mesh_interface, "MeshInterface", None)
     mesh_error_type = getattr(mesh_interface_class, "MeshInterfaceError", None)
-    if (
-        mesh_error_type
-        and _is_type_or_tuple(mesh_error_type)
-        and isinstance(error, mesh_error_type)
-    ):
+    if mesh_error_type and isinstance(error, mesh_error_type):
         return True
 
     return False

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2466,16 +2466,18 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
         if from_id is not None:
             from_display = _get_node_display_name(from_id, interface, fallback="")
         details_map = {
-            "from": from_display or from_id,
+            "from": from_id,
             "channel": packet.get("channel"),
             "id": packet.get("id"),
         }
         details_map.update(_get_packet_details(decoded, packet, portnum_name))
 
-        details = [f"{portnum_name}"]
+        details = []
+        if from_display:
+            details.append(from_display)
         for key, value in details_map.items():
             if value is not None:
-                if key == "from" and from_display and from_display != value:
+                if key == "from":
                     details.append(f"from={value}")
                 elif key == "batt":
                     details.append(f"{value}")
@@ -2489,14 +2491,12 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
                     details.append(f"s={value}")
                 elif key == "relayed":
                     details.append(f"r={value}")
-                elif key == "priority" and value != "BACKGROUND":
+                elif key == "priority":
                     details.append(f"p={value}")
                 else:
                     details.append(f"{key}={value}")
 
-        prefix = "[" + " ".join(details) + "]"
-        if from_display:
-            prefix = f"{from_display} {prefix}"
+        prefix = f"[{portnum_name}] " + " ".join(details)
         logger.debug(prefix)
 
     # Check if config is available

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -441,14 +441,10 @@ def _scan_for_ble_address(ble_address: str, timeout: float) -> bool:
             find_device = getattr(BleakScanner, "find_device_by_address", None)
             if callable(find_device):
                 try:
-                    return await find_device(ble_address, timeout=timeout) is not None
+                    result = await find_device(ble_address, timeout=timeout)
+                    return result is not None
                 except TypeError:
-                    return (
-                        await asyncio.wait_for(
-                            find_device(ble_address), timeout=timeout
-                        )
-                        is not None
-                    )
+                    return False
 
             devices = await BleakScanner.discover(timeout=timeout)
             return any(
@@ -1615,6 +1611,47 @@ def _get_portnum_name(portnum: Any) -> str:
     return f"UNKNOWN (type={type(portnum).__name__})"
 
 
+def _get_node_display_name(
+    from_id: int | str, interface: Any, fallback: str = ""
+) -> str:
+    """
+    Get a human-readable display name for a Meshtastic node.
+
+    Prioritizes short name from interface, then short name from database,
+    then long name from database, falling back to node ID if none found.
+
+    Parameters:
+        from_id: Meshtastic node identifier (int or str)
+        interface: Meshtastic interface with nodes mapping
+        fallback: Optional fallback string if no name found
+
+    Returns:
+        str: Node display name or node ID if no name available
+    """
+    from_id_str = str(from_id)
+
+    if interface and hasattr(interface, "nodes"):
+        nodes = interface.nodes
+        if nodes and isinstance(nodes, dict):
+            if from_id_str in nodes:
+                node = nodes[from_id_str]
+                if isinstance(node, dict):
+                    user = node.get("user")
+                    if user and isinstance(user, dict):
+                        if short_name := user.get("shortName"):
+                            return short_name
+
+    from mmrelay.db_utils import get_longname, get_shortname
+
+    if short_name := get_shortname(from_id_str):
+        return short_name
+
+    if long_name := get_longname(from_id_str):
+        return long_name
+
+    return fallback if fallback is not None else from_id_str
+
+
 def serial_port_exists(port_name: str) -> bool:
     """
     Determine whether a serial port with the given device name exists on the system.
@@ -1766,10 +1803,12 @@ def connect_meshtastic(
         and (retry_limit == 0 or attempts <= retry_limit)
         and not shutting_down
     ):
+        # Initialize before try block to avoid unbound variable errors
+        ble_address: str | None = None
+        supports_auto_reconnect = False
+
         try:
             client = None
-            ble_address: str | None = None
-            supports_auto_reconnect = False
             if connection_type == CONNECTION_TYPE_SERIAL:
                 # Serial connection
                 serial_port = config["meshtastic"].get(CONFIG_KEY_SERIAL_PORT)
@@ -2228,24 +2267,6 @@ def connect_meshtastic(
                 wait_time,
             )
             time.sleep(wait_time)
-        except (serial.SerialException, BleakDBusError, BleakError) as e:
-            # Handle specific connection errors
-            if shutting_down:
-                logger.debug("Shutdown in progress. Aborting connection attempts.")
-                break
-            attempts += 1
-            if retry_limit == 0 or attempts <= retry_limit:
-                wait_time = min(2**attempts, 60)  # Consistent exponential backoff
-                logger.warning(
-                    "Connection attempt %s failed: %s. Retrying in %s seconds...",
-                    attempts,
-                    e,
-                    wait_time,
-                )
-                time.sleep(wait_time)
-            else:
-                logger.exception("Connection failed after %s attempts", attempts)
-                return None
         except Exception as e:
             if shutting_down:
                 logger.debug("Shutdown in progress. Aborting connection attempts.")
@@ -2440,15 +2461,43 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
             decoded.get("portnum") if decoded and isinstance(decoded, dict) else None
         )
         portnum_name = _get_portnum_name(portnum)
+        from_id = packet.get("fromId") or packet.get("from")
+        from_display = ""
+        if from_id is not None:
+            from_display = _get_node_display_name(from_id, interface, fallback="")
         details_map = {
-            "from": packet.get("fromId") or packet.get("from"),
+            "from": from_display or from_id,
             "channel": packet.get("channel"),
             "id": packet.get("id"),
         }
         details_map.update(_get_packet_details(decoded, packet, portnum_name))
-        details = [f"type={portnum_name}"]
-        details.extend(f"{k}={v}" for k, v in details_map.items() if v is not None)
-        logger.debug(f"Received non-text Meshtastic message: {', '.join(details)}")
+
+        details = [f"{portnum_name}"]
+        for key, value in details_map.items():
+            if value is not None:
+                if key == "from" and from_display and from_display != value:
+                    details.append(f"from={value}")
+                elif key == "batt":
+                    details.append(f"{value}")
+                elif key == "voltage":
+                    details.append(f"v={value}")
+                elif key == "temp":
+                    details.append(f"t={value}")
+                elif key == "humidity":
+                    details.append(f"h={value}")
+                elif key == "signal":
+                    details.append(f"s={value}")
+                elif key == "relayed":
+                    details.append(f"r={value}")
+                elif key == "priority" and value != "BACKGROUND":
+                    details.append(f"p={value}")
+                else:
+                    details.append(f"{key}={value}")
+
+        prefix = "[" + " ".join(details) + "]"
+        if from_display:
+            prefix = f"{from_display} {prefix}"
+        logger.debug(prefix)
 
     # Check if config is available
     if config is None:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -441,7 +441,7 @@ def _scan_for_ble_address(ble_address: str, timeout: float) -> bool:
             find_device = getattr(BleakScanner, "find_device_by_address", None)
             if callable(find_device):
                 try:
-                    result = await find_device(ble_address, timeout=timeout)
+                    result = await find_device(ble_address, timeout=timeout)  # type: ignore[misc]
                     return result is not None
                 except TypeError:
                     return False

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -502,15 +502,30 @@ def _is_ble_discovery_error(error: Exception) -> bool:
     if "Timed out waiting for connection completion" in message:
         return True
 
+    def _is_type_or_tuple(candidate: object) -> bool:
+        if isinstance(candidate, type):
+            return True
+        if isinstance(candidate, tuple):
+            return all(isinstance(item, type) for item in candidate)
+        return False
+
     ble_interface = getattr(meshtastic.ble_interface, "BLEInterface", None)
     ble_error_type = getattr(ble_interface, "BLEError", None)
-    if ble_error_type and isinstance(error, ble_error_type):
+    if (
+        ble_error_type
+        and _is_type_or_tuple(ble_error_type)
+        and isinstance(error, ble_error_type)
+    ):
         return True
 
     mesh_interface = getattr(meshtastic, "mesh_interface", None)
     mesh_interface_class = getattr(mesh_interface, "MeshInterface", None)
     mesh_error_type = getattr(mesh_interface_class, "MeshInterfaceError", None)
-    if mesh_error_type and isinstance(error, mesh_error_type):
+    if (
+        mesh_error_type
+        and _is_type_or_tuple(mesh_error_type)
+        and isinstance(error, mesh_error_type)
+    ):
         return True
 
     return False

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -47,7 +47,7 @@ from mmrelay.plugin_loader import (
 )
 
 # Global config variable that will be set from main.py
-config = None
+config: dict[str, Any] | None = None
 
 # Track if we've already shown the deprecated warning
 _deprecated_warning_shown = False

--- a/src/mmrelay/plugins/drop_plugin.py
+++ b/src/mmrelay/plugins/drop_plugin.py
@@ -44,13 +44,14 @@ class Plugin(BasePlugin):
         Returns:
             position (dict[str, Any] | None): The node's `position` dictionary (typically containing latitude and longitude) if the node is found and has position data; `None` if the node is not found or has no `position`.
         """
-        for _node, info in meshtastic_client.nodes.items():
-            if info["user"]["id"] == node_id:
-                if "position" in info:
-                    pos: dict[str, Any] = info["position"]
-                    return pos
-                else:
-                    return None
+        if meshtastic_client.nodes:
+            for _node, info in meshtastic_client.nodes.items():
+                if info["user"]["id"] == node_id:
+                    if "position" in info:
+                        pos: dict[str, Any] = info["position"]
+                        return pos
+                    else:
+                        return None
         return None
 
     async def handle_meshtastic_message(

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -66,7 +66,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: Command names handled by this plugin (for example, ['help']).
         """
-        return [self.plugin_name]  # type: ignore[return-value]
+        return [cast(str, self.plugin_name)]
 
     def get_mesh_commands(self) -> list[str]:
         """

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio import (  # type: ignore[import-untyped]
@@ -66,7 +66,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: Command names handled by this plugin (for example, ['help']).
         """
-        return [self.plugin_name]
+        return [self.plugin_name]  # type: ignore[return-value]
 
     def get_mesh_commands(self) -> list[str]:
         """

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -372,7 +372,7 @@ class Plugin(BasePlugin):
     def description(self) -> str:
         """
         Provide a brief human-readable description of the plugin for listings and help.
-        
+
         Returns:
             str: One-line description mentioning map generation and supported `zoom` and `size` options.
         """
@@ -410,7 +410,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: A list of command strings that the plugin responds to (typically containing the plugin's name).
         """
-        return [self.plugin_name]
+        return [self.plugin_name]  # type: ignore[return-value]
 
     def get_mesh_commands(self) -> list[str]:
         """

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -410,7 +410,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: A list of command strings that the plugin responds to (typically containing the plugin's name).
         """
-        return [self.plugin_name]  # type: ignore[return-value]
+        return [cast(str, self.plugin_name)]
 
     def get_mesh_commands(self) -> list[str]:
         """

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -1,6 +1,6 @@
 import asyncio
 import re
-from typing import Any
+from typing import Any, cast
 
 from meshtastic.mesh_interface import BROADCAST_NUM  # type: ignore[import-untyped]
 
@@ -183,7 +183,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: A list containing the plugin's Matrix command (the plugin_name).
         """
-        return [self.plugin_name]  # type: ignore[return-value]
+        return [cast(str, self.plugin_name)]
 
     def get_mesh_commands(self) -> list[str]:
         """
@@ -192,7 +192,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: Command names provided by the plugin (typically a single-element list containing the plugin's name).
         """
-        return [self.plugin_name]  # type: ignore[return-value]
+        return [cast(str, self.plugin_name)]
 
     async def handle_room_message(
         self,

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -183,7 +183,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: A list containing the plugin's Matrix command (the plugin_name).
         """
-        return [self.plugin_name]
+        return [self.plugin_name]  # type: ignore[return-value]
 
     def get_mesh_commands(self) -> list[str]:
         """
@@ -192,7 +192,7 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: Command names provided by the plugin (typically a single-element list containing the plugin's name).
         """
-        return [self.plugin_name]
+        return [self.plugin_name]  # type: ignore[return-value]
 
     async def handle_room_message(
         self,

--- a/src/mmrelay/setup_utils.py
+++ b/src/mmrelay/setup_utils.py
@@ -144,10 +144,10 @@ def wait_for_service_start() -> None:
 
     # Create a Rich progress display with spinner and elapsed time
     if not running_as_service:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[bold green]Starting mmrelay service..."),
-            TimeElapsedColumn(),
+        with Progress(  # type: ignore[name-defined]
+            SpinnerColumn(),  # type: ignore[name-defined]
+            TextColumn("[bold green]Starting mmrelay service..."),  # type: ignore[name-defined]
+            TimeElapsedColumn(),  # type: ignore[name-defined]
             transient=True,
         ) as progress:
             # Add a task that will run for approximately 10 seconds

--- a/src/mmrelay/setup_utils.py
+++ b/src/mmrelay/setup_utils.py
@@ -130,6 +130,7 @@ def wait_for_service_start() -> None:
 
     from mmrelay.runtime_utils import is_running_as_service
 
+    Progress = SpinnerColumn = TextColumn = TimeElapsedColumn = None
     running_as_service = is_running_as_service()
     if not running_as_service:
         try:
@@ -139,15 +140,16 @@ def wait_for_service_start() -> None:
                 TextColumn,
                 TimeElapsedColumn,
             )
-        except Exception:
+        except ImportError:
+            Progress = SpinnerColumn = TextColumn = TimeElapsedColumn = None
             running_as_service = True
 
     # Create a Rich progress display with spinner and elapsed time
-    if not running_as_service:
-        with Progress(  # type: ignore[name-defined]
-            SpinnerColumn(),  # type: ignore[name-defined]
-            TextColumn("[bold green]Starting mmrelay service..."),  # type: ignore[name-defined]
-            TimeElapsedColumn(),  # type: ignore[name-defined]
+    if not running_as_service and Progress is not None:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[bold green]Starting mmrelay service..."),
+            TimeElapsedColumn(),
             transient=True,
         ) as progress:
             # Add a task that will run for approximately 10 seconds

--- a/src/mmrelay/windows_utils.py
+++ b/src/mmrelay/windows_utils.py
@@ -7,7 +7,7 @@ for better compatibility and user experience on Windows systems.
 
 import os
 import sys
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from mmrelay.constants.app import WINDOWS_PLATFORM
 
@@ -39,9 +39,9 @@ def setup_windows_console() -> None:
     try:
         # Enable UTF-8 output on Windows
         if hasattr(sys.stdout, "reconfigure"):
-            sys.stdout.reconfigure(encoding="utf-8")
+            cast(Any, sys.stdout).reconfigure(encoding="utf-8")
         if hasattr(sys.stderr, "reconfigure"):
-            sys.stderr.reconfigure(encoding="utf-8")
+            cast(Any, sys.stderr).reconfigure(encoding="utf-8")
 
         # Enable ANSI color codes on Windows 10+
         import ctypes

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -200,23 +200,6 @@ class _ImmediateEvent:
         return None
 
 
-class _AutoSetEvent:
-    """Event that is unset until wait() is called, then sets itself."""
-
-    def __init__(self) -> None:
-        self._set = False
-
-    def is_set(self) -> bool:
-        return self._set
-
-    def set(self) -> None:
-        self._set = True
-
-    async def wait(self) -> None:
-        self._set = True
-        return None
-
-
 class _CloseFutureBase(concurrent.futures.Future):
     """Future with a cancel flag for shutdown test assertions."""
 
@@ -582,12 +565,7 @@ class TestMain(unittest.TestCase):
         mock_connect_matrix.side_effect = _make_async_return(None)
         mock_join_room.side_effect = _async_noop
 
-        shutdown_event = _AutoSetEvent()
-
-        async def _sleep_and_set(*_args, **_kwargs):
-            shutdown_event.set()
-
-        # Call main function (should exit after one retry)
+        # Call main function (should exit early due to connection failures)
         with (
             patch(
                 "mmrelay.main.asyncio.get_running_loop",
@@ -597,10 +575,9 @@ class TestMain(unittest.TestCase):
                 "mmrelay.main.asyncio.to_thread",
                 side_effect=inline_to_thread,
             ),
-            patch("mmrelay.main.asyncio.Event", return_value=shutdown_event),
-            patch("mmrelay.main.asyncio.sleep", side_effect=_sleep_and_set),
         ):
-            asyncio.run(main(self.mock_config))
+            with contextlib.suppress(ConnectionError):
+                asyncio.run(main(self.mock_config))
 
         # Should still proceed with Matrix connection
         mock_connect_matrix.assert_called_once()
@@ -632,13 +609,7 @@ class TestMain(unittest.TestCase):
         mock_connect_matrix.side_effect = _make_async_raise(
             Exception("Matrix connection failed")
         )
-
-        shutdown_event = _AutoSetEvent()
-
-        async def _sleep_and_set(*_args, **_kwargs):
-            shutdown_event.set()
-
-        # Should retry and exit when shutdown is signaled
+        # Should raise the Matrix connection exception
         with (
             patch(
                 "mmrelay.main.asyncio.get_running_loop",
@@ -648,12 +619,10 @@ class TestMain(unittest.TestCase):
                 "mmrelay.main.asyncio.to_thread",
                 side_effect=inline_to_thread,
             ),
-            patch("mmrelay.main.asyncio.Event", return_value=shutdown_event),
-            patch("mmrelay.main.asyncio.sleep", side_effect=_sleep_and_set),
         ):
-            asyncio.run(main(self.mock_config))
-
-        mock_connect_matrix.assert_called_once()
+            with self.assertRaises(Exception) as context:
+                asyncio.run(main(self.mock_config))
+        self.assertIn("Matrix connection failed", str(context.exception))
 
     @patch("mmrelay.main.initialize_database")
     @patch("mmrelay.main.load_plugins")
@@ -689,7 +658,7 @@ class TestMain(unittest.TestCase):
                 "mmrelay.main.asyncio.get_running_loop",
                 side_effect=_make_patched_get_running_loop(),
             ),
-            patch("mmrelay.main.asyncio.Event", return_value=_AutoSetEvent()),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
             patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch("mmrelay.main.get_message_queue") as mock_get_queue,
         ):
@@ -747,7 +716,7 @@ class TestMain(unittest.TestCase):
 
         executor = _ControlledExecutor()
         with (
-            patch("mmrelay.main.asyncio.Event", return_value=_AutoSetEvent()),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
             patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch(
                 "mmrelay.main.concurrent.futures.ThreadPoolExecutor",
@@ -809,7 +778,7 @@ class TestMain(unittest.TestCase):
 
         executor = _ControlledExecutor(close_future_factory=_TimeoutCloseFuture)
         with (
-            patch("mmrelay.main.asyncio.Event", return_value=_AutoSetEvent()),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
             patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch(
                 "mmrelay.main.concurrent.futures.ThreadPoolExecutor",
@@ -854,7 +823,7 @@ class TestMain(unittest.TestCase):
 
         executor = _ControlledExecutor(close_future_factory=_ErrorCloseFuture)
         with (
-            patch("mmrelay.main.asyncio.Event", return_value=_AutoSetEvent()),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
             patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch(
                 "mmrelay.main.concurrent.futures.ThreadPoolExecutor",
@@ -905,7 +874,7 @@ class TestMain(unittest.TestCase):
 
         executor = _ControlledExecutor(shutdown_typeerror=True)
         with (
-            patch("mmrelay.main.asyncio.Event", return_value=_AutoSetEvent()),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
             patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch(
                 "mmrelay.main.concurrent.futures.ThreadPoolExecutor",
@@ -946,7 +915,7 @@ class TestMain(unittest.TestCase):
 
         executor = _ControlledExecutor(submit_timeout=True)
         with (
-            patch("mmrelay.main.asyncio.Event", return_value=_AutoSetEvent()),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
             patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
             patch(
                 "mmrelay.main.concurrent.futures.ThreadPoolExecutor",
@@ -2026,7 +1995,7 @@ class TestMainAsyncFunction(unittest.TestCase):
             patch("mmrelay.main.shutdown_plugins"),
             patch("mmrelay.main.stop_message_queue"),
             patch("mmrelay.main.sys.platform", "linux"),
-            patch("mmrelay.main.asyncio.Event", return_value=_AutoSetEvent()),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
         ):
             mock_queue = MagicMock()
             mock_queue.ensure_processor_started = MagicMock()

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1305,7 +1305,10 @@ class TestBleHelperFunctions(unittest.TestCase):
         from mmrelay.meshtastic_utils import _scan_for_ble_address
 
         async def _find_device(_address: str):
-            return object()
+            return None
+
+        async def _wait_for(coro, timeout=None):
+            return await coro
 
         fake_bleak = SimpleNamespace(
             BleakScanner=SimpleNamespace(find_device_by_address=_find_device)
@@ -1318,8 +1321,10 @@ class TestBleHelperFunctions(unittest.TestCase):
                 "mmrelay.meshtastic_utils.asyncio.get_running_loop",
                 side_effect=RuntimeError(),
             ),
+            patch("mmrelay.meshtastic_utils.asyncio.wait_for", side_effect=_wait_for),
         ):
-            self.assertTrue(_scan_for_ble_address("AA:BB", 0.1))
+            result = _scan_for_ble_address("AA:BB", 0.1)
+            self.assertFalse(result)
 
     def test_scan_for_ble_address_discover_fallback(self):
         """Cover BleakScanner.discover() fallback when find_device_by_address is absent."""

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -267,8 +267,7 @@ class TestMeshtasticUtils(unittest.TestCase):
 
             # Verify debug log was called with packet type information
             log_output = "\n".join(cm.output)
-            self.assertIn("Received non-text Meshtastic message", log_output)
-            self.assertIn("type=REMOTE_HARDWARE_APP", log_output)
+            self.assertIn("REMOTE_HARDWARE_APP", log_output)
             self.assertIn("from=123456789", log_output)
             self.assertIn("channel=0", log_output)
             self.assertIn("id=12345", log_output)
@@ -1255,8 +1254,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
 
             # Verify debug log was called with packet type information (portnum None)
             log_output = "\n".join(cm.output)
-            self.assertIn("Received non-text Meshtastic message", log_output)
-            self.assertIn("type=UNKNOWN (None)", log_output)
+            self.assertIn("UNKNOWN (None)", log_output)
             self.assertIn("from=123456789", log_output)
             self.assertIn("channel=0", log_output)
             self.assertIn("id=12345", log_output)
@@ -1314,8 +1312,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
 
             # Verify debug log was called with packet type information
             log_output = "\n".join(cm.output)
-            self.assertIn("Received non-text Meshtastic message", log_output)
-            self.assertIn("type=TEXT_MESSAGE_APP", log_output)
+            self.assertIn("TEXT_MESSAGE_APP", log_output)
             self.assertIn("from=123456789", log_output)
             self.assertIn("channel=0", log_output)
             self.assertIn("id=12345", log_output)

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -15,6 +15,7 @@ import os
 import sys
 import unittest
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -286,9 +287,51 @@ class TestMeshtasticUtils(unittest.TestCase):
                 "mmrelay.meshtastic_utils.matrix_rooms",
                 self.mock_config["matrix_rooms"],
             ),
+            patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
+            patch(
+                "mmrelay.matrix_utils.get_interaction_settings",
+                return_value={"reactions": True, "replies": True},
+            ),
+            patch("mmrelay.matrix_utils.matrix_relay"),
+            patch("mmrelay.meshtastic_utils._submit_coro"),
         ):
             result = on_meshtastic_message(packet, mock_interface)
             self.assertIsNone(result)
+
+    def test_on_meshtastic_message_ignores_other_node(self):
+        """
+        Ensure handler ignores packets addressed to a different node.
+        """
+        packet = self.mock_packet.copy()
+        packet["to"] = BROADCAST_NUM + 1
+        mock_interface = MagicMock()
+        mock_interface.myInfo.my_node_num = 12345
+
+        with (
+            patch("mmrelay.meshtastic_utils.config", self.mock_config),
+            patch(
+                "mmrelay.meshtastic_utils.matrix_rooms",
+                self.mock_config["matrix_rooms"],
+            ),
+            patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
+            patch(
+                "mmrelay.matrix_utils.get_interaction_settings",
+                return_value={"reactions": True, "replies": True},
+            ),
+            patch("mmrelay.matrix_utils.matrix_relay"),
+            patch("mmrelay.meshtastic_utils._submit_coro") as mock_submit,
+        ):
+            with self.assertLogs("Meshtastic", level="DEBUG") as log_cm:
+                result = on_meshtastic_message(packet, mock_interface)
+
+            self.assertIsNone(result)
+            mock_submit.assert_not_called()
+            self.assertTrue(
+                any(
+                    "Ignoring message intended for node" in message
+                    for message in log_cm.output
+                )
+            )
 
     def test_on_meshtastic_message_reaction_relay(self):
         """
@@ -1181,6 +1224,169 @@ class TestConnectMeshtasticEdgeCases(unittest.TestCase):
         # Should handle gracefully
         self.assertIsNone(result)
 
+    @patch("mmrelay.meshtastic_utils.logger")
+    def test_connect_meshtastic_returns_none_when_shutting_down(self, mock_logger):
+        """Return None immediately when shutting_down is True."""
+        import mmrelay.meshtastic_utils as mu
+
+        original_shutdown = mu.shutting_down
+        try:
+            mu.shutting_down = True
+            result = connect_meshtastic(
+                passed_config={
+                    "meshtastic": {"connection_type": "tcp", "host": "127.0.0.1"}
+                }
+            )
+        finally:
+            mu.shutting_down = original_shutdown
+
+        self.assertIsNone(result)
+        mock_logger.debug.assert_called_with(
+            "Shutdown in progress. Not attempting to connect."
+        )
+
+    def test_connect_meshtastic_updates_matrix_rooms_with_existing_client(self):
+        """Ensure passed_config updates matrix_rooms even when a client exists."""
+        import mmrelay.meshtastic_utils as mu
+
+        original_client = mu.meshtastic_client
+        original_config = mu.config
+        original_rooms = mu.matrix_rooms
+
+        existing_client = MagicMock()
+        config = {
+            "meshtastic": {"connection_type": "tcp", "host": "127.0.0.1"},
+            "matrix_rooms": [{"id": "!room:example.org", "meshtastic_channel": 0}],
+        }
+
+        try:
+            mu.meshtastic_client = existing_client
+            mu.shutting_down = False
+            mu.reconnecting = False
+            result = connect_meshtastic(passed_config=config)
+            observed_rooms = list(mu.matrix_rooms)
+            observed_config = mu.config
+        finally:
+            mu.meshtastic_client = original_client
+            mu.config = original_config
+            mu.matrix_rooms = original_rooms
+
+        self.assertIs(result, existing_client)
+        self.assertEqual(observed_rooms, config["matrix_rooms"])
+        self.assertIs(observed_config, config)
+
+
+class TestBleHelperFunctions(unittest.TestCase):
+    """Test BLE helper functions."""
+
+    def test_scan_for_ble_address_find_device_with_timeout(self):
+        """Cover BleakScanner.find_device_by_address(timeout=...)."""
+        from mmrelay.meshtastic_utils import _scan_for_ble_address
+
+        async def _find_device(_address: str, timeout: float | None = None):
+            return object()
+
+        fake_bleak = SimpleNamespace(
+            BleakScanner=SimpleNamespace(find_device_by_address=_find_device)
+        )
+
+        with (
+            patch("mmrelay.meshtastic_utils.BLE_AVAILABLE", True),
+            patch.dict(sys.modules, {"bleak": fake_bleak}),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.get_running_loop",
+                side_effect=RuntimeError(),
+            ),
+        ):
+            self.assertTrue(_scan_for_ble_address("AA:BB", 0.1))
+
+    def test_scan_for_ble_address_find_device_without_timeout(self):
+        """Cover BleakScanner.find_device_by_address() without timeout support."""
+        from mmrelay.meshtastic_utils import _scan_for_ble_address
+
+        async def _find_device(_address: str):
+            return object()
+
+        fake_bleak = SimpleNamespace(
+            BleakScanner=SimpleNamespace(find_device_by_address=_find_device)
+        )
+
+        with (
+            patch("mmrelay.meshtastic_utils.BLE_AVAILABLE", True),
+            patch.dict(sys.modules, {"bleak": fake_bleak}),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.get_running_loop",
+                side_effect=RuntimeError(),
+            ),
+        ):
+            self.assertTrue(_scan_for_ble_address("AA:BB", 0.1))
+
+    def test_scan_for_ble_address_discover_fallback(self):
+        """Cover BleakScanner.discover() fallback when find_device_by_address is absent."""
+        from mmrelay.meshtastic_utils import _scan_for_ble_address
+
+        async def _discover(timeout: float | None = None):
+            device = SimpleNamespace(address="AA:BB")
+            return [device]
+
+        fake_bleak = SimpleNamespace(
+            BleakScanner=SimpleNamespace(
+                find_device_by_address=None,
+                discover=_discover,
+            )
+        )
+
+        with (
+            patch("mmrelay.meshtastic_utils.BLE_AVAILABLE", True),
+            patch.dict(sys.modules, {"bleak": fake_bleak}),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.get_running_loop",
+                side_effect=RuntimeError(),
+            ),
+        ):
+            self.assertTrue(_scan_for_ble_address("AA:BB", 0.1))
+
+    def test_is_ble_discovery_error_message_matches(self):
+        """Cover message substring checks in _is_ble_discovery_error."""
+        from mmrelay.meshtastic_utils import _is_ble_discovery_error
+
+        self.assertTrue(
+            _is_ble_discovery_error(
+                Exception("No Meshtastic BLE peripheral found during scan")
+            )
+        )
+        self.assertTrue(
+            _is_ble_discovery_error(
+                Exception("Timed out waiting for connection completion")
+            )
+        )
+
+    def test_is_ble_discovery_error_type_matches(self):
+        """Cover BLEError and MeshInterfaceError type checks."""
+        from mmrelay.meshtastic_utils import _is_ble_discovery_error
+
+        class FakeBleInterface:
+            class BLEError(Exception):
+                pass
+
+        class FakeMeshInterface:
+            class MeshInterfaceError(Exception):
+                pass
+
+        with patch(
+            "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
+            FakeBleInterface,
+        ):
+            self.assertTrue(_is_ble_discovery_error(FakeBleInterface.BLEError("boom")))
+
+        with patch(
+            "mmrelay.meshtastic_utils.meshtastic.mesh_interface.MeshInterface",
+            FakeMeshInterface,
+        ):
+            self.assertTrue(
+                _is_ble_discovery_error(FakeMeshInterface.MeshInterfaceError("boom"))
+            )
+
 
 class TestMessageProcessingEdgeCases(unittest.TestCase):
     """Test cases for edge cases in message processing."""
@@ -1537,6 +1743,25 @@ class TestAsyncHelperUtilities(unittest.TestCase):
         def trigger(self) -> None:
             for callback in self._callbacks:
                 callback(self)
+
+    def test_fire_and_forget_ignores_non_coroutine(self):
+        """Ensure fire-and-forget returns early for non-coroutines."""
+        from mmrelay.meshtastic_utils import _fire_and_forget
+
+        with patch("mmrelay.meshtastic_utils._submit_coro") as mock_submit:
+            _fire_and_forget("not-a-coro")  # type: ignore[arg-type]
+
+        mock_submit.assert_not_called()
+
+    def test_fire_and_forget_returns_when_submit_none(self):
+        """Ensure fire-and-forget returns when _submit_coro yields no task."""
+        from mmrelay.meshtastic_utils import _fire_and_forget
+
+        async def _noop():
+            return None
+
+        with patch("mmrelay.meshtastic_utils._submit_coro", return_value=None):
+            _fire_and_forget(_noop())
 
     def test_fire_and_forget_ignores_cancelled_error(self):
         """Ensure fire-and-forget ignores CancelledError in callbacks."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR updates documentation (including Kubernetes deployment guidance), tightens type annotations across the codebase, and improves Meshtastic BLE/message handling and related tests. Changes focus on clearer authentication guidance favoring mmrelay auth login, improved type-safety and defensive checks, richer Meshtastic message logging and name resolution, and expanded test coverage.

## Key changes

### Features
- Documentation
  - Added Kubernetes deployment guide and references in README, INSTRUCTIONS, and DOCKER docs.
  - Introduced ADVANCED_CONFIGURATION content for Matrix authentication in container deployments (MMRELAY_MATRIX_* env vars) and deployment-specific recommendations.
- Meshtastic utilities
  - Added internal helper _get_node_display_name(...) to produce human-friendly sender names (interface name → DB short/long name → id/fallback).
  - Enhanced non-text Meshtastic message logging with structured sender/display info and richer short-keyed fields (batt, volt, temp, humidity, signal, relayed, priority).

### Fixes / Stability
- BLE and discovery
  - _scan_for_ble_address now awaits BleakScanner.find_device_by_address(...) and returns False on TypeError to avoid unexpected fallback behavior.
  - _is_ble_discovery_error adds defensive checks to verify BLEError/MeshInterfaceError types before isinstance calls.
- Startup and runtime guards
  - connect_meshtastic initializes local variables (ble_address, supports_auto_reconnect) each retry to avoid unbound-variable issues.
  - wait_for_service_start now gracefully disables Rich progress UI when rich.progress components cannot be imported.
  - drop_plugin.get_position skips iteration when meshtastic_client.nodes is falsy to avoid needless looping.

### Refactors / Type-safety
- Added pyrightconfig.json (venv and include/exclude settings).
- Widespread addition of type annotations, explicit typing casts (typing.cast), assertions, and selective type: ignore comments to satisfy static checkers (matrix-nio, Rich, SSL contexts).
- Matrix callback registrations and several call sites updated to use cast(...) to satisfy typing without changing runtime behavior.
- Class attribute annotations added (e.g., E2EEDebugger.config, E2EEDebugger.client) and several local-variable annotations.

### Tests
- Expanded test suite for meshtastic utilities and BLE edge cases:
  - New tests for BLE address handling, discovery errors, message filtering (ignoring messages for other nodes), shutdown behavior, reuse of existing Meshtastic client, and fire-and-forget behavior.
  - Relaxed fragile log assertions to accommodate the new, richer message-detail format.

## Breaking changes / Migration notes
- Documentation now emphasizes using mmrelay auth login (credentials.json) and adds Kubernetes deployment guidance. Password-based, non-interactive YAML auth guidance has been removed from primary doc flow and is presented only as a fallback—users are encouraged to migrate to auth login and follow updated container/Kubernetes instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->