### PR TITLE
Enhance credentials discovery and Matrix sync filters

### DIFF
--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -2,4 +2,4 @@
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
 
-__version__ = "1.2.9"
+__version__ = "1.2.10"

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -634,8 +634,16 @@ def save_credentials(
                 ) or relay_config.get("credentials_path")
         if credentials_path:
             credentials_path = os.path.expanduser(credentials_path)
-            if os.path.isdir(credentials_path):
-                credentials_path = os.path.join(credentials_path, "credentials.json")
+            path_is_dir = os.path.isdir(credentials_path)
+            if not path_is_dir:
+                path_is_dir = credentials_path.endswith(os.path.sep) or (
+                    os.path.altsep and credentials_path.endswith(os.path.altsep)
+                )
+            if path_is_dir:
+                credentials_path = os.path.join(
+                    credentials_path.rstrip(os.path.sep).rstrip(os.path.altsep or ""),
+                    "credentials.json",
+                )
             config_dir = os.path.dirname(credentials_path)
             if not config_dir:
                 config_dir = get_base_dir()

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -621,17 +621,13 @@ def save_credentials(
     config_dir = ""
     try:
         if not credentials_path:
-            matrix_config = relay_config.get("matrix", {})
-            if isinstance(matrix_config, dict):
-                credentials_path = (
-                    os.getenv("MMRELAY_CREDENTIALS_PATH")
-                    or relay_config.get("credentials_path")
-                    or matrix_config.get("credentials_path")
-                )
-            else:
-                credentials_path = os.getenv(
-                    "MMRELAY_CREDENTIALS_PATH"
-                ) or relay_config.get("credentials_path")
+            credentials_path = os.getenv(
+                "MMRELAY_CREDENTIALS_PATH"
+            ) or relay_config.get("credentials_path")
+            if not credentials_path:
+                matrix_config = relay_config.get("matrix", {})
+                if isinstance(matrix_config, dict):
+                    credentials_path = matrix_config.get("credentials_path")
         if credentials_path:
             credentials_path = os.path.expanduser(credentials_path)
             path_is_dir = os.path.isdir(credentials_path)

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -621,11 +621,17 @@ def save_credentials(
     config_dir = ""
     try:
         if not credentials_path:
-            credentials_path = os.getenv("MMRELAY_CREDENTIALS_PATH")
-        if not credentials_path:
-            credentials_path = relay_config.get("credentials_path")
-            if not credentials_path and isinstance(relay_config.get("matrix"), dict):
-                credentials_path = relay_config["matrix"].get("credentials_path")
+            matrix_config = relay_config.get("matrix", {})
+            if isinstance(matrix_config, dict):
+                credentials_path = (
+                    os.getenv("MMRELAY_CREDENTIALS_PATH")
+                    or relay_config.get("credentials_path")
+                    or matrix_config.get("credentials_path")
+                )
+            else:
+                credentials_path = os.getenv(
+                    "MMRELAY_CREDENTIALS_PATH"
+                ) or relay_config.get("credentials_path")
         if credentials_path:
             credentials_path = os.path.expanduser(credentials_path)
             if os.path.isdir(credentials_path):

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -604,16 +604,24 @@ def save_credentials(
     credentials: dict[str, Any], credentials_path: str | None = None
 ) -> None:
     """
-    Persist a JSON-serializable credentials mapping to <base_dir>/credentials.json.
+    Persist a JSON-serializable credentials mapping to a credentials.json path.
 
-    Writes the provided credentials (a JSON-serializable mapping) to the application's
-    base configuration directory as credentials.json, creating the base directory if
-    necessary. On Unix-like systems the file permissions are adjusted to be
-    restrictive (0o600) when possible. I/O and permission errors are caught and
-    logged; the function does not raise them.
+    Writes the provided credentials (a JSON-serializable mapping) to the resolved
+    credentials path, creating the target directory if necessary. When
+    `credentials_path` is not provided, the function resolves the path in order:
+    1) MMRELAY_CREDENTIALS_PATH environment variable
+    2) relay_config["credentials_path"]
+    3) relay_config["matrix"]["credentials_path"] (when matrix config is a dict)
+    If the resolved path points to a directory, "credentials.json" is appended.
+    On Unix-like systems the file permissions are adjusted to be restrictive (0o600)
+    when possible. I/O and permission errors are caught and logged; the function
+    does not raise them.
 
     Parameters:
         credentials (dict): JSON-serializable mapping of credentials to persist.
+        credentials_path (str | None): Optional path or directory override for
+            where to save credentials.json. If omitted, the path is resolved from
+            environment/config defaults.
 
     Returns:
         None

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -604,25 +604,15 @@ def save_credentials(
     credentials: dict[str, Any], credentials_path: str | None = None
 ) -> None:
     """
-    Persist a JSON-serializable credentials mapping to a credentials.json path.
-
-    Writes the provided credentials (a JSON-serializable mapping) to the resolved
-    credentials path, creating the target directory if necessary. When
-    `credentials_path` is not provided, the function resolves the path in order:
-    1) MMRELAY_CREDENTIALS_PATH environment variable
-    2) relay_config["credentials_path"]
-    3) relay_config["matrix"]["credentials_path"] (when matrix config is a dict)
-    If the resolved path points to a directory, "credentials.json" is appended.
-    On Unix-like systems the file permissions are adjusted to be restrictive (0o600)
-    when possible. I/O and permission errors are caught and logged; the function
-    does not raise them.
-
+    Persist a JSON-serializable credentials mapping to a credentials.json file.
+    
+    If `credentials_path` is provided it is used as the target file or directory; if it refers to a directory (or ends with a path separator) "credentials.json" is appended. If `credentials_path` is not provided the path is resolved in order from: the `MMRELAY_CREDENTIALS_PATH` environment variable, `relay_config["credentials_path"]`, and `relay_config["matrix"]["credentials_path"]` (when `matrix` is a dict). The function creates the target directory if missing and, on Unix-like systems, attempts to set restrictive file permissions (0o600). I/O and permission errors are caught and logged; they are not raised.
+    
     Parameters:
         credentials (dict): JSON-serializable mapping of credentials to persist.
-        credentials_path (str | None): Optional path or directory override for
-            where to save credentials.json. If omitted, the path is resolved from
-            environment/config defaults.
-
+        credentials_path (str | None): Optional path or directory override for where to save credentials.json.
+            If omitted, the path is resolved from environment/config defaults.
+    
     Returns:
         None
     """

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -623,13 +623,19 @@ def save_credentials(
         if not credentials_path:
             credentials_path = os.getenv("MMRELAY_CREDENTIALS_PATH")
         if not credentials_path:
-            explicit = relay_config.get("credentials_path")
-            if not explicit and isinstance(relay_config.get("matrix"), dict):
-                explicit = relay_config["matrix"].get("credentials_path")
-            credentials_path = explicit
+            credentials_path = relay_config.get("credentials_path")
+            if not credentials_path and isinstance(relay_config.get("matrix"), dict):
+                credentials_path = relay_config["matrix"].get("credentials_path")
         if credentials_path:
             credentials_path = os.path.expanduser(credentials_path)
+            if os.path.isdir(credentials_path):
+                credentials_path = os.path.join(credentials_path, "credentials.json")
             config_dir = os.path.dirname(credentials_path)
+            if not config_dir:
+                config_dir = get_base_dir()
+                credentials_path = os.path.join(
+                    config_dir, os.path.basename(credentials_path)
+                )
         else:
             config_dir = get_base_dir()
             credentials_path = os.path.join(config_dir, "credentials.json")

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -236,8 +236,16 @@ async def main(config: dict[str, Any]) -> None:
                     meshtastic_logger.warning("Meshtastic client is not connected.")
 
                 matrix_logger.info("Starting Matrix sync loop...")
+                sync_filter = getattr(matrix_client, "mmrelay_sync_filter", None)
+                first_sync_filter = getattr(
+                    matrix_client, "mmrelay_first_sync_filter", None
+                )
                 sync_task = asyncio.create_task(
-                    matrix_client.sync_forever(timeout=30000)
+                    matrix_client.sync_forever(
+                        timeout=30000,
+                        sync_filter=sync_filter,
+                        first_sync_filter=first_sync_filter,
+                    )
                 )
 
                 shutdown_task = asyncio.create_task(shutdown_event.wait())

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -52,6 +52,7 @@ from mmrelay.cli_utils import (
     msg_require_auth_login,
     msg_retry_auth_login,
 )
+from mmrelay.config import config_path as loaded_config_path
 from mmrelay.config import (
     get_base_dir,
     get_e2ee_store_dir,
@@ -1229,9 +1230,6 @@ async def connect_matrix(
 
     # Try to find credentials.json from explicit config, config directory, or base dir
     try:
-        from mmrelay.config import config_path as loaded_config_path
-        from mmrelay.config import get_base_dir
-
         explicit_path = None
         if isinstance(config, dict):
             explicit_path = config.get("credentials_path")

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -1195,14 +1195,14 @@ async def connect_matrix(
     passed_config: dict[str, Any] | None = None,
 ) -> AsyncClient | None:
     """
-    Prepare and return a configured Matrix AsyncClient using available credentials and configuration.
-
+    Initialize and return a configured Matrix AsyncClient using available credentials and configuration.
+    
     Parameters:
-        passed_config (dict | None): Optional configuration override for this connection attempt; when provided it is used instead of the module-level config for this call.
-
+        passed_config (dict[str, Any] | None): Optional configuration override for this connection attempt; when provided it is used instead of the module-level config for this call.
+    
     Returns:
-        AsyncClient | None: An initialized AsyncClient ready for use, or `None` if connection or credential setup failed.
-
+        AsyncClient | None: A configured and initialized Matrix AsyncClient when connection and setup succeed, or `None` if connection or credential setup failed.
+    
     Raises:
         ValueError: If the required top-level "matrix_rooms" configuration is missing.
         ConnectionError: If the initial Matrix sync fails or times out.
@@ -1717,12 +1717,12 @@ async def connect_matrix(
     # Resolve room aliases in config (supports list[str|dict] and dict[str->str|dict])
     async def _resolve_alias(alias: str) -> str | None:
         """
-        Resolve a Matrix room alias to its canonical room ID.
-
-        Attempts to resolve the given room alias via the module-level Matrix client. If the alias is resolved, the canonical room ID string is returned; if the client is unavailable, the alias cannot be resolved, or an error occurs, `None` is returned. Underlying client and network errors are caught internally.
-
+        Return the canonical Matrix room ID for the given room alias.
+        
+        If the module-level Matrix client is unavailable or the alias cannot be resolved, returns None. Network and client errors are handled internally and do not raise.
+        
         Returns:
-            str | None: The resolved room ID when available, `None` otherwise.
+            The resolved room ID string if successful, None otherwise.
         """
         if not matrix_client:
             logger.warning(

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -1601,7 +1601,7 @@ async def connect_matrix(
 
     # Perform initial sync to populate rooms (needed for message delivery)
     logger.debug("Performing initial sync to initialize rooms...")
-    invite_safe_filter: dict[str, Any] | None = {"room": {"invite": {"limit": 0}}}
+    invite_safe_filter: dict[str, Any] = {"room": {"invite": {"limit": 0}}}
     sync_response: Any | None = None
     try:
         # A full_state=True sync is required to get room encryption state

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -38,6 +38,7 @@ from nio import (  # type: ignore[import-untyped]
     RoomMessageEmote,
     RoomMessageNotice,
     RoomMessageText,
+    SyncError,
     UploadError,
     UploadResponse,
 )
@@ -1678,26 +1679,20 @@ async def connect_matrix(
             raise ConnectionError("Matrix sync failed") from exc
 
     # If the sync returned an explicit error response, treat it as a failure.
-    if (
-        hasattr(sync_response, "__class__")
-        and "Error" in sync_response.__class__.__name__
-    ):
+    if isinstance(sync_response, SyncError):
         error_type = sync_response.__class__.__name__
         error_details = _get_detailed_matrix_error_message(sync_response)
         logger.error(f"Initial sync failed: {error_type}")
         logger.error(f"Error details: {error_details}")
 
-        if "SyncError" in error_type:
-            logger.error(
-                "This usually indicates a network connectivity issue or server problem."
-            )
-            logger.error("Troubleshooting steps:")
-            logger.error("1. Check your internet connection")
-            logger.error(
-                f"2. Verify the homeserver URL is correct: {matrix_homeserver}"
-            )
-            logger.error("3. Ensure the Matrix server is online and accessible")
-            logger.error("4. Check if your credentials are still valid")
+        logger.error(
+            "This usually indicates a network connectivity issue or server problem."
+        )
+        logger.error("Troubleshooting steps:")
+        logger.error("1. Check your internet connection")
+        logger.error(f"2. Verify the homeserver URL is correct: {matrix_homeserver}")
+        logger.error("3. Ensure the Matrix server is online and accessible")
+        logger.error("4. Check if your credentials are still valid")
 
         try:
             await matrix_client.close()

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -1743,10 +1743,8 @@ async def connect_matrix(
                     return []
 
                 try:
-                    setattr(
-                        nio_responses.SyncResponse,
-                        "_get_invite_state",
-                        staticmethod(_safe_get_invite_state),
+                    nio_responses.SyncResponse._get_invite_state = staticmethod(
+                        _safe_get_invite_state
                     )
                     return await asyncio.wait_for(
                         matrix_client.sync(
@@ -1758,10 +1756,8 @@ async def connect_matrix(
                     )
                 finally:
                     if original_descriptor is not None:
-                        setattr(
-                            nio_responses.SyncResponse,
-                            "_get_invite_state",
-                            original_descriptor,
+                        nio_responses.SyncResponse._get_invite_state = (
+                            original_descriptor
                         )
 
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,27 @@ class MockWhoamiError(Exception):
         self.message = message
 
 
+class MockSyncError(Exception):
+    def __init__(
+        self,
+        message: str = "Sync error",
+        status_code: str | None = None,
+        retry_after_ms: int | None = None,
+        soft_logout: bool = False,
+    ):
+        """
+        Initialize a SyncError-like exception for nio mocks.
+
+        Mirrors the attributes used by matrix-nio SyncError so isinstance checks and
+        message parsing behave like the real response type in tests.
+        """
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.retry_after_ms = retry_after_ms
+        self.soft_logout = soft_logout
+
+
 nio_mock.AsyncClientConfig = MagicMock()
 nio_mock.MatrixRoom = MockMatrixRoom
 nio_mock.ReactionEvent = MockReactionEvent
@@ -202,6 +223,7 @@ nio_mock.RoomEncryptionEvent = MockRoomEncryptionEvent
 nio_mock.MegolmEvent = MockMegolmEvent
 nio_mock.UploadResponse = MagicMock()
 nio_mock.WhoamiError = MockWhoamiError
+nio_mock.SyncError = MockSyncError
 sys.modules["nio.events.room_events"].RoomMemberEvent = MagicMock()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,13 +180,13 @@ class MockMegolmEvent:
 class MockWhoamiError(Exception):
     def __init__(self, message="Whoami error"):
         """
-        Initialize the Whoami error exception.
-
+        Create a Whoami error carrying a human-readable message.
+        
         Parameters:
-            message (str): Human-readable error message. Defaults to "Whoami error".
-
+            message (str): Error message describing the condition. Defaults to "Whoami error".
+        
         Attributes:
-            message (str): The provided message (also available as the exception's first arg).
+            message (str): The provided error message (also available as the exception's first argument).
         """
         super().__init__(message)
         self.message = message
@@ -201,10 +201,13 @@ class MockSyncError(Exception):
         soft_logout: bool = False,
     ):
         """
-        Initialize a SyncError-like exception for nio mocks.
-
-        Mirrors the attributes used by matrix-nio SyncError so isinstance checks and
-        message parsing behave like the real response type in tests.
+        Create a mock SyncError carrying the attributes used by matrix-nio for tests.
+        
+        Parameters:
+            message (str): Human-readable error message.
+            status_code (str | None): Optional error status code returned by the server.
+            retry_after_ms (int | None): Optional suggested retry delay in milliseconds.
+            soft_logout (bool): Whether the error indicates a soft logout condition.
         """
         super().__init__(message)
         self.message = message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,18 +178,18 @@ class MockMegolmEvent:
 
 
 class MockWhoamiError(Exception):
-    def __init__(self, message="Whoami error"):
+    def __init__(self, message: str = "Whoami error") -> None:
         """
         Create a Whoami error carrying a human-readable message.
-        
+
         Parameters:
             message (str): Error message describing the condition. Defaults to "Whoami error".
-        
+
         Attributes:
             message (str): The provided error message (also available as the exception's first argument).
         """
         super().__init__(message)
-        self.message = message
+        self.message: str = message
 
 
 class MockSyncError(Exception):
@@ -202,7 +202,7 @@ class MockSyncError(Exception):
     ):
         """
         Create a mock SyncError carrying the attributes used by matrix-nio for tests.
-        
+
         Parameters:
             message (str): Human-readable error message.
             status_code (str | None): Optional error status code returned by the server.

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -183,9 +183,9 @@ class TestAsyncPatterns(unittest.TestCase):
 
     def test_async_error_propagation(self):
         """
-        Test that exceptions in async operations are correctly propagated and can be handled by the caller.
-
-        This test verifies that when an async method raises an exception, the exception is either handled gracefully by the function under test or properly propagated to the caller for handling.
+        Verify that exceptions raised by async operations during Matrix connection are either handled or propagated with the expected message.
+        
+        Patches the Matrix AsyncClient to raise during sync and asserts that connect_matrix either returns a non-None client (indicating graceful handling) or raises a ConnectionError whose message contains "Matrix sync failed".
         """
 
         async def test_error_handling():

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -210,9 +210,9 @@ class TestAsyncPatterns(unittest.TestCase):
                         result = await connect_matrix(self.config)
                         # connect_matrix should handle errors and return client anyway
                         self.assertIsNotNone(result)
-                    except Exception as e:
+                    except ConnectionError as e:
                         # If exception is raised, it should be the expected one
-                        self.assertIn("Connection failed", str(e))
+                        self.assertIn("Matrix sync failed", str(e))
 
         # Run the error handling test
         asyncio.run(test_error_handling())

--- a/tests/test_async_patterns.py
+++ b/tests/test_async_patterns.py
@@ -21,7 +21,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from mmrelay.matrix_utils import connect_matrix, matrix_relay
+from mmrelay.matrix_utils import (
+    NioLocalTransportError,
+    connect_matrix,
+    matrix_relay,
+)
 
 
 class TestAsyncPatterns(unittest.TestCase):
@@ -184,7 +188,7 @@ class TestAsyncPatterns(unittest.TestCase):
     def test_async_error_propagation(self):
         """
         Verify that exceptions raised by async operations during Matrix connection are either handled or propagated with the expected message.
-        
+
         Patches the Matrix AsyncClient to raise during sync and asserts that connect_matrix either returns a non-None client (indicating graceful handling) or raises a ConnectionError whose message contains "Matrix sync failed".
         """
 
@@ -202,7 +206,9 @@ class TestAsyncPatterns(unittest.TestCase):
                 with patch("mmrelay.matrix_utils.AsyncClient") as mock_client_class:
                     mock_client = AsyncMock()
                     mock_client.rooms = {}
-                    mock_client.sync.side_effect = Exception("Connection failed")
+                    mock_client.sync.side_effect = NioLocalTransportError(
+                        "Connection failed"
+                    )
                     mock_client_class.return_value = mock_client
 
                     # Should handle the exception gracefully

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -986,7 +986,7 @@ class TestCredentials(unittest.TestCase):
         original_env = os.environ.copy()
         try:
             config_module.relay_config = {}
-            os.environ["MMRELAY_CREDENTIALS_PATH"] = "/custom/dir\\"
+            os.environ["MMRELAY_CREDENTIALS_PATH"] = "/custom/dir/"
 
             save_credentials(credentials)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -986,7 +986,7 @@ class TestCredentials(unittest.TestCase):
         original_env = os.environ.copy()
         try:
             config_module.relay_config = {}
-            os.environ["MMRELAY_CREDENTIALS_PATH"] = "/custom/dir/"
+            os.environ["MMRELAY_CREDENTIALS_PATH"] = "/custom/dir\\"
 
             save_credentials(credentials)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1008,6 +1008,282 @@ class TestCredentials(unittest.TestCase):
             os.environ.clear()
             os.environ.update(original_env)
 
+    @patch("mmrelay.config.get_base_dir", return_value="/fake/dir")
+    @patch("mmrelay.config.os.makedirs")
+    @patch("mmrelay.config.os.path.join", side_effect=os.path.join)
+    @patch("mmrelay.config.os.path.isdir", return_value=False)
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_credentials_from_env_var(
+        self,
+        _mock_open,
+        _mock_makedirs,
+        _mock_join,
+        _mock_get_base_dir,
+        _mock_isdir,
+    ):
+        """Test save_credentials uses MMRELAY_CREDENTIALS_PATH environment variable."""
+        credentials = {"user_id": "test", "access_token": "token"}
+
+        from mmrelay import config as config_module
+
+        original_relay_config = config_module.relay_config.copy()
+        original_env = os.environ.copy()
+        try:
+            config_module.relay_config = {}
+            os.environ["MMRELAY_CREDENTIALS_PATH"] = "/custom/creds.json"
+
+            save_credentials(credentials)
+
+            _mock_makedirs.assert_called_once()
+            _mock_open.assert_called_once()
+            call_args = _mock_open.call_args
+            final_path = call_args[0][0]
+            self.assertEqual(
+                final_path,
+                "/custom/creds.json",
+                "Should use path from MMRELAY_CREDENTIALS_PATH environment variable",
+            )
+        finally:
+            config_module.relay_config = original_relay_config
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    @patch("mmrelay.config.get_base_dir", return_value="/fake/dir")
+    @patch("mmrelay.config.os.makedirs")
+    @patch("mmrelay.config.os.path.join", side_effect=os.path.join)
+    @patch("mmrelay.config.os.path.isdir", return_value=False)
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_credentials_from_relay_config(
+        self,
+        _mock_open,
+        _mock_makedirs,
+        _mock_join,
+        _mock_get_base_dir,
+        _mock_isdir,
+    ):
+        """Test save_credentials uses relay_config['credentials_path'] when env var not set."""
+        credentials = {"user_id": "test", "access_token": "token"}
+
+        from mmrelay import config as config_module
+
+        original_relay_config = config_module.relay_config.copy()
+        original_env = os.environ.copy()
+        try:
+            config_module.relay_config = {"credentials_path": "/config/creds.json"}
+
+            save_credentials(credentials)
+
+            _mock_makedirs.assert_called_once()
+            _mock_open.assert_called_once()
+            call_args = _mock_open.call_args
+            final_path = call_args[0][0]
+            self.assertEqual(
+                final_path,
+                "/config/creds.json",
+                "Should use path from relay_config['credentials_path']",
+            )
+        finally:
+            config_module.relay_config = original_relay_config
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    @patch("mmrelay.config.get_base_dir", return_value="/fake/dir")
+    @patch("mmrelay.config.os.makedirs")
+    @patch("mmrelay.config.os.path.join", side_effect=os.path.join)
+    @patch("mmrelay.config.os.path.isdir", return_value=False)
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_credentials_from_matrix_config(
+        self,
+        _mock_open,
+        _mock_makedirs,
+        _mock_join,
+        _mock_get_base_dir,
+        _mock_isdir,
+    ):
+        """Test save_credentials uses relay_config['matrix']['credentials_path'] as fallback."""
+        credentials = {"user_id": "test", "access_token": "token"}
+
+        from mmrelay import config as config_module
+
+        original_relay_config = config_module.relay_config.copy()
+        original_env = os.environ.copy()
+        try:
+            config_module.relay_config = {
+                "matrix": {"credentials_path": "/matrix/creds.json"}
+            }
+
+            save_credentials(credentials)
+
+            _mock_makedirs.assert_called_once()
+            _mock_open.assert_called_once()
+            call_args = _mock_open.call_args
+            final_path = call_args[0][0]
+            self.assertEqual(
+                final_path,
+                "/matrix/creds.json",
+                "Should use path from relay_config['matrix']['credentials_path']",
+            )
+        finally:
+            config_module.relay_config = original_relay_config
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    @patch("mmrelay.config.get_base_dir", return_value="/fake/dir")
+    @patch("mmrelay.config.os.makedirs")
+    @patch("mmrelay.config.os.path.join", side_effect=os.path.join)
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_credentials_from_matrix_config_not_dict(
+        self,
+        _mock_open,
+        _mock_makedirs,
+        _mock_join,
+        _mock_get_base_dir,
+    ):
+        """Test save_credentials when matrix config is not a dict."""
+        credentials = {"user_id": "test", "access_token": "token"}
+
+        from mmrelay import config as config_module
+
+        original_relay_config = config_module.relay_config.copy()
+        original_env = os.environ.copy()
+        try:
+            config_module.relay_config = {"matrix": "not_a_dict"}
+
+            save_credentials(credentials)
+
+            _mock_makedirs.assert_called_once()
+            _mock_open.assert_called_once()
+            call_args = _mock_open.call_args
+            final_path = call_args[0][0]
+            self.assertEqual(
+                final_path,
+                "/fake/dir/credentials.json",
+                "Should use get_base_dir() when matrix config is not a dict",
+            )
+        finally:
+            config_module.relay_config = original_relay_config
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    @patch("mmrelay.config.get_base_dir", return_value="/actual/directory")
+    @patch("mmrelay.config.os.makedirs")
+    @patch("mmrelay.config.os.path.join", side_effect=os.path.join)
+    @patch("mmrelay.config.os.path.isdir", return_value=True)
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_credentials_actual_directory_path(
+        self,
+        _mock_open,
+        _mock_makedirs,
+        _mock_join,
+        _mock_get_base_dir,
+        _mock_isdir,
+    ):
+        """Test save_credentials when path is an actual directory (via os.path.isdir)."""
+        credentials = {"user_id": "test", "access_token": "token"}
+
+        from mmrelay import config as config_module
+
+        original_relay_config = config_module.relay_config.copy()
+        original_env = os.environ.copy()
+        try:
+            config_module.relay_config = {}
+            os.environ["MMRELAY_CREDENTIALS_PATH"] = "/actual/directory"
+
+            save_credentials(credentials)
+
+            _mock_makedirs.assert_called_once()
+            _mock_open.assert_called_once()
+            call_args = _mock_open.call_args
+            final_path = call_args[0][0]
+            self.assertEqual(
+                final_path,
+                "/actual/directory/credentials.json",
+                "Should append credentials.json to actual directory",
+            )
+        finally:
+            config_module.relay_config = original_relay_config
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    @patch("mmrelay.config.get_base_dir", return_value="/custom/dir")
+    @patch("mmrelay.config.os.makedirs")
+    @patch.object(os.path, "altsep", "\\")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_credentials_altsep_path_detection(
+        self, _mock_open, _mock_makedirs, _mock_get_base_dir
+    ):
+        """Test save_credentials detects path ending with altsep (Windows separator) as directory."""
+        credentials = {"user_id": "test", "access_token": "token"}
+
+        from mmrelay import config as config_module
+
+        original_relay_config = config_module.relay_config.copy()
+        original_env = os.environ.copy()
+        try:
+            config_module.relay_config = {}
+            os.environ["MMRELAY_CREDENTIALS_PATH"] = "/custom/dir/"
+
+            save_credentials(credentials)
+
+            _mock_open.assert_called_once()
+            call_args = _mock_open.call_args
+            final_path = call_args[0][0]
+            self.assertTrue(
+                final_path.endswith("credentials.json"),
+                f"Should append credentials.json: {final_path}",
+            )
+        finally:
+            config_module.relay_config = original_relay_config
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    @patch("mmrelay.config.get_base_dir", return_value="/base/dir")
+    @patch("mmrelay.config.os.makedirs")
+    @patch("mmrelay.config.os.path.join", side_effect=os.path.join)
+    @patch("mmrelay.config.os.path.dirname", return_value="")
+    @patch("mmrelay.config.os.path.basename", return_value="creds.json")
+    @patch("mmrelay.config.os.path.isdir", return_value=False)
+    @patch("mmrelay.config.os.path.expanduser", side_effect=lambda x: x)
+    @patch("builtins.open", new_callable=mock_open)
+    def test_save_credentials_empty_config_dir_uses_base_dir(
+        self,
+        _mock_open,
+        _mock_expanduser,
+        _mock_isdir,
+        _mock_basename,
+        _mock_dirname,
+        _mock_join,
+        _mock_makedirs,
+        _mock_get_base_dir,
+    ):
+        """Test save_credentials uses get_base_dir when config_dir is empty."""
+        credentials = {"user_id": "test", "access_token": "token"}
+
+        from mmrelay import config as config_module
+
+        original_relay_config = config_module.relay_config.copy()
+        original_env = os.environ.copy()
+        try:
+            config_module.relay_config = {}
+            os.environ["MMRELAY_CREDENTIALS_PATH"] = "creds.json"
+
+            save_credentials(credentials)
+
+            _mock_makedirs.assert_called_once()
+            _mock_open.assert_called_once()
+            call_args = _mock_open.call_args
+            final_path = call_args[0][0]
+            self.assertEqual(
+                final_path,
+                "/base/dir/creds.json",
+                "Should use get_base_dir when config_dir is empty",
+            )
+            _mock_get_base_dir.assert_called()
+        finally:
+            config_module.relay_config = original_relay_config
+            os.environ.clear()
+            os.environ.update(original_env)
+
 
 class TestYAMLValidation(unittest.TestCase):
     """Test YAML syntax validation."""

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -3578,6 +3578,14 @@ async def test_connect_matrix_sync_error_close_failure_logs():
     )
 
     def fake_async_client(*_args, **_kwargs):
+        """
+        Return the preconfigured mock Matrix client, ignoring all positional and keyword arguments.
+        
+        This helper supplies the shared mock client instance for tests that expect an async client factory.
+        
+        Returns:
+            mock_client: The mock Matrix client instance used by the test suite.
+        """
         return mock_client
 
     config = {
@@ -3623,6 +3631,19 @@ async def test_connect_matrix_sync_validation_error_retries_with_invite_safe_fil
     call_count = [0]
 
     async def mock_sync(*_args, **_kwargs):
+        """
+        Test helper that simulates a sync operation failing once with a ValidationError and succeeding thereafter.
+        
+        On each invocation this increments the enclosing `call_count[0]` counter. The first call raises a
+        jsonschema.exceptions.ValidationError to simulate an invite-safe filtering error; subsequent calls
+        return a simple success sentinel.
+        
+        Raises:
+            jsonschema.exceptions.ValidationError: on the first invocation.
+        
+        Returns:
+            SimpleNamespace: A success sentinel object on invocations after the first.
+        """
         call_count[0] += 1
         if call_count[0] == 1:
             # First sync raises ValidationError (caught, triggers invite-safe filter)
@@ -3638,6 +3659,14 @@ async def test_connect_matrix_sync_validation_error_retries_with_invite_safe_fil
 
     # Set up mocks for connect_matrix
     def fake_async_client(*_args, **_kwargs):
+        """
+        Return the preconfigured mock Matrix client, ignoring all positional and keyword arguments.
+        
+        This helper supplies the shared mock client instance for tests that expect an async client factory.
+        
+        Returns:
+            mock_client: The mock Matrix client instance used by the test suite.
+        """
         return mock_client
 
     # Patch jsonschema.exceptions to simulate ImportError for ValidationError only
@@ -3701,6 +3730,11 @@ async def test_connect_matrix_sync_validation_error_retry_failure_closes_client(
     call_count = {"count": 0}
 
     async def mock_sync(*_args, **_kwargs):
+        """
+        Simulate a sync operation that increments a shared call counter and fails with controlled exceptions.
+        
+        Increments call_count["count"] each invocation. On the first invocation raises jsonschema.exceptions.ValidationError with message "Invalid schema"; on every subsequent invocation raises RuntimeError("retry failed"). Positional and keyword arguments are ignored.
+        """
         call_count["count"] += 1
         if call_count["count"] == 1:
             raise jsonschema.exceptions.ValidationError(
@@ -3713,6 +3747,14 @@ async def test_connect_matrix_sync_validation_error_retry_failure_closes_client(
     mock_client.sync = mock_sync
 
     def fake_async_client(*_args, **_kwargs):
+        """
+        Return the preconfigured mock Matrix client, ignoring all positional and keyword arguments.
+        
+        This helper supplies the shared mock client instance for tests that expect an async client factory.
+        
+        Returns:
+            mock_client: The mock Matrix client instance used by the test suite.
+        """
         return mock_client
 
     config = {
@@ -3740,7 +3782,11 @@ async def test_connect_matrix_sync_validation_error_retry_failure_closes_client(
 
 @pytest.mark.asyncio
 async def test_connect_matrix_uploads_keys_when_needed(monkeypatch):
-    """When should_upload_keys is True, keys_upload should be called once."""
+    """
+    Verify that the Matrix client uploads keys when the client's key-upload flag is enabled.
+    
+    Asserts that connect_matrix returns the created client and that the client's `keys_upload` coroutine is awaited exactly once when `should_upload_keys` is truthy.
+    """
     mock_client = MagicMock()
     mock_client.rooms = {}
     mock_client.sync = AsyncMock(return_value=SimpleNamespace())
@@ -3918,6 +3964,15 @@ async def test_connect_matrix_explicit_credentials_path_is_used():
     )
 
     def fake_isfile(path):
+        """
+        Check whether the provided path matches the predefined expanded_path from the enclosing scope.
+        
+        Parameters:
+            path (str): File path to check.
+        
+        Returns:
+            bool: `true` if `path` is equal to the captured `expanded_path`, `false` otherwise.
+        """
         return path == expanded_path
 
     config = {

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -3643,6 +3643,8 @@ async def test_connect_matrix_sync_validation_error_retries_with_invite_safe_fil
     # Patch jsonschema.exceptions to simulate ImportError for ValidationError only
     with (
         patch("mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock()),
+        patch("mmrelay.matrix_utils.os.path.exists", return_value=False),
+        patch("mmrelay.matrix_utils.os.path.isfile", return_value=False),
         patch(
             "mmrelay.matrix_utils._resolve_aliases_in_mapping",
             AsyncMock(return_value=None),
@@ -3724,6 +3726,7 @@ async def test_connect_matrix_sync_validation_error_retry_failure_closes_client(
 
     with (
         patch("mmrelay.matrix_utils.AsyncClient", fake_async_client),
+        patch("mmrelay.matrix_utils.os.path.exists", return_value=False),
         patch("mmrelay.matrix_utils.matrix_client", None),
         patch("mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock()),
         patch("mmrelay.matrix_utils.os.path.isfile", return_value=False),
@@ -4008,7 +4011,7 @@ async def test_connect_matrix_ignores_config_access_token_when_credentials_prese
         patch("mmrelay.matrix_utils.os.path.isfile", return_value=True),
         patch("builtins.open", new_callable=MagicMock),
         patch(
-            "json.load",
+            "mmrelay.matrix_utils.json.load",
             return_value={
                 "homeserver": "https://matrix.example.org",
                 "user_id": "@bot:example.org",

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -3704,6 +3704,7 @@ async def test_connect_matrix_credentials_load_exception_uses_config(monkeypatch
 
     with (
         patch("mmrelay.matrix_utils.os.path.exists", return_value=True),
+        patch("mmrelay.matrix_utils.os.path.isfile", return_value=True),
         patch("builtins.open", side_effect=OSError("boom")),
         patch(
             "mmrelay.e2ee_utils.get_e2ee_status", return_value={"overall_status": "ok"}
@@ -3715,7 +3716,7 @@ async def test_connect_matrix_credentials_load_exception_uses_config(monkeypatch
 
     assert client is mock_client
     assert any(
-        "Error loading credentials" in call.args[0]
+        "Ignoring invalid credentials file" in call.args[0]
         for call in mock_logger.warning.call_args_list
     )
 
@@ -3764,9 +3765,10 @@ async def test_connect_matrix_ignores_config_access_token_when_credentials_prese
 
     with (
         patch("mmrelay.matrix_utils.os.path.exists", return_value=True),
+        patch("mmrelay.matrix_utils.os.path.isfile", return_value=True),
         patch("builtins.open", new_callable=MagicMock),
         patch(
-            "mmrelay.matrix_utils.json.load",
+            "json.load",
             return_value={
                 "homeserver": "https://matrix.example.org",
                 "user_id": "@bot:example.org",
@@ -4306,6 +4308,7 @@ async def test_connect_matrix_whoami_missing_device_id_warns(monkeypatch):
 
     with (
         patch("mmrelay.matrix_utils.os.path.exists", return_value=True),
+        patch("mmrelay.matrix_utils.os.path.isfile", return_value=True),
         patch("builtins.open", new_callable=MagicMock),
         patch(
             "mmrelay.matrix_utils.json.load",
@@ -4366,6 +4369,7 @@ async def test_connect_matrix_whoami_failure_warns(monkeypatch):
 
     with (
         patch("mmrelay.matrix_utils.os.path.exists", return_value=True),
+        patch("mmrelay.matrix_utils.os.path.isfile", return_value=True),
         patch("builtins.open", new_callable=MagicMock),
         patch(
             "mmrelay.matrix_utils.json.load",
@@ -4433,6 +4437,7 @@ async def test_connect_matrix_save_credentials_failure_warns(monkeypatch):
 
     with (
         patch("mmrelay.matrix_utils.os.path.exists", return_value=True),
+        patch("mmrelay.matrix_utils.os.path.isfile", return_value=True),
         patch("builtins.open", new_callable=MagicMock),
         patch(
             "mmrelay.matrix_utils.json.load",

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -3580,9 +3580,9 @@ async def test_connect_matrix_sync_error_close_failure_logs():
     def fake_async_client(*_args, **_kwargs):
         """
         Return the preconfigured mock Matrix client, ignoring all positional and keyword arguments.
-        
+
         This helper supplies the shared mock client instance for tests that expect an async client factory.
-        
+
         Returns:
             mock_client: The mock Matrix client instance used by the test suite.
         """
@@ -3633,14 +3633,14 @@ async def test_connect_matrix_sync_validation_error_retries_with_invite_safe_fil
     async def mock_sync(*_args, **_kwargs):
         """
         Test helper that simulates a sync operation failing once with a ValidationError and succeeding thereafter.
-        
+
         On each invocation this increments the enclosing `call_count[0]` counter. The first call raises a
         jsonschema.exceptions.ValidationError to simulate an invite-safe filtering error; subsequent calls
         return a simple success sentinel.
-        
+
         Raises:
             jsonschema.exceptions.ValidationError: on the first invocation.
-        
+
         Returns:
             SimpleNamespace: A success sentinel object on invocations after the first.
         """
@@ -3661,9 +3661,9 @@ async def test_connect_matrix_sync_validation_error_retries_with_invite_safe_fil
     def fake_async_client(*_args, **_kwargs):
         """
         Return the preconfigured mock Matrix client, ignoring all positional and keyword arguments.
-        
+
         This helper supplies the shared mock client instance for tests that expect an async client factory.
-        
+
         Returns:
             mock_client: The mock Matrix client instance used by the test suite.
         """
@@ -3732,7 +3732,7 @@ async def test_connect_matrix_sync_validation_error_retry_failure_closes_client(
     async def mock_sync(*_args, **_kwargs):
         """
         Simulate a sync operation that increments a shared call counter and fails with controlled exceptions.
-        
+
         Increments call_count["count"] each invocation. On the first invocation raises jsonschema.exceptions.ValidationError with message "Invalid schema"; on every subsequent invocation raises RuntimeError("retry failed"). Positional and keyword arguments are ignored.
         """
         call_count["count"] += 1
@@ -3749,9 +3749,9 @@ async def test_connect_matrix_sync_validation_error_retry_failure_closes_client(
     def fake_async_client(*_args, **_kwargs):
         """
         Return the preconfigured mock Matrix client, ignoring all positional and keyword arguments.
-        
+
         This helper supplies the shared mock client instance for tests that expect an async client factory.
-        
+
         Returns:
             mock_client: The mock Matrix client instance used by the test suite.
         """
@@ -3784,7 +3784,7 @@ async def test_connect_matrix_sync_validation_error_retry_failure_closes_client(
 async def test_connect_matrix_uploads_keys_when_needed(monkeypatch):
     """
     Verify that the Matrix client uploads keys when the client's key-upload flag is enabled.
-    
+
     Asserts that connect_matrix returns the created client and that the client's `keys_upload` coroutine is awaited exactly once when `should_upload_keys` is truthy.
     """
     mock_client = MagicMock()
@@ -3966,10 +3966,10 @@ async def test_connect_matrix_explicit_credentials_path_is_used():
     def fake_isfile(path):
         """
         Check whether the provided path matches the predefined expanded_path from the enclosing scope.
-        
+
         Parameters:
             path (str): File path to check.
-        
+
         Returns:
             bool: `true` if `path` is equal to the captured `expanded_path`, `false` otherwise.
         """
@@ -4011,7 +4011,7 @@ async def test_connect_matrix_explicit_credentials_path_is_used():
         client = await connect_matrix(config)
 
     assert client is mock_client
-    mock_expand.assert_called_once_with("~/explicit_credentials.json")
+    mock_expand.assert_any_call("~/explicit_credentials.json")
     mock_client.restore_login.assert_called_once_with(
         user_id="@bot:example.org",
         device_id="DEVICE123",

--- a/tests/test_matrix_utils_auth.py
+++ b/tests/test_matrix_utils_auth.py
@@ -335,6 +335,7 @@ async def test_connect_matrix_alias_resolution_failure(
 @patch("mmrelay.matrix_utils.os.makedirs")
 @patch("mmrelay.matrix_utils.os.listdir")
 @patch("mmrelay.matrix_utils.os.path.exists")
+@patch("mmrelay.matrix_utils.os.path.isfile")
 @patch("builtins.open")
 @patch("mmrelay.matrix_utils.json.load")
 @patch("mmrelay.matrix_utils._create_ssl_context")
@@ -348,11 +349,13 @@ async def test_connect_matrix_with_e2ee_credentials(
     mock_json_load,
     mock_open,
     mock_exists,
+    mock_isfile,
     mock_listdir,
     mock_makedirs,
 ):
     """Test Matrix connection with E2EE credentials."""
     mock_exists.return_value = True
+    mock_isfile.return_value = True
     mock_json_load.return_value = {
         "homeserver": "https://matrix.example.org",
         "user_id": "@bot:example.org",

--- a/tests/test_matrix_utils_auth.py
+++ b/tests/test_matrix_utils_auth.py
@@ -1031,7 +1031,7 @@ def test_get_e2ee_store_dir(mock_makedirs):
 @patch("mmrelay.config.get_base_dir")
 @patch("os.path.exists")
 @patch("builtins.open")
-@patch("json.load")
+@patch("mmrelay.config.json.load")
 def test_load_credentials_success(
     mock_json_load, mock_open, mock_exists, mock_get_base_dir
 ):
@@ -1068,7 +1068,7 @@ def test_load_credentials_file_not_exists(mock_exists, mock_get_base_dir):
 
 @patch("mmrelay.config.get_base_dir")
 @patch("builtins.open")
-@patch("json.dump")
+@patch("mmrelay.config.json.dump")
 @patch("os.makedirs")  # Mock the directory creation
 @patch("os.path.exists", return_value=True)  # Mock file existence check
 def test_save_credentials(

--- a/tests/test_matrix_utils_auth.py
+++ b/tests/test_matrix_utils_auth.py
@@ -351,7 +351,7 @@ async def test_connect_matrix_with_e2ee_credentials(
     mock_exists,
     mock_isfile,
     mock_listdir,
-    mock_makedirs,
+    _mock_makedirs,
 ):
     """Test Matrix connection with E2EE credentials."""
     mock_exists.return_value = True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves Matrix credentials discovery and persistence and makes the Matrix sync loop more resilient. It broadens where credentials are located and how they are saved, makes malformed/invalid credential files non-fatal (logged and skipped), forwards sync filters into the sync loop (including a distinct first-sync filter), and retries an initial sync that fails JSON Schema validation using an invite-safe filter. Logging and tests were expanded to exercise these behaviors and edge cases.

## Key Changes

Features
- Multi-source credential discovery: connect_matrix now searches multiple candidate locations (explicit credentials_path, MMRELAY_CREDENTIALS_PATH, relay_config["credentials_path"], relay_config["matrix"]["credentials_path"] when matrix is a dict, credentials.json in the config-derived directory, and credentials.json in the base dir) and records the first valid credentials file found.
- Sync filter support: forwards mmrelay_sync_filter (sync_filter) and mmrelay_first_sync_filter (first_sync_filter) to matrix_client.sync_forever so initial and ongoing syncs can use different filters.
- Invite-safe initial-sync retry: if initial sync fails with a jsonschema.ValidationError for invite state, the code retries initial sync using an invite-safe filter that excludes invites and logs guidance.

Fixes & Improvements
- save_credentials signature extended: save_credentials(credentials: dict[str, Any], credentials_path: str | None = None) — callers may now pass an explicit path; resolution also respects MMRELAY_CREDENTIALS_PATH and config sources when credentials_path is omitted.
- Robust credentials path handling: expands ~, treats trailing path separators as directories (appends credentials.json), normalizes Windows altsep, prefers existing resolved paths, and falls back to config-derived directory or get_base_dir() when needed.
- Resilient invalid-credentials handling: malformed matrix config (non-dict) or invalid/malformed credentials files are logged and skipped instead of causing AttributeError or crashing; connect_matrix and save_credentials log invalid-credentials cases and accept credentials_path overrides.
- Narrowed sync exception handling and improved cleanup: sync-related exception catching was narrowed to jsonschema and nio-specific exceptions; client cleanup extracted to a helper and ensured on retry/failure; final retry temporarily patches SyncResponse._get_invite_state to tolerate invalid invite_state payloads and removes the patch after use.
- Expanded logging and observability around credential loading/persistence, sync retries, E2EE store paths, and alias resolution.

Refactors & Tests
- Consolidated credential-path resolution logic and extended save_credentials resolution to consider environment variable and config sources.
- Tests updated/added to cover:
  - Credentials path behavior (trailing separators, Windows altsep, directory vs file).
  - Environment variable vs config priority for credentials path.
  - Explicit credentials_path expansion and restore_login usage when device_id is discovered.
  - Invite-safe retry behavior on jsonschema.ValidationError and failure cleanup that raises ConnectionError.
  - Sync error handling (SyncError, NioLocalTransportError) and close-failure scenarios.
  - Adjusted mocks to patch os.path.isfile, mmrelay.config.json.load/dump, and to use real-like SyncError instances for reliable branches.
- Autogenerated docstrings added across modules and tests.

Breaking Changes / Migration Notes
- save_credentials now accepts an optional credentials_path parameter (defaults to None). This is backward compatible; callers that need a specific save location can pass credentials_path explicitly. No other public API breaking changes identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->