### PR TITLE
Add automatic room join-on-invite functionality

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,13 +17,14 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - pyright@1.1.408
     - dotenv-linter@4.0.0
     - hadolint@2.14.0
     - taplo@0.10.0
     - actionlint@1.7.10
     - bandit@1.9.3
     - black@26.1.0
-    - checkov@3.2.497
+    - checkov@3.2.499
     - git-diff-check
     - isort@7.0.0
     - markdownlint@0.47.0

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -10,7 +10,7 @@ import os
 import platform
 import re
 import shutil
-import subprocess
+import subprocess  # nosec B404 - subprocess used for kubectl/oc work in user-invoked CLI flows
 import sys
 import tempfile
 from collections.abc import Mapping
@@ -1818,7 +1818,7 @@ def handle_k8s_command(args: argparse.Namespace) -> int:
                         "yaml",
                     ]
                     try:
-                        create_result = subprocess.run(
+                        create_result = subprocess.run(  # nosec B603 - command constructed from trusted CLI/config inputs
                             create_cmd,
                             capture_output=True,
                             text=True,
@@ -1834,7 +1834,7 @@ def handle_k8s_command(args: argparse.Namespace) -> int:
                             print(create_result.stderr.strip())
                             create_secret_now = False
                         else:
-                            apply_result = subprocess.run(
+                            apply_result = subprocess.run(  # nosec B603 - command constructed from trusted CLI/config inputs
                                 [kubectl, "apply", "-f", "-"],
                                 input=create_result.stdout,
                                 capture_output=True,
@@ -1888,7 +1888,7 @@ def handle_k8s_command(args: argparse.Namespace) -> int:
                                 "-o",
                                 "yaml",
                             ]
-                            create_result = subprocess.run(
+                            create_result = subprocess.run(  # nosec B603 - command constructed from trusted CLI/config inputs
                                 create_cmd,
                                 capture_output=True,
                                 text=True,
@@ -1900,7 +1900,7 @@ def handle_k8s_command(args: argparse.Namespace) -> int:
                                 print(create_result.stderr.strip())
                                 create_secret_now = False
                             else:
-                                apply_result = subprocess.run(
+                                apply_result = subprocess.run(  # nosec B603 - command constructed from trusted CLI/config inputs
                                     [kubectl, "apply", "-f", "-"],
                                     input=create_result.stdout,
                                     capture_output=True,

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -422,14 +422,22 @@ def _handle_matrix_error(
         exception, "status_code"
     ):
         if (
-            hasattr(exception, "errcode") and exception.errcode == "M_FORBIDDEN"  # type: ignore[attr-defined]
-        ) or exception.status_code == 401:  # type: ignore[attr-defined]
+            hasattr(exception, "errcode")
+            and exception.errcode
+            == "M_FORBIDDEN"  # pyright: ignore[reportAttributeAccessIssue]
+        ) or exception.status_code == 401:  # pyright: ignore[reportAttributeAccessIssue]
             error_category = "credentials"
-        elif exception.status_code in [500, 502, 503]:  # type: ignore[attr-defined]
+        elif exception.status_code in [
+            500,
+            502,
+            503,
+        ]:  # pyright: ignore[reportAttributeAccessIssue]
             error_category = "server"
         else:
             error_category = "other"
-            error_detail = str(exception.status_code)  # type: ignore[attr-defined]
+            error_detail = str(
+                exception.status_code
+            )  # pyright: ignore[reportAttributeAccessIssue]
     # Handle network/transport exceptions
     elif isinstance(
         exception,
@@ -573,7 +581,9 @@ async def logout_matrix_bot(password: str) -> bool:
             ssl_context = _create_ssl_context()
 
             # Create a temporary client to fetch user_id
-            temp_client = AsyncClient(homeserver, ssl=ssl_context)  # type: ignore[arg-type]
+            temp_client = AsyncClient(
+                homeserver, ssl=ssl_context
+            )  # pyright: ignore[reportArgumentType]
             temp_client.access_token = access_token
 
             # Fetch user_id using whoami
@@ -583,7 +593,9 @@ async def logout_matrix_bot(password: str) -> bool:
             )
 
             if hasattr(whoami_response, "user_id"):
-                user_id = whoami_response.user_id  # type: ignore[assignment]
+                user_id = (
+                    whoami_response.user_id
+                )  # pyright: ignore[reportAttributeAccessIssue]
                 logger.info(f"Successfully fetched user_id: {user_id}")
                 print(f"✅ Successfully fetched user_id: {user_id}")
 

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -630,8 +630,13 @@ def save_credentials(
             credentials_path = os.path.expanduser(credentials_path)
             path_is_dir = os.path.isdir(credentials_path)
             if not path_is_dir:
-                path_is_dir = credentials_path.endswith(os.path.sep) or (
-                    os.path.altsep and credentials_path.endswith(os.path.altsep)
+                path_is_dir = bool(
+                    credentials_path.endswith(
+                        os.path.sep
+                    )  # pyright: ignore[reportArgumentType]
+                    or (
+                        os.path.altsep and credentials_path.endswith(os.path.altsep)
+                    )  # pyright: ignore[reportArgumentType]
                 )
             if path_is_dir:
                 credentials_path = os.path.join(

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -605,14 +605,14 @@ def save_credentials(
 ) -> None:
     """
     Persist a JSON-serializable credentials mapping to a credentials.json file.
-    
+
     If `credentials_path` is provided it is used as the target file or directory; if it refers to a directory (or ends with a path separator) "credentials.json" is appended. If `credentials_path` is not provided the path is resolved in order from: the `MMRELAY_CREDENTIALS_PATH` environment variable, `relay_config["credentials_path"]`, and `relay_config["matrix"]["credentials_path"]` (when `matrix` is a dict). The function creates the target directory if missing and, on Unix-like systems, attempts to set restrictive file permissions (0o600). I/O and permission errors are caught and logged; they are not raised.
-    
+
     Parameters:
         credentials (dict): JSON-serializable mapping of credentials to persist.
         credentials_path (str | None): Optional path or directory override for where to save credentials.json.
             If omitted, the path is resolved from environment/config defaults.
-    
+
     Returns:
         None
     """

--- a/src/mmrelay/k8s_utils.py
+++ b/src/mmrelay/k8s_utils.py
@@ -28,7 +28,14 @@ _SERIAL_CONTAINER_DEVICE_PATH = "/dev/ttyUSB0"
 
 
 def _get_storage_classes_from_kubectl() -> list[tuple[str, bool]] | None:
-    """Return storage class names and default flags using kubectl, if available."""
+    """
+    Discover Kubernetes StorageClass names and whether each is marked as the default using the system's kubectl tool.
+    
+    Returns:
+        classes (list[tuple[str, bool]] | None): A list of tuples (storage_class_name, is_default) where
+            `is_default` is `True` if the StorageClass is annotated as the default. Returns `None` if
+            `kubectl` is not available, execution fails, or the output cannot be parsed.
+    """
     kubectl = shutil.which("kubectl")
     if not kubectl:
         logger.debug("kubectl not found; skipping storage class discovery")
@@ -80,7 +87,12 @@ def _get_storage_classes_from_kubectl() -> list[tuple[str, bool]] | None:
 
 
 def _get_current_namespace_from_kubectl() -> str | None:
-    """Return the current namespace from kubectl context, if available."""
+    """
+    Determine the current Kubernetes namespace from the user's kubectl context.
+    
+    Returns:
+        The namespace string from the current kubectl context, or `None` if kubectl is not available, the command fails, the context has no namespace, or the output cannot be parsed.
+    """
     kubectl = shutil.which("kubectl")
     if not kubectl:
         logger.debug("kubectl not found; skipping namespace discovery")

--- a/src/mmrelay/k8s_utils.py
+++ b/src/mmrelay/k8s_utils.py
@@ -30,7 +30,7 @@ _SERIAL_CONTAINER_DEVICE_PATH = "/dev/ttyUSB0"
 def _get_storage_classes_from_kubectl() -> list[tuple[str, bool]] | None:
     """
     Discover Kubernetes StorageClass names and whether each is marked as the default using the system's kubectl tool.
-    
+
     Returns:
         classes (list[tuple[str, bool]] | None): A list of tuples (storage_class_name, is_default) where
             `is_default` is `True` if the StorageClass is annotated as the default. Returns `None` if
@@ -89,7 +89,7 @@ def _get_storage_classes_from_kubectl() -> list[tuple[str, bool]] | None:
 def _get_current_namespace_from_kubectl() -> str | None:
     """
     Determine the current Kubernetes namespace from the user's kubectl context.
-    
+
     Returns:
         The namespace string from the current kubectl context, or `None` if kubectl is not available, the command fails, the context has no namespace, or the output cannot be parsed.
     """

--- a/src/mmrelay/k8s_utils.py
+++ b/src/mmrelay/k8s_utils.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 import shutil
-import subprocess
+import subprocess  # nosec B404 - subprocess used for optional kubectl queries
 import tempfile
 from typing import Any
 
@@ -34,7 +34,7 @@ def _get_storage_classes_from_kubectl() -> list[tuple[str, bool]] | None:
         logger.debug("kubectl not found; skipping storage class discovery")
         return None
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - kubectl path resolved from system, fixed args
             [kubectl, "get", "storageclass", "-o", "json"],
             capture_output=True,
             text=True,
@@ -86,7 +86,7 @@ def _get_current_namespace_from_kubectl() -> str | None:
         logger.debug("kubectl not found; skipping namespace discovery")
         return None
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 - kubectl path resolved from system, fixed args
             [kubectl, "config", "view", "--minify", "-o", "json"],
             capture_output=True,
             text=True,

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -206,15 +206,15 @@ def _configure_logger(
     logger: logging.Logger, *, args: argparse.Namespace | None = None
 ) -> logging.Logger:
     """
-    Configure and attach console and optional rotating file handlers to a logger based on application configuration and optional CLI arguments.
-
-    Reapplies the current logging settings (level, formatters, handlers) when the configuration generation has changed, disables propagation on the logger, and updates the global `log_file_path` when the main application logger is configured for file logging.
-
+    Configure a logger's level and attach console and optional rotating file handlers based on the application's configuration and optional CLI arguments.
+    
+    Updates internal generation tracking for the logger and, when configuring the main application logger, updates the module-level log file path.
+    
     Parameters:
-        args: Optional CLI arguments that can override or force file logging and influence logfile path resolution.
-
+        args (argparse.Namespace | None): Optional CLI arguments that can force or override file logging and influence the resolved logfile path.
+    
     Returns:
-        The same `logging.Logger` instance after applying the configuration.
+        logging.Logger: The same logger instance after applying the configuration.
     """
     global log_file_path
 

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -207,12 +207,12 @@ def _configure_logger(
 ) -> logging.Logger:
     """
     Configure a logger's level and attach console and optional rotating file handlers based on the application's configuration and optional CLI arguments.
-    
+
     Updates internal generation tracking for the logger and, when configuring the main application logger, updates the module-level log file path.
-    
+
     Parameters:
         args (argparse.Namespace | None): Optional CLI arguments that can force or override file logging and influence the resolved logfile path.
-    
+
     Returns:
         logging.Logger: The same logger instance after applying the configuration.
     """

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -14,12 +14,15 @@ try:
 
     if not is_running_as_service():
         from rich.console import Console
+        from rich.logging import RichHandler
 
         RICH_AVAILABLE = True
     else:
         RICH_AVAILABLE = False
+        RichHandler = None  # type: ignore[assignment]
 except ImportError:
     RICH_AVAILABLE = False
+    RichHandler = None  # type: ignore[assignment]
 
 # Import parse_arguments only when needed to avoid conflicts with pytest
 from mmrelay.config import get_log_dir
@@ -256,12 +259,10 @@ def _configure_logger(
 
     # Add handler for console logging (with or without colors), unless in CLI mode.
     if not _cli_mode:
-        if color_enabled and RICH_AVAILABLE:
+        if color_enabled and RICH_AVAILABLE and RichHandler is not None:
             # Use Rich handler with colors
-            from rich.logging import RichHandler as _RichHandler
-
             console_handler: logging.Handler = (
-                _RichHandler(  # pyright: ignore[reportPossiblyUnboundVariable]
+                RichHandler(  # pyright: ignore[reportPossiblyUnboundVariable]
                     rich_tracebacks=rich_tracebacks_enabled,
                     console=console,  # pyright: ignore[reportArgumentType]
                     show_time=True,

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -35,7 +35,7 @@ from mmrelay.db_utils import (
     wipe_message_map,
 )
 from mmrelay.log_utils import get_logger
-from mmrelay.matrix_utils import InviteMemberEvent  # type: ignore[import-untyped]
+from mmrelay.matrix_utils import InviteMemberEvent  # type: ignore[attr-defined]
 from mmrelay.matrix_utils import (
     connect_matrix,
     join_matrix_room,

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -81,15 +81,15 @@ def print_banner() -> None:
 async def main(config: dict[str, Any]) -> None:
     """
     Run the relay: initialize core services, connect to Meshtastic and Matrix, run the Matrix sync loop with health-monitoring and retry behavior, and perform an orderly shutdown.
-    
+
     Initializes the database and plugins, starts the message queue and Meshtastic connection, connects and joins configured Matrix rooms, registers Matrix event handlers (including invite and member events), monitors connection health, and coordinates a graceful shutdown sequence (optionally wiping the message map on startup and shutdown).
-    
+
     Parameters:
         config (dict[str, Any]): Application configuration. Relevant keys:
             - "matrix_rooms": list of room dicts containing at least an "id" key.
             - "meshtastic": optional dict; may include "message_delay" to control outbound pacing.
             - "database" (preferred) or legacy "db": optional dict containing "msg_map" with a boolean "wipe_on_restart" that, when true, causes the message map to be wiped at startup and shutdown. Using the legacy "db.msg_map" triggers a deprecation warning.
-    
+
     Raises:
         ConnectionError: If a Matrix client cannot be established and operation cannot continue.
     """

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -22,6 +22,14 @@ from nio import (  # type: ignore[import-untyped]
 )
 from nio.events.room_events import RoomMemberEvent  # type: ignore[import-untyped]
 
+# Import InviteMemberEvent separately to avoid submodule import issues
+try:
+    from nio import InviteMemberEvent  # type: ignore[import-untyped]
+except ImportError:
+    from nio.events.invite_events import (
+        InviteMemberEvent,  # type: ignore[import-untyped]
+    )
+
 # Import version from package
 # Import meshtastic_utils as a module to set event_loop
 from mmrelay import __version__, meshtastic_utils
@@ -42,6 +50,7 @@ from mmrelay.matrix_utils import (
 from mmrelay.matrix_utils import logger as matrix_logger
 from mmrelay.matrix_utils import (
     on_decryption_failure,
+    on_invite,
     on_room_member,
     on_room_message,
 )
@@ -168,6 +177,10 @@ async def main(config: dict[str, Any]) -> None:
     # Add RoomMemberEvent callback to track room-specific display name changes
     matrix_client.add_event_callback(
         cast(Any, on_room_member), cast(Any, (RoomMemberEvent,))
+    )
+    # Add InviteMemberEvent callback to automatically join mapped rooms on invite
+    matrix_client.add_event_callback(
+        cast(Any, on_invite), cast(Any, (InviteMemberEvent,))
     )
 
     # Set up shutdown event

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -22,14 +22,6 @@ from nio import (  # type: ignore[import-untyped]
 )
 from nio.events.room_events import RoomMemberEvent  # type: ignore[import-untyped]
 
-# Import InviteMemberEvent separately to avoid submodule import issues
-try:
-    from nio import InviteMemberEvent  # type: ignore[import-untyped]
-except ImportError:
-    from nio.events.invite_events import (
-        InviteMemberEvent,  # type: ignore[import-untyped]
-    )
-
 # Import version from package
 # Import meshtastic_utils as a module to set event_loop
 from mmrelay import __version__, meshtastic_utils
@@ -43,6 +35,7 @@ from mmrelay.db_utils import (
     wipe_message_map,
 )
 from mmrelay.log_utils import get_logger
+from mmrelay.matrix_utils import InviteMemberEvent  # type: ignore[import-untyped]
 from mmrelay.matrix_utils import (
     connect_matrix,
     join_matrix_room,

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -80,18 +80,18 @@ def print_banner() -> None:
 
 async def main(config: dict[str, Any]) -> None:
     """
-    Coordinate startup, runtime, and orderly shutdown of the relay between Meshtastic and Matrix.
-
-    Initializes database and plugins, starts the message queue and Meshtastic connection, connects and joins configured Matrix rooms, registers Matrix event handlers, runs the Matrix sync loop with retry and health-monitoring logic, and performs a coordinated shutdown (optionally wiping the message map on start and stop).
-
+    Run the relay: initialize core services, connect to Meshtastic and Matrix, run the Matrix sync loop with health-monitoring and retry behavior, and perform an orderly shutdown.
+    
+    Initializes the database and plugins, starts the message queue and Meshtastic connection, connects and joins configured Matrix rooms, registers Matrix event handlers (including invite and member events), monitors connection health, and coordinates a graceful shutdown sequence (optionally wiping the message map on startup and shutdown).
+    
     Parameters:
         config (dict[str, Any]): Application configuration. Relevant keys:
-            - "matrix_rooms": list of room dictionaries, each containing at least an "id" key.
-            - "meshtastic": optional dict; may include "message_delay" to configure outbound pacing.
-            - "database" (preferred) or legacy "db": optional dict containing "msg_map" with a "wipe_on_restart" boolean to control wiping the message map at startup and shutdown.
-
+            - "matrix_rooms": list of room dicts containing at least an "id" key.
+            - "meshtastic": optional dict; may include "message_delay" to control outbound pacing.
+            - "database" (preferred) or legacy "db": optional dict containing "msg_map" with a boolean "wipe_on_restart" that, when true, causes the message map to be wiped at startup and shutdown. Using the legacy "db.msg_map" triggers a deprecation warning.
+    
     Raises:
-        ConnectionError: If a Matrix client cannot be obtained and operation cannot continue.
+        ConnectionError: If a Matrix client cannot be established and operation cannot continue.
     """
     # Extract Matrix configuration
     matrix_rooms: list[dict[str, Any]] = config["matrix_rooms"]

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -4037,6 +4037,10 @@ async def on_invite(room: MatrixRoom, event: InviteMemberEvent) -> None:
     """
     global bot_user_id, matrix_rooms, matrix_client
 
+    if not bot_user_id:
+        logger.warning("bot_user_id is not set, cannot process invites.")
+        return
+
     # Only process invites directed at the bot
     if event.state_key != bot_user_id:
         logger.debug(
@@ -4072,11 +4076,7 @@ async def on_invite(room: MatrixRoom, event: InviteMemberEvent) -> None:
             if joined_room_id:
                 logger.info(f"Successfully joined room '{joined_room_id}'")
             else:
-                error_details = (
-                    getattr(response, "message", response)
-                    if response
-                    else "No response from server"
-                )
+                error_details = _get_detailed_matrix_error_message(response)
                 logger.error(f"Failed to join room '{room_id}': {error_details}")
         else:
             logger.debug(f"Bot is already in room '{room_id}', no action needed")

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -27,7 +27,7 @@ from typing import (
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
-    from jsonschema.exceptions import ValidationError
+    pass
 
 # matrix-nio is not marked py.typed in our environment, so mypy treats it as untyped.
 from nio import (  # type: ignore[import-untyped]
@@ -1741,12 +1741,8 @@ async def connect_matrix(
                 ),
                 timeout=MATRIX_SYNC_OPERATION_TIMEOUT,
             )
-            matrix_client.mmrelay_sync_filter = (
-                invite_safe_filter  # pyright: ignore[reportAttributeAccessIssue]
-            )
-            matrix_client.mmrelay_first_sync_filter = (
-                invite_safe_filter  # pyright: ignore[reportAttributeAccessIssue]
-            )
+            cast(Any, matrix_client).mmrelay_sync_filter = invite_safe_filter
+            cast(Any, matrix_client).mmrelay_first_sync_filter = invite_safe_filter
             logger.info(
                 "Initial sync completed after invite-safe retry. "
                 "Invite handling is disabled for subsequent syncs."
@@ -1811,12 +1807,8 @@ async def connect_matrix(
 
             try:
                 sync_response = await _sync_ignore_invalid_invites()
-                matrix_client.mmrelay_sync_filter = (
-                    invite_safe_filter  # pyright: ignore[reportAttributeAccessIssue]
-                )
-                matrix_client.mmrelay_first_sync_filter = (
-                    invite_safe_filter  # pyright: ignore[reportAttributeAccessIssue]
-                )
+                cast(Any, matrix_client).mmrelay_sync_filter = invite_safe_filter
+                cast(Any, matrix_client).mmrelay_first_sync_filter = invite_safe_filter
                 logger.info(
                     "Initial sync completed after invite-safe retry "
                     "with invalid invite_state payloads ignored."

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -166,9 +166,7 @@ except ImportError:  # pragma: no cover - jsonschema is expected in runtime
 if jsonschema is not None:
     from jsonschema.exceptions import ValidationError as _ValidationError
 
-    JSONSCHEMA_VALIDATION_ERROR: Type[ValidationError] | Type[Exception] = (
-        _ValidationError
-    )
+    JSONSCHEMA_VALIDATION_ERROR: Type[BaseException] = _ValidationError
 else:
 
     class _JsonSchemaValidationError(Exception):

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -236,11 +236,11 @@ def _extract_localpart_from_mxid(mxid: str | None) -> str | None:
 def _is_room_mapped(mapping: Any, room_id_or_alias: str) -> bool:
     """
     Determine whether a room ID or alias exists in a matrix_rooms configuration.
-    
+
     Parameters:
         mapping (list|dict): The matrix_rooms configuration (accepted as a list or dict form).
         room_id_or_alias (str): Room ID (e.g., "!abc:server") or room alias (e.g., "#room:server").
-    
+
     Returns:
         bool: `True` if the room ID or alias is present in the mapping, `False` otherwise.
     """
@@ -1252,15 +1252,15 @@ async def connect_matrix(
 ) -> AsyncClient | None:
     """
     Initialize and configure a Matrix AsyncClient using available credentials and configuration.
-    
+
     Attempts to authenticate (via credentials.json, automatic login, or config), enable end-to-end encryption when configured, perform an initial sync to populate room state, and return a ready-to-use AsyncClient.
-    
+
     Parameters:
         passed_config (dict[str, Any] | None): Optional configuration override for this connection attempt; when provided it is used instead of the module-level config for this call.
-    
+
     Returns:
         AsyncClient | None: A configured and initialized Matrix AsyncClient on success, or `None` if connection or credential setup failed.
-    
+
     Raises:
         ValueError: If the required top-level "matrix_rooms" configuration is missing.
         ConnectionError: If the initial Matrix sync fails or times out.
@@ -1761,12 +1761,12 @@ async def connect_matrix(
             async def _sync_ignore_invalid_invites() -> Any:
                 """
                 Perform a Matrix sync using an invite-safe filter while ignoring invalid invite_state payloads.
-                
+
                 Temporarily patches nio.responses.SyncResponse._get_invite_state so that malformed or schema-invalid
                 invite_state payloads are treated as empty (no invite events), invokes matrix_client.sync with the
                 invite-safe filter and configured timeouts, and restores the original _get_invite_state descriptor
                 before returning.
-                
+
                 Returns:
                     The SyncResponse object returned by the matrix client's sync call.
                 """
@@ -1782,14 +1782,14 @@ async def connect_matrix(
                 def _safe_get_invite_state(invite_state_dict: Any) -> list[Any]:
                     """
                     Safely extract a list of invite-state events from a raw invite_state mapping.
-                    
+
                     Attempts to parse `invite_state_dict["events"]` via an internal callable and returns the resulting list.
                     If `invite_state_dict` is not a dict, lacks an "events" key, or the parsing raises a JSON schema validation error,
                     an empty list is returned.
-                    
+
                     Parameters:
                         invite_state_dict (Any): Raw invite state payload (typically from a Matrix invite event).
-                    
+
                     Returns:
                         list[Any]: Parsed list of invite-state events, or an empty list on invalid/missing input or validation failure.
                     """
@@ -4028,9 +4028,9 @@ async def on_room_member(room: MatrixRoom, event: RoomMemberEvent) -> None:
 async def on_invite(room: MatrixRoom, event: InviteMemberEvent) -> None:
     """
     Handle an invite targeted at the bot and join the room when it is configured in matrix_rooms.
-    
+
     Attempts to join the invited room via the global matrix_client when all of the following are true: the event's state_key matches the bot's user id, the membership is "invite", and the room is present in the matrix_rooms configuration. Logs outcomes and failures; performs no return value.
-    
+
     Parameters:
         room (MatrixRoom): The Matrix room associated with the invite.
         event (InviteMemberEvent): The invite event containing membership and state_key information.

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -235,14 +235,14 @@ def _extract_localpart_from_mxid(mxid: str | None) -> str | None:
 
 def _is_room_mapped(mapping: Any, room_id_or_alias: str) -> bool:
     """
-    Check if a room ID or alias is present in the matrix_rooms configuration.
-
+    Determine whether a room ID or alias exists in a matrix_rooms configuration.
+    
     Parameters:
-        mapping (list|dict): The matrix_rooms configuration from config.yaml.
-        room_id_or_alias (str): Room ID (e.g., "!abc:server") or alias (e.g., "#room:server").
-
+        mapping (list|dict): The matrix_rooms configuration (accepted as a list or dict form).
+        room_id_or_alias (str): Room ID (e.g., "!abc:server") or room alias (e.g., "#room:server").
+    
     Returns:
-        bool: True if the room ID or alias is found in the mapping, False otherwise.
+        bool: `True` if the room ID or alias is present in the mapping, `False` otherwise.
     """
     if not isinstance(mapping, (list, dict)):
         return False
@@ -1251,14 +1251,16 @@ async def connect_matrix(
     passed_config: dict[str, Any] | None = None,
 ) -> AsyncClient | None:
     """
-    Initialize and return a configured Matrix AsyncClient using available credentials and configuration.
-
+    Initialize and configure a Matrix AsyncClient using available credentials and configuration.
+    
+    Attempts to authenticate (via credentials.json, automatic login, or config), enable end-to-end encryption when configured, perform an initial sync to populate room state, and return a ready-to-use AsyncClient.
+    
     Parameters:
         passed_config (dict[str, Any] | None): Optional configuration override for this connection attempt; when provided it is used instead of the module-level config for this call.
-
+    
     Returns:
-        AsyncClient | None: A configured and initialized Matrix AsyncClient when connection and setup succeed, or `None` if connection or credential setup failed.
-
+        AsyncClient | None: A configured and initialized Matrix AsyncClient on success, or `None` if connection or credential setup failed.
+    
     Raises:
         ValueError: If the required top-level "matrix_rooms" configuration is missing.
         ConnectionError: If the initial Matrix sync fails or times out.
@@ -1757,6 +1759,17 @@ async def connect_matrix(
             )
 
             async def _sync_ignore_invalid_invites() -> Any:
+                """
+                Perform a Matrix sync using an invite-safe filter while ignoring invalid invite_state payloads.
+                
+                Temporarily patches nio.responses.SyncResponse._get_invite_state so that malformed or schema-invalid
+                invite_state payloads are treated as empty (no invite events), invokes matrix_client.sync with the
+                invite-safe filter and configured timeouts, and restores the original _get_invite_state descriptor
+                before returning.
+                
+                Returns:
+                    The SyncResponse object returned by the matrix client's sync call.
+                """
                 import nio.responses as nio_responses  # type: ignore[import-untyped]
 
                 original_descriptor = vars(nio_responses.SyncResponse).get(
@@ -1767,6 +1780,19 @@ async def connect_matrix(
                 )
 
                 def _safe_get_invite_state(invite_state_dict: Any) -> list[Any]:
+                    """
+                    Safely extract a list of invite-state events from a raw invite_state mapping.
+                    
+                    Attempts to parse `invite_state_dict["events"]` via an internal callable and returns the resulting list.
+                    If `invite_state_dict` is not a dict, lacks an "events" key, or the parsing raises a JSON schema validation error,
+                    an empty list is returned.
+                    
+                    Parameters:
+                        invite_state_dict (Any): Raw invite state payload (typically from a Matrix invite event).
+                    
+                    Returns:
+                        list[Any]: Parsed list of invite-state events, or an empty list on invalid/missing input or validation failure.
+                    """
                     if (
                         not isinstance(invite_state_dict, dict)
                         or "events" not in invite_state_dict
@@ -4001,15 +4027,13 @@ async def on_room_member(room: MatrixRoom, event: RoomMemberEvent) -> None:
 
 async def on_invite(room: MatrixRoom, event: InviteMemberEvent) -> None:
     """
-    Handle room invitation events and automatically join mapped rooms.
-
-    Checks if the invitation is for the bot (state_key matches bot_user_id),
-    verifies the room is configured in matrix_rooms, and joins the room
-    if both conditions are met. Logs the outcome for all scenarios.
-
+    Handle an invite targeted at the bot and join the room when it is configured in matrix_rooms.
+    
+    Attempts to join the invited room via the global matrix_client when all of the following are true: the event's state_key matches the bot's user id, the membership is "invite", and the room is present in the matrix_rooms configuration. Logs outcomes and failures; performs no return value.
+    
     Parameters:
-        room (MatrixRoom): The Matrix room for the invite.
-        event (InviteMemberEvent): The invite event containing membership details.
+        room (MatrixRoom): The Matrix room associated with the invite.
+        event (InviteMemberEvent): The invite event containing membership and state_key information.
     """
     global bot_user_id, matrix_rooms, matrix_client
 

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -247,10 +247,10 @@ def _is_room_mapped(mapping: Any, room_id_or_alias: str) -> bool:
     if not isinstance(mapping, (list, dict)):
         return False
 
-    for alias_or_id, _setter in _iter_room_alias_entries(mapping):
-        if alias_or_id == room_id_or_alias:
-            return True
-    return False
+    return any(
+        alias_or_id == room_id_or_alias
+        for alias_or_id, _ in _iter_room_alias_entries(mapping)
+    )
 
 
 def _iter_room_alias_entries(
@@ -4028,15 +4028,12 @@ async def on_invite(room: MatrixRoom, event: InviteMemberEvent) -> None:
     room_id = room.room_id
 
     # Check if room is in matrix_rooms configuration
-    if matrix_rooms and _is_room_mapped(matrix_rooms, room_id):
-        logger.info(
-            f"Room '{room_id}' is in matrix_rooms configuration, accepting invite"
-        )
-    else:
+    if not _is_room_mapped(matrix_rooms, room_id):
         logger.info(
             f"Room '{room_id}' is not in matrix_rooms configuration, ignoring invite"
         )
         return
+    logger.info(f"Room '{room_id}' is in matrix_rooms configuration, accepting invite")
 
     if not matrix_client:
         logger.error("matrix_client is None, cannot join room")

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio import (  # type: ignore[import-untyped]
@@ -66,7 +66,9 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: Command names handled by this plugin (for example, ['help']).
         """
-        return [cast(str, self.plugin_name)]
+        if self.plugin_name is None:
+            return []
+        return [self.plugin_name]
 
     def get_mesh_commands(self) -> list[str]:
         """

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -62,7 +62,7 @@ class Plugin(BasePlugin):
     def get_matrix_commands(self) -> list[str]:
         """
         Return the Matrix command names exposed by this plugin.
-        
+
         Returns:
             list[str]: A list containing the plugin's command name (e.g., ['help']), or an empty list if the plugin has no name.
         """

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -61,10 +61,10 @@ class Plugin(BasePlugin):
 
     def get_matrix_commands(self) -> list[str]:
         """
-        Lists Matrix command names provided by this plugin.
-
+        Return the Matrix command names exposed by this plugin.
+        
         Returns:
-            list[str]: Command names handled by this plugin (for example, ['help']).
+            list[str]: A list containing the plugin's command name (e.g., ['help']), or an empty list if the plugin has no name.
         """
         if self.plugin_name is None:
             return []

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -405,10 +405,10 @@ class Plugin(BasePlugin):
 
     def get_matrix_commands(self) -> list[str]:
         """
-        List the Matrix command names handled by this plugin.
-
+        Return the Matrix command names registered by this plugin.
+        
         Returns:
-            list[str]: A list of command strings that the plugin responds to (typically containing the plugin's name).
+            list[str]: Command names the plugin handles; empty list if the plugin has no configured name.
         """
         if self.plugin_name is None:
             return []
@@ -416,10 +416,10 @@ class Plugin(BasePlugin):
 
     def get_mesh_commands(self) -> list[str]:
         """
-        Return the mesh-specific command names handled by this plugin.
-
+        List mesh-specific command names handled by this plugin.
+        
         Returns:
-            list[str]: Mesh command names handled by the plugin; an empty list if the plugin does not handle any mesh commands.
+            list[str]: Command name strings handled by the plugin; empty list if the plugin does not handle any mesh commands.
         """
         return []
 

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -410,7 +410,9 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: A list of command strings that the plugin responds to (typically containing the plugin's name).
         """
-        return [cast(str, self.plugin_name)]
+        if self.plugin_name is None:
+            return []
+        return [self.plugin_name]
 
     def get_mesh_commands(self) -> list[str]:
         """

--- a/src/mmrelay/plugins/mesh_relay_plugin.py
+++ b/src/mmrelay/plugins/mesh_relay_plugin.py
@@ -100,9 +100,9 @@ class Plugin(BasePlugin):
     def _iter_room_configs(self) -> list[dict[str, Any]]:
         """
         Normalize configured Matrix room entries and return them as a list of dictionaries.
-        
+
         Accepts either a mapping or a list from the global `matrix_rooms` configuration, filters out any non-dictionary entries, and returns an empty list if the global config or `matrix_rooms` is missing or malformed.
-        
+
         Returns:
             A list of room configuration dictionaries.
         """

--- a/src/mmrelay/plugins/mesh_relay_plugin.py
+++ b/src/mmrelay/plugins/mesh_relay_plugin.py
@@ -99,12 +99,12 @@ class Plugin(BasePlugin):
 
     def _iter_room_configs(self) -> list[dict[str, Any]]:
         """
-        Return a normalized list of matrix room configuration dictionaries.
-
-        This reads the global `matrix_rooms` entry from the relay config, accepts either a dict or a list for backward compatibility, filters out any non-dict entries, and returns an empty list if the global config or `matrix_rooms` is absent or malformed.
-
+        Normalize configured Matrix room entries and return them as a list of dictionaries.
+        
+        Accepts either a mapping or a list from the global `matrix_rooms` configuration, filters out any non-dictionary entries, and returns an empty list if the global config or `matrix_rooms` is missing or malformed.
+        
         Returns:
-            list[dict[str, Any]]: A list of room configuration dictionaries suitable for iteration.
+            A list of room configuration dictionaries.
         """
         # matrix_rooms live in the global relay config, not per-plugin config.
         global_config = config

--- a/src/mmrelay/plugins/mesh_relay_plugin.py
+++ b/src/mmrelay/plugins/mesh_relay_plugin.py
@@ -5,7 +5,7 @@ import base64
 import binascii
 import json
 import re
-from typing import Any, cast
+from typing import Any, Iterable, cast
 
 from meshtastic import mesh_pb2  # type: ignore[import-untyped]
 
@@ -112,6 +112,7 @@ class Plugin(BasePlugin):
             return []
 
         matrix_rooms = global_config.get("matrix_rooms", [])
+        iterable_rooms: Iterable[Any] | None = None
         if isinstance(matrix_rooms, dict):
             iterable_rooms = matrix_rooms.values()
         elif isinstance(matrix_rooms, list):

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -178,10 +178,10 @@ class Plugin(BasePlugin):
 
     def get_matrix_commands(self) -> list[str]:
         """
-        Provide the Matrix command names exposed by this plugin.
-
+        List the Matrix command names provided by this plugin.
+        
         Returns:
-            list[str]: A list containing the plugin's Matrix command (the plugin_name).
+            A list containing the plugin's command name, or an empty list if `plugin_name` is None.
         """
         if self.plugin_name is None:
             return []

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -1,6 +1,6 @@
 import asyncio
 import re
-from typing import Any, cast
+from typing import Any
 
 from meshtastic.mesh_interface import BROADCAST_NUM  # type: ignore[import-untyped]
 
@@ -183,7 +183,9 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: A list containing the plugin's Matrix command (the plugin_name).
         """
-        return [cast(str, self.plugin_name)]
+        if self.plugin_name is None:
+            return []
+        return [self.plugin_name]
 
     def get_mesh_commands(self) -> list[str]:
         """
@@ -192,7 +194,9 @@ class Plugin(BasePlugin):
         Returns:
             list[str]: Command names provided by the plugin (typically a single-element list containing the plugin's name).
         """
-        return [cast(str, self.plugin_name)]
+        if self.plugin_name is None:
+            return []
+        return [self.plugin_name]
 
     async def handle_room_message(
         self,

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -179,7 +179,7 @@ class Plugin(BasePlugin):
     def get_matrix_commands(self) -> list[str]:
         """
         List the Matrix command names provided by this plugin.
-        
+
         Returns:
             A list containing the plugin's command name, or an empty list if `plugin_name` is None.
         """

--- a/src/mmrelay/setup_utils.py
+++ b/src/mmrelay/setup_utils.py
@@ -14,6 +14,10 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
 
 from mmrelay.constants.database import PROGRESS_COMPLETE, PROGRESS_TOTAL_STEPS
 from mmrelay.constants.network import SYSTEMCTL_FALLBACK
@@ -130,7 +134,10 @@ def wait_for_service_start() -> None:
 
     from mmrelay.runtime_utils import is_running_as_service
 
-    Progress = SpinnerColumn = TextColumn = TimeElapsedColumn = None
+    Progress: type[Any] | None = None
+    SpinnerColumn: type[Any] | None = None
+    TextColumn: type[Any] | None = None
+    TimeElapsedColumn: type[Any] | None = None
     running_as_service = is_running_as_service()
     if not running_as_service:
         try:
@@ -141,11 +148,15 @@ def wait_for_service_start() -> None:
                 TimeElapsedColumn,
             )
         except ImportError:
-            Progress = SpinnerColumn = TextColumn = TimeElapsedColumn = None
             running_as_service = True
 
     # Create a Rich progress display with spinner and elapsed time
     if not running_as_service and Progress is not None:
+        assert (
+            SpinnerColumn is not None
+            and TextColumn is not None
+            and TimeElapsedColumn is not None
+        )
         with Progress(
             SpinnerColumn(),
             TextColumn("[bold green]Starting mmrelay service..."),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -450,9 +450,9 @@ def reset_plugin_loader_cache():
 def cleanup_asyncmock_objects(request):
     """
     Force garbage collection for tests that commonly create AsyncMock objects to suppress "never awaited" RuntimeWarning messages.
-    
+
     This pytest fixture yields to the test, then inspects the test filename and, for a predefined set of test-name patterns that regularly create AsyncMock objects, performs a garbage-collection pass while suppressing RuntimeWarnings about unawaited coroutines.
-    
+
     Parameters:
         request (pytest.FixtureRequest): The pytest request object used to determine the executing test's filename.
     """
@@ -722,7 +722,7 @@ def reset_matrix_utils_globals():
 def comprehensive_cleanup():
     """
     Perform thorough cleanup of asyncio resources, executors, event loops, and non-daemon threads after a test.
-    
+
     When used as an autouse fixture, yields to the test and on teardown cancels pending asyncio tasks and waits for them to finish, shuts down the loop's default executor if present, closes and clears the event loop, runs garbage collection before and after thread cleanup, and joins remaining non-daemon threads to reduce resource leaks and test flakiness.
     """
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -449,12 +449,12 @@ def reset_plugin_loader_cache():
 @pytest.fixture(autouse=True)
 def cleanup_asyncmock_objects(request):
     """
-    Force garbage collection after tests that commonly create AsyncMock objects to avoid "never awaited" RuntimeWarning messages.
-
-    This fixture yields to run the test, then inspects the requesting test filename; if it matches a known set of test-name patterns that use AsyncMock, it runs gc.collect() inside a warnings suppression context that ignores "never awaited" RuntimeWarning messages raised by lingering coroutine objects.
-
+    Force garbage collection for tests that commonly create AsyncMock objects to suppress "never awaited" RuntimeWarning messages.
+    
+    This pytest fixture yields to the test, then inspects the test filename and, for a predefined set of test-name patterns that regularly create AsyncMock objects, performs a garbage-collection pass while suppressing RuntimeWarnings about unawaited coroutines.
+    
     Parameters:
-        request: The pytest `Request` object for the executing test (used to determine the test filename).
+        request (pytest.FixtureRequest): The pytest request object used to determine the executing test's filename.
     """
     yield
 
@@ -721,16 +721,9 @@ def reset_matrix_utils_globals():
 @pytest.fixture
 def comprehensive_cleanup():
     """
-    Pytest fixture that performs a thorough cleanup of async resources, event loops, executors, and non-daemon threads after a test.
-
-    When used as an autouse fixture, it yields to the test and on teardown:
-    - cancels pending asyncio tasks and waits for their completion,
-    - shuts down the loop's default executor (if any) and closes the event loop,
-    - clears the global event loop reference,
-    - runs garbage collection before and after thread cleanup,
-    - joins any remaining non-daemon threads for a short timeout.
-
-    This prevents resource warnings about unclosed sockets, executors, or event loops and reduces flaky CI failures related to lingering async resources.
+    Perform thorough cleanup of asyncio resources, executors, event loops, and non-daemon threads after a test.
+    
+    When used as an autouse fixture, yields to the test and on teardown cancels pending asyncio tasks and waits for them to finish, shuts down the loop's default executor if present, closes and clears the event loop, runs garbage collection before and after thread cleanup, and joins remaining non-daemon threads to reduce resource leaks and test flakiness.
     """
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -466,6 +466,7 @@ def cleanup_asyncmock_objects(request):
         "test_async_patterns",
         "test_matrix_utils",
         "test_matrix_utils_edge_cases",
+        "test_matrix_utils_invite",
         "test_mesh_relay_plugin",
         "test_map_plugin",
         "test_meshtastic_utils",
@@ -647,8 +648,8 @@ def reset_meshtastic_globals():
     Temporarily reset key module-level state in mmrelay.meshtastic_utils for a test and restore it on teardown.
 
     Saves the original values of attributes such as `config`, `meshtastic_client`, reconnect/shutdown flags and tasks,
-    subscription flags, and internal futures; sets those attributes to clean defaults for the duration of the test,
-    yields control to the test, and restores the saved values on teardown. The module's `logger` and `event_loop`
+    subscription flags, and internal futures; sets those attributes to clean defaults for duration of the test,
+    yields control to test, and restores the saved values on teardown. The module's `logger` and `event_loop`
     are intentionally left unchanged.
     """
     import mmrelay.meshtastic_utils as mu
@@ -684,6 +685,37 @@ def reset_meshtastic_globals():
     # Restore original values (including Nones) to avoid state leakage
     for attr_name, original_value in original_values.items():
         setattr(mu, attr_name, original_value)
+
+
+@pytest.fixture
+def reset_matrix_utils_globals():
+    """
+    Temporarily reset key module-level state in mmrelay.matrix_utils for a test and restore it on teardown.
+
+    Saves the original values of attributes such as `matrix_client`, `matrix_rooms`, and `bot_user_id`;
+    sets those attributes to clean defaults for duration of the test, yields control to test,
+    and restores the saved values on teardown. The module's `logger` and `config`
+    are intentionally left unchanged.
+    """
+    import mmrelay.matrix_utils
+
+    # Store original values (excluding logger and config to keep them functional)
+    original_values = {
+        "matrix_client": getattr(mmrelay.matrix_utils, "matrix_client", None),
+        "matrix_rooms": getattr(mmrelay.matrix_utils, "matrix_rooms", None),
+        "bot_user_id": getattr(mmrelay.matrix_utils, "bot_user_id", None),
+    }
+
+    # Reset mutable globals to a clean state; keep logger and config usable
+    mmrelay.matrix_utils.matrix_client = None
+    mmrelay.matrix_utils.matrix_rooms = None
+    mmrelay.matrix_utils.bot_user_id = None
+
+    yield
+
+    # Restore original values (including Nones) to avoid state leakage
+    for attr_name, original_value in original_values.items():
+        setattr(mmrelay.matrix_utils, attr_name, original_value)
 
 
 @pytest.fixture

--- a/tests/test_matrix_utils_invite.py
+++ b/tests/test_matrix_utils_invite.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+Test suite for Matrix room invitation handling in MMRelay.
+
+Tests automatic room joining on invitation:
+- _is_room_mapped() helper function
+- on_invite() callback function
+- Room filtering and validation
+- Edge cases for various invite scenarios
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.matrix_utils import (
+    _is_room_mapped,
+    on_invite,
+)
+
+
+class TestIsRoomMapped(unittest.TestCase):
+    """Test cases for the _is_room_mapped helper function."""
+
+    def test_is_room_mapped_with_list_format_room_id(self):
+        """
+        Test that _is_room_mapped returns True for a room ID in list format.
+        """
+        mapping = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
+            {"id": "!def456:matrix.org", "meshtastic_channel": 1},
+        ]
+
+        result = _is_room_mapped(mapping, "!abc123:matrix.org")
+        self.assertTrue(result)
+
+    def test_is_room_mapped_with_list_format_alias(self):
+        """
+        Test that _is_room_mapped returns True for a room alias in list format.
+        """
+        mapping = [
+            {"id": "#general:matrix.org", "meshtastic_channel": 0},
+            {"id": "#random:matrix.org", "meshtastic_channel": 1},
+        ]
+
+        result = _is_room_mapped(mapping, "#general:matrix.org")
+        self.assertTrue(result)
+
+    def test_is_room_mapped_with_dict_format_room_id(self):
+        """
+        Test that _is_room_mapped returns True for a room ID in dict format.
+        """
+        mapping = {
+            "general": {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
+            "random": {"id": "!def456:matrix.org", "meshtastic_channel": 1},
+        }
+
+        result = _is_room_mapped(mapping, "!abc123:matrix.org")
+        self.assertTrue(result)
+
+    def test_is_room_mapped_with_dict_format_alias(self):
+        """
+        Test that _is_room_mapped returns True for a room alias in dict format.
+        """
+        mapping = {
+            "general": {"id": "#general:matrix.org", "meshtastic_channel": 0},
+            "random": {"id": "#random:matrix.org", "meshtastic_channel": 1},
+        }
+
+        result = _is_room_mapped(mapping, "#general:matrix.org")
+        self.assertTrue(result)
+
+    def test_is_room_mapped_not_found(self):
+        """
+        Test that _is_room_mapped returns False for unmapped rooms.
+        """
+        mapping = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
+            {"id": "!def456:matrix.org", "meshtastic_channel": 1},
+        ]
+
+        result = _is_room_mapped(mapping, "!xyz789:matrix.org")
+        self.assertFalse(result)
+
+    def test_is_room_mapped_with_empty_mapping(self):
+        """
+        Test that _is_room_mapped returns False for empty mapping.
+        """
+        mapping = []
+        result = _is_room_mapped(mapping, "!abc123:matrix.org")
+        self.assertFalse(result)
+
+    def test_is_room_mapped_with_none_mapping(self):
+        """
+        Test that _is_room_mapped returns False for None mapping.
+        """
+        result = _is_room_mapped(None, "!abc123:matrix.org")
+        self.assertFalse(result)
+
+    def test_is_room_mapped_with_invalid_type(self):
+        """
+        Test that _is_room_mapped returns False for invalid mapping types.
+        """
+        result = _is_room_mapped("invalid", "!abc123:matrix.org")
+        self.assertFalse(result)
+
+        result = _is_room_mapped(123, "!abc123:matrix.org")
+        self.assertFalse(result)
+
+
+class TestOnInvite(unittest.TestCase):
+    """Test cases for the on_invite callback function."""
+
+    def setUp(self):
+        """
+        Resets global state in the mmrelay.matrix_utils module before each test.
+        """
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.matrix_client = None
+        mmrelay.matrix_utils.matrix_rooms = None
+        mmrelay.matrix_utils.bot_user_id = None
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_ignores_non_bot_invites(self, mock_logger):
+        """
+        Test that on_invite ignores invites not directed at the bot.
+        """
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@other:matrix.org"
+        mock_event.membership = "invite"
+        mock_event.sender = "@inviter:matrix.org"
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.debug.assert_any_call(
+            "Ignoring invite for @other:matrix.org (not for bot @bot:matrix.org)"
+        )
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_ignores_non_invite_membership(self, mock_logger):
+        """
+        Test that on_invite ignores non-invite membership events.
+        """
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@bot:matrix.org"
+        mock_event.membership = "join"
+        mock_event.sender = "@inviter:matrix.org"
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.debug.assert_any_call("Ignoring non-invite membership event: join")
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_ignores_unmapped_rooms(self, mock_logger):
+        """
+        Test that on_invite ignores invites to unmapped rooms.
+        """
+        # Removed: invite_events import
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@bot:matrix.org"
+        mock_event.membership = "invite"
+        mock_event.sender = "@inviter:matrix.org"
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!other:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.info.assert_any_call(
+            "Room '!abc123:matrix.org' is not in matrix_rooms configuration, ignoring invite"
+        )
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_joins_mapped_room(self, mock_logger):
+        """
+        Test that on_invite joins rooms that are mapped.
+        """
+        # Removed: invite_events import
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@bot:matrix.org"
+        mock_event.membership = "invite"
+        mock_event.sender = "@inviter:matrix.org"
+
+        mock_client = AsyncMock()
+        mock_client.rooms = {}
+        mock_join_response = MagicMock()
+        mock_join_response.room_id = "!abc123:matrix.org"
+        mock_client.join.return_value = mock_join_response
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.matrix_client = mock_client
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.info.assert_any_call(
+            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+        )
+        mock_logger.info.assert_any_call("Joining mapped room '!abc123:matrix.org'...")
+        mock_logger.info.assert_any_call(
+            "Successfully joined room '!abc123:matrix.org'"
+        )
+        mock_client.join.assert_called_once_with("!abc123:matrix.org")
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_already_in_room(self, mock_logger):
+        """
+        Test that on_invite skips joining if already in the room.
+        """
+        # Removed: invite_events import
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@bot:matrix.org"
+        mock_event.membership = "invite"
+        mock_event.sender = "@inviter:matrix.org"
+
+        mock_client = AsyncMock()
+        mock_client.rooms = {"!abc123:matrix.org": MagicMock()}
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.matrix_client = mock_client
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.info.assert_any_call(
+            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+        )
+        mock_logger.debug.assert_any_call(
+            "Bot is already in room '!abc123:matrix.org', no action needed"
+        )
+        mock_client.join.assert_not_called()
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_handles_join_failure(self, mock_logger):
+        """
+        Test that on_invite handles join failures gracefully.
+        """
+        # Removed: invite_events import
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@bot:matrix.org"
+        mock_event.membership = "invite"
+        mock_event.sender = "@inviter:matrix.org"
+
+        mock_client = AsyncMock()
+        mock_client.rooms = {}
+        mock_error_response = MagicMock()
+        mock_error_response.room_id = None
+        mock_error_response.message = "Forbidden: you are not allowed to join this room"
+        mock_client.join.return_value = mock_error_response
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.matrix_client = mock_client
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.info.assert_any_call(
+            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+        )
+        mock_logger.info.assert_any_call("Joining mapped room '!abc123:matrix.org'...")
+        mock_logger.error.assert_any_call(
+            "Failed to join room '!abc123:matrix.org': Forbidden: you are not allowed to join this room"
+        )
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_handles_no_client(self, mock_logger):
+        """
+        Test that on_invite handles missing matrix_client gracefully.
+        """
+        # Removed: invite_events import
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@bot:matrix.org"
+        mock_event.membership = "invite"
+        mock_event.sender = "@inviter:matrix.org"
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.matrix_client = None
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.error.assert_any_call("matrix_client is None, cannot join room")
+
+    @patch("mmrelay.matrix_utils.logger")
+    def test_on_invite_with_alias_in_mapping(self, mock_logger):
+        """
+        Test that on_invite joins rooms matched by alias in config.
+        """
+        # Removed: invite_events import
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!abc123:matrix.org"
+
+        mock_event = MagicMock()
+        mock_event.state_key = "@bot:matrix.org"
+        mock_event.membership = "invite"
+        mock_event.sender = "@inviter:matrix.org"
+
+        mock_client = AsyncMock()
+        mock_client.rooms = {}
+        mock_join_response = MagicMock()
+        mock_join_response.room_id = "!abc123:matrix.org"
+        mock_client.join.return_value = mock_join_response
+
+        import mmrelay.matrix_utils
+
+        mmrelay.matrix_utils.matrix_client = mock_client
+        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+        mmrelay.matrix_utils.matrix_rooms = [
+            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+        ]
+
+        result = asyncio.run(on_invite(mock_room, mock_event))
+
+        self.assertIsNone(result)
+        mock_logger.info.assert_any_call(
+            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+        )
+        mock_client.join.assert_called_once_with("!abc123:matrix.org")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_matrix_utils_invite.py
+++ b/tests/test_matrix_utils_invite.py
@@ -334,9 +334,9 @@ async def test_on_invite_handles_join_failure(mock_logger: MagicMock) -> None:
 async def test_on_invite_handles_no_client(mock_logger: MagicMock) -> None:
     """
     Verifies that on_invite logs an error and takes no action when the Matrix client is not configured.
-    
+
     Asserts that the function returns None and that an error message indicating the missing client is logged.
-    
+
     Parameters:
         mock_logger (MagicMock): Mocked logger used to assert that the expected error message was emitted.
     """

--- a/tests/test_matrix_utils_invite.py
+++ b/tests/test_matrix_utils_invite.py
@@ -9,14 +9,14 @@ Tests automatic room joining on invitation:
 - Edge cases for various invite scenarios
 """
 
-import asyncio
 import os
 import sys
-import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import pytest
 
 from mmrelay.matrix_utils import (
     _is_room_mapped,
@@ -24,373 +24,371 @@ from mmrelay.matrix_utils import (
 )
 
 
-class TestIsRoomMapped(unittest.TestCase):
-    """Test cases for the _is_room_mapped helper function."""
-
-    def test_is_room_mapped_with_list_format_room_id(self):
-        """
-        Test that _is_room_mapped returns True for a room ID in list format.
-        """
-        mapping = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
-            {"id": "!def456:matrix.org", "meshtastic_channel": 1},
-        ]
-
-        result = _is_room_mapped(mapping, "!abc123:matrix.org")
-        self.assertTrue(result)
-
-    def test_is_room_mapped_with_list_format_alias(self):
-        """
-        Test that _is_room_mapped returns True for a room alias in list format.
-        """
-        mapping = [
-            {"id": "#general:matrix.org", "meshtastic_channel": 0},
-            {"id": "#random:matrix.org", "meshtastic_channel": 1},
-        ]
-
-        result = _is_room_mapped(mapping, "#general:matrix.org")
-        self.assertTrue(result)
-
-    def test_is_room_mapped_with_dict_format_room_id(self):
-        """
-        Test that _is_room_mapped returns True for a room ID in dict format.
-        """
-        mapping = {
-            "general": {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
-            "random": {"id": "!def456:matrix.org", "meshtastic_channel": 1},
-        }
-
-        result = _is_room_mapped(mapping, "!abc123:matrix.org")
-        self.assertTrue(result)
-
-    def test_is_room_mapped_with_dict_format_alias(self):
-        """
-        Test that _is_room_mapped returns True for a room alias in dict format.
-        """
-        mapping = {
-            "general": {"id": "#general:matrix.org", "meshtastic_channel": 0},
-            "random": {"id": "#random:matrix.org", "meshtastic_channel": 1},
-        }
-
-        result = _is_room_mapped(mapping, "#general:matrix.org")
-        self.assertTrue(result)
-
-    def test_is_room_mapped_not_found(self):
-        """
-        Test that _is_room_mapped returns False for unmapped rooms.
-        """
-        mapping = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
-            {"id": "!def456:matrix.org", "meshtastic_channel": 1},
-        ]
-
-        result = _is_room_mapped(mapping, "!xyz789:matrix.org")
-        self.assertFalse(result)
-
-    def test_is_room_mapped_with_empty_mapping(self):
-        """
-        Test that _is_room_mapped returns False for empty mapping.
-        """
-        mapping = []
-        result = _is_room_mapped(mapping, "!abc123:matrix.org")
-        self.assertFalse(result)
-
-    def test_is_room_mapped_with_none_mapping(self):
-        """
-        Test that _is_room_mapped returns False for None mapping.
-        """
-        result = _is_room_mapped(None, "!abc123:matrix.org")
-        self.assertFalse(result)
-
-    def test_is_room_mapped_with_invalid_type(self):
-        """
-        Test that _is_room_mapped returns False for invalid mapping types.
-        """
-        result = _is_room_mapped("invalid", "!abc123:matrix.org")
-        self.assertFalse(result)
-
-        result = _is_room_mapped(123, "!abc123:matrix.org")
-        self.assertFalse(result)
-
-
-class TestOnInvite(unittest.TestCase):
-    """Test cases for the on_invite callback function."""
-
-    def setUp(self):
-        """
-        Resets global state in the mmrelay.matrix_utils module before each test.
-        """
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.matrix_client = None
-        mmrelay.matrix_utils.matrix_rooms = None
-        mmrelay.matrix_utils.bot_user_id = None
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_ignores_non_bot_invites(self, mock_logger):
-        """
-        Test that on_invite ignores invites not directed at the bot.
-        """
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@other:matrix.org"
-        mock_event.membership = "invite"
-        mock_event.sender = "@inviter:matrix.org"
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.debug.assert_any_call(
-            "Ignoring invite for @other:matrix.org (not for bot @bot:matrix.org)"
-        )
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_ignores_non_invite_membership(self, mock_logger):
-        """
-        Test that on_invite ignores non-invite membership events.
-        """
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@bot:matrix.org"
-        mock_event.membership = "join"
-        mock_event.sender = "@inviter:matrix.org"
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.debug.assert_any_call("Ignoring non-invite membership event: join")
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_ignores_unmapped_rooms(self, mock_logger):
-        """
-        Test that on_invite ignores invites to unmapped rooms.
-        """
-        # Removed: invite_events import
-
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@bot:matrix.org"
-        mock_event.membership = "invite"
-        mock_event.sender = "@inviter:matrix.org"
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!other:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.info.assert_any_call(
-            "Room '!abc123:matrix.org' is not in matrix_rooms configuration, ignoring invite"
-        )
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_joins_mapped_room(self, mock_logger):
-        """
-        Test that on_invite joins rooms that are mapped.
-        """
-        # Removed: invite_events import
-
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@bot:matrix.org"
-        mock_event.membership = "invite"
-        mock_event.sender = "@inviter:matrix.org"
-
-        mock_client = AsyncMock()
-        mock_client.rooms = {}
-        mock_join_response = MagicMock()
-        mock_join_response.room_id = "!abc123:matrix.org"
-        mock_client.join.return_value = mock_join_response
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.matrix_client = mock_client
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.info.assert_any_call(
-            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
-        )
-        mock_logger.info.assert_any_call("Joining mapped room '!abc123:matrix.org'...")
-        mock_logger.info.assert_any_call(
-            "Successfully joined room '!abc123:matrix.org'"
-        )
-        mock_client.join.assert_called_once_with("!abc123:matrix.org")
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_already_in_room(self, mock_logger):
-        """
-        Test that on_invite skips joining if already in the room.
-        """
-        # Removed: invite_events import
-
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@bot:matrix.org"
-        mock_event.membership = "invite"
-        mock_event.sender = "@inviter:matrix.org"
-
-        mock_client = AsyncMock()
-        mock_client.rooms = {"!abc123:matrix.org": MagicMock()}
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.matrix_client = mock_client
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.info.assert_any_call(
-            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
-        )
-        mock_logger.debug.assert_any_call(
-            "Bot is already in room '!abc123:matrix.org', no action needed"
-        )
-        mock_client.join.assert_not_called()
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_handles_join_failure(self, mock_logger):
-        """
-        Test that on_invite handles join failures gracefully.
-        """
-        # Removed: invite_events import
-
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@bot:matrix.org"
-        mock_event.membership = "invite"
-        mock_event.sender = "@inviter:matrix.org"
-
-        mock_client = AsyncMock()
-        mock_client.rooms = {}
-        mock_error_response = MagicMock()
-        mock_error_response.room_id = None
-        mock_error_response.message = "Forbidden: you are not allowed to join this room"
-        mock_client.join.return_value = mock_error_response
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.matrix_client = mock_client
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.info.assert_any_call(
-            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
-        )
-        mock_logger.info.assert_any_call("Joining mapped room '!abc123:matrix.org'...")
-        mock_logger.error.assert_any_call(
-            "Failed to join room '!abc123:matrix.org': Forbidden: you are not allowed to join this room"
-        )
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_handles_no_client(self, mock_logger):
-        """
-        Test that on_invite handles missing matrix_client gracefully.
-        """
-        # Removed: invite_events import
-
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@bot:matrix.org"
-        mock_event.membership = "invite"
-        mock_event.sender = "@inviter:matrix.org"
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.matrix_client = None
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.error.assert_any_call("matrix_client is None, cannot join room")
-
-    @patch("mmrelay.matrix_utils.logger")
-    def test_on_invite_with_alias_in_mapping(self, mock_logger):
-        """
-        Test that on_invite joins rooms matched by alias in config.
-        """
-        # Removed: invite_events import
-
-        mock_room = MagicMock()
-        mock_room.room_id = "!abc123:matrix.org"
-
-        mock_event = MagicMock()
-        mock_event.state_key = "@bot:matrix.org"
-        mock_event.membership = "invite"
-        mock_event.sender = "@inviter:matrix.org"
-
-        mock_client = AsyncMock()
-        mock_client.rooms = {}
-        mock_join_response = MagicMock()
-        mock_join_response.room_id = "!abc123:matrix.org"
-        mock_client.join.return_value = mock_join_response
-
-        import mmrelay.matrix_utils
-
-        mmrelay.matrix_utils.matrix_client = mock_client
-        mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
-        mmrelay.matrix_utils.matrix_rooms = [
-            {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
-        ]
-
-        result = asyncio.run(on_invite(mock_room, mock_event))
-
-        self.assertIsNone(result)
-        mock_logger.info.assert_any_call(
-            "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
-        )
-        mock_client.join.assert_called_once_with("!abc123:matrix.org")
-
-
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_with_list_format_room_id() -> None:
+    """
+    Test that _is_room_mapped returns True for a room ID in list format.
+    """
+    mapping = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
+        {"id": "!def456:matrix.org", "meshtastic_channel": 1},
+    ]
+
+    result = _is_room_mapped(mapping, "!abc123:matrix.org")
+    assert result is True
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_with_list_format_alias() -> None:
+    """
+    Test that _is_room_mapped returns True for a room alias in list format.
+    """
+    mapping = [
+        {"id": "#general:matrix.org", "meshtastic_channel": 0},
+        {"id": "#random:matrix.org", "meshtastic_channel": 1},
+    ]
+
+    result = _is_room_mapped(mapping, "#general:matrix.org")
+    assert result is True
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_with_dict_format_room_id() -> None:
+    """
+    Test that _is_room_mapped returns True for a room ID in dict format.
+    """
+    mapping = {
+        "general": {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
+        "random": {"id": "!def456:matrix.org", "meshtastic_channel": 1},
+    }
+
+    result = _is_room_mapped(mapping, "!abc123:matrix.org")
+    assert result is True
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_with_dict_format_alias() -> None:
+    """
+    Test that _is_room_mapped returns True for a room alias in dict format.
+    """
+    mapping = {
+        "general": {"id": "#general:matrix.org", "meshtastic_channel": 0},
+        "random": {"id": "#random:matrix.org", "meshtastic_channel": 1},
+    }
+
+    result = _is_room_mapped(mapping, "#general:matrix.org")
+    assert result is True
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_not_found() -> None:
+    """
+    Test that _is_room_mapped returns False for unmapped rooms.
+    """
+    mapping = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0},
+        {"id": "!def456:matrix.org", "meshtastic_channel": 1},
+    ]
+
+    result = _is_room_mapped(mapping, "!xyz789:matrix.org")
+    assert result is False
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_with_empty_mapping() -> None:
+    """
+    Test that _is_room_mapped returns False for empty mapping.
+    """
+    mapping = []
+    result = _is_room_mapped(mapping, "!abc123:matrix.org")
+    assert result is False
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_with_none_mapping() -> None:
+    """
+    Test that _is_room_mapped returns False for None mapping.
+    """
+    result = _is_room_mapped(None, "!abc123:matrix.org")
+    assert result is False
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+def test_is_room_mapped_with_invalid_type() -> None:
+    """
+    Test that _is_room_mapped returns False for invalid mapping types.
+    """
+    result = _is_room_mapped("invalid", "!abc123:matrix.org")
+    assert result is False
+
+    result = _is_room_mapped(123, "!abc123:matrix.org")
+    assert result is False
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_ignores_non_bot_invites(mock_logger: MagicMock) -> None:
+    """
+    Test that on_invite ignores invites not directed at the bot.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@other:matrix.org"
+    mock_event.membership = "invite"
+    mock_event.sender = "@inviter:matrix.org"
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.debug.assert_any_call(
+        "Ignoring invite for @other:matrix.org (not for bot @bot:matrix.org)"
+    )
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_ignores_non_invite_membership(
+    mock_logger: MagicMock,
+) -> None:
+    """
+    Test that on_invite ignores non-invite membership events.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@bot:matrix.org"
+    mock_event.membership = "join"
+    mock_event.sender = "@inviter:matrix.org"
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.debug.assert_any_call("Ignoring non-invite membership event: join")
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_ignores_unmapped_rooms(mock_logger: MagicMock) -> None:
+    """
+    Test that on_invite ignores invites to unmapped rooms.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@bot:matrix.org"
+    mock_event.membership = "invite"
+    mock_event.sender = "@inviter:matrix.org"
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!other:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.info.assert_any_call(
+        "Room '!abc123:matrix.org' is not in matrix_rooms configuration, ignoring invite"
+    )
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_joins_mapped_room(mock_logger: MagicMock) -> None:
+    """
+    Test that on_invite joins rooms that are mapped.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@bot:matrix.org"
+    mock_event.membership = "invite"
+    mock_event.sender = "@inviter:matrix.org"
+
+    mock_client = AsyncMock()
+    mock_client.rooms = {}
+    mock_join_response = MagicMock()
+    mock_join_response.room_id = "!abc123:matrix.org"
+    mock_client.join.return_value = mock_join_response
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.matrix_client = mock_client
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.info.assert_any_call(
+        "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+    )
+    mock_logger.info.assert_any_call("Joining mapped room '!abc123:matrix.org'...")
+    mock_logger.info.assert_any_call("Successfully joined room '!abc123:matrix.org'")
+    mock_client.join.assert_called_once_with("!abc123:matrix.org")
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_already_in_room(mock_logger: MagicMock) -> None:
+    """
+    Test that on_invite skips joining if already in the room.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@bot:matrix.org"
+    mock_event.membership = "invite"
+    mock_event.sender = "@inviter:matrix.org"
+
+    mock_client = AsyncMock()
+    mock_client.rooms = {"!abc123:matrix.org": MagicMock()}
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.matrix_client = mock_client
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.info.assert_any_call(
+        "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+    )
+    mock_logger.debug.assert_any_call(
+        "Bot is already in room '!abc123:matrix.org', no action needed"
+    )
+    mock_client.join.assert_not_called()
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_handles_join_failure(mock_logger: MagicMock) -> None:
+    """
+    Test that on_invite handles join failures gracefully.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@bot:matrix.org"
+    mock_event.membership = "invite"
+    mock_event.sender = "@inviter:matrix.org"
+
+    mock_client = AsyncMock()
+    mock_client.rooms = {}
+    mock_error_response = MagicMock()
+    mock_error_response.room_id = None
+    mock_error_response.message = "Forbidden: you are not allowed to join this room"
+    mock_client.join.return_value = mock_error_response
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.matrix_client = mock_client
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.info.assert_any_call(
+        "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+    )
+    mock_logger.info.assert_any_call("Joining mapped room '!abc123:matrix.org'...")
+    mock_logger.error.assert_any_call(
+        "Failed to join room '!abc123:matrix.org': Forbidden: you are not allowed to join this room"
+    )
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_handles_no_client(mock_logger: MagicMock) -> None:
+    """
+    Test that on_invite handles missing matrix_client gracefully.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@bot:matrix.org"
+    mock_event.membership = "invite"
+    mock_event.sender = "@inviter:matrix.org"
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.matrix_client = None
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.error.assert_any_call("matrix_client is None, cannot join room")
+
+
+@pytest.mark.usefixtures("reset_matrix_utils_globals")
+@patch("mmrelay.matrix_utils.logger")
+async def test_on_invite_with_id_in_mapping(mock_logger: MagicMock) -> None:
+    """
+    Test that on_invite joins rooms matched by room ID in config.
+    """
+    mock_room = MagicMock()
+    mock_room.room_id = "!abc123:matrix.org"
+
+    mock_event = MagicMock()
+    mock_event.state_key = "@bot:matrix.org"
+    mock_event.membership = "invite"
+    mock_event.sender = "@inviter:matrix.org"
+
+    mock_client = AsyncMock()
+    mock_client.rooms = {}
+    mock_join_response = MagicMock()
+    mock_join_response.room_id = "!abc123:matrix.org"
+    mock_client.join.return_value = mock_join_response
+
+    import mmrelay.matrix_utils
+
+    mmrelay.matrix_utils.matrix_client = mock_client
+    mmrelay.matrix_utils.bot_user_id = "@bot:matrix.org"
+    mmrelay.matrix_utils.matrix_rooms = [
+        {"id": "!abc123:matrix.org", "meshtastic_channel": 0}
+    ]
+
+    result = await on_invite(mock_room, mock_event)
+
+    assert result is None
+    mock_logger.info.assert_any_call(
+        "Room '!abc123:matrix.org' is in matrix_rooms configuration, accepting invite"
+    )
+    mock_client.join.assert_called_once_with("!abc123:matrix.org")

--- a/tests/test_matrix_utils_invite.py
+++ b/tests/test_matrix_utils_invite.py
@@ -333,7 +333,12 @@ async def test_on_invite_handles_join_failure(mock_logger: MagicMock) -> None:
 @patch("mmrelay.matrix_utils.logger")
 async def test_on_invite_handles_no_client(mock_logger: MagicMock) -> None:
     """
-    Test that on_invite handles missing matrix_client gracefully.
+    Verifies that on_invite logs an error and takes no action when the Matrix client is not configured.
+    
+    Asserts that the function returns None and that an error message indicating the missing client is logged.
+    
+    Parameters:
+        mock_logger (MagicMock): Mocked logger used to assert that the expected error message was emitted.
     """
     mock_room = MagicMock()
     mock_room.room_id = "!abc123:matrix.org"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds automatic join-on-invite behavior for Matrix: when the bot is invited to a room that appears in the configured matrix_rooms mapping, it will attempt to join. It introduces a new invite handler and a mapping-check helper, wires the handler into main event registrations, makes several imports and type handling more robust, and adds tests and test fixtures to cover invite handling and related module state. The changes also include autogenerated docstrings and a number of small refactors and typing improvements across modules.

## Key Changes

### Features
- Automatic room joining on invite
  - New async handler on_invite(room, event) that:
    - Confirms the invite targets the bot (state_key == bot_user_id)
    - Ensures the membership event is an "invite"
    - Checks whether the invited room (ID or alias) is present in matrix_rooms
    - Attempts to join mapped rooms via matrix_client.join and logs success or failure
- Room mapping helper
  - New helper _is_room_mapped(mapping, room_id_or_alias) supports both list and dict formats of matrix_rooms and returns whether a room ID or alias is mapped

### Integration & wiring
- Event registration
  - InviteMemberEvent is imported and registered in main.py; matrix_client.add_event_callback now registers on_invite for InviteMemberEvent so invite events invoke the new handler
- Import robustness and typing
  - Guarded imports for InviteMemberEvent and jsonschema (fallback ValidationError), plus TYPE_CHECKING guards across modules to avoid runtime import failures and improve static typing without changing runtime behavior

### Testing
- New tests and fixtures
  - tests/test_matrix_utils_invite.py: comprehensive tests for _is_room_mapped and on_invite covering list/dict mappings, alias vs ID matching, bot-target checks, non-invite membership, unmapped rooms, join success/failure, already-in-room, matrix_client None, and other edge cases
  - tests/conftest.py: added reset_matrix_utils_globals fixture to isolate and restore matrix_utils globals between tests; adjusted asyncmock cleanup to include invite tests

### Refactors / Minor fixes
- Subprocess safety: CLI and k8s subprocess calls now include explicit timeouts and check=False and are annotated with nosec comments
- Logging/UI guards: Rich Console/Progress and related handlers moved behind TYPE_CHECKING/runtime guards to avoid hard dependencies at import time
- Plugin robustness: help/map/ping plugins now guard against None plugin_name and return [] when unset
- Autogenerated docstrings: many modules and tests received autogenerated docstrings; minor docstring and wording updates across codebase
- Lint/type updates: trunk lint config updated (pyright added) and various type-handling adjustments (getattr/casts, fewer type-ignore annotations)

## Breaking changes / Migration notes
- No breaking API changes detected. Public function signatures remain the same; the only runtime-visible addition is the new invite handler registration.
- matrix_rooms configuration formats remain supported (both list and dict).
- Optional dependencies like nio and jsonschema are still expected in typical deployments; the code includes guarded fallbacks to ease testing or environments missing those optional packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->