### PR TITLE
Update Kubernetes docs, improve secrets, refactor CLI logging

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,6 +17,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - mypy@1.19.1
     - pyright@1.1.408
     - dotenv-linter@4.0.0
     - hadolint@2.14.0

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -75,7 +75,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - test "$(( $(date +%s) - $(stat -c %Y /run/mmrelay/ready) ))" -lt 120
+                - python -c 'import os,time; p="/run/mmrelay/ready"; raise SystemExit(0 if os.path.exists(p) and time.time() - os.path.getmtime(p) < 120 else 1)'
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -73,7 +73,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - find /run/mmrelay/ready -mmin -2 | grep -q .
+                - test "$(( $(date +%s) - $(stat -c %Y /run/mmrelay/ready) ))" -lt 120
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -48,6 +48,8 @@ spec:
               value: /run/mmrelay/ready
             - name: MMRELAY_CREDENTIALS_PATH
               value: /data/credentials.json
+            - name: MMRELAY_BASE_DIR
+              value: /data
           envFrom:
             - secretRef:
                 name: mmrelay-matrix-auth

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -37,7 +37,7 @@ export MMRELAY_VERSION=1.2.9
 # Download manifests from the main branch
 BASE_URL="https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/main/deploy/k8s"
 for manifest in pvc.yaml networkpolicy.yaml deployment.yaml kustomization.yaml overlays/digest/kustomization.yaml; do
-  DEST_PATH="./mmrelay-k8s/${manifest}"
+  DEST_PATH="./deploy/k8s/${manifest}"
   mkdir -p "$(dirname "${DEST_PATH}")"
   curl -Lo "${DEST_PATH}" "${BASE_URL}/${manifest}"
 done
@@ -46,7 +46,7 @@ done
 kubectl create namespace mmrelay --dry-run=client -o yaml | kubectl apply -f -
 
 # Edit namespace/image tag in kustomization.yaml
-$EDITOR ./mmrelay-k8s/kustomization.yaml
+$EDITOR ./deploy/k8s/kustomization.yaml
 # Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION})
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
@@ -77,7 +77,7 @@ kubectl create secret generic mmrelay-config \
   --namespace mmrelay
 
 # Apply manifests
-kubectl apply -k ./mmrelay-k8s
+kubectl apply -k ./deploy/k8s
 
 # Check status
 kubectl get pods -n mmrelay -l app=mmrelay
@@ -89,12 +89,12 @@ kubectl logs -n mmrelay -f deployment/mmrelay
 If you want immutable image references for production, use the digest overlay.
 This requires a published image with a digest from GitHub Packages.
 
-Replace the placeholder digest in `./mmrelay-k8s/overlays/digest/kustomization.yaml`.
+Replace the placeholder digest in `./deploy/k8s/overlays/digest/kustomization.yaml`.
 Tags and digests are listed on the GitHub Packages page:
 [https://github.com/jeremiah-k/meshtastic-matrix-relay/pkgs/container/mmrelay](https://github.com/jeremiah-k/meshtastic-matrix-relay/pkgs/container/mmrelay)
 
 ```bash
-kubectl apply -k ./mmrelay-k8s/overlays/digest
+kubectl apply -k ./deploy/k8s/overlays/digest
 ```
 
 ## Secrets and configuration
@@ -121,7 +121,7 @@ The deployment uses `/data` as the base directory for all persistent data:
 
 This is configured in `deployment.yaml` via `--base-dir /data` and the PVC mount. All data persists across pod restarts.
 
-`./mmrelay-k8s/pvc.yaml` uses the cluster default StorageClass. If your cluster requires a specific StorageClass, add `storageClassName` there.
+`./deploy/k8s/pvc.yaml` uses the cluster default StorageClass. If your cluster requires a specific StorageClass, add `storageClassName` there.
 
 ## Connection types
 
@@ -135,7 +135,7 @@ Serial requires host device access and node pinning. Start with the most restric
 
 1.  Add the device mount to the container:
 
-    In `./mmrelay-k8s/deployment.yaml`, add this entry under
+    In `./deploy/k8s/deployment.yaml`, add this entry under
     `spec.template.spec.containers[0].volumeMounts`:
 
     ```yaml

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -46,18 +46,19 @@ done
 kubectl create namespace mmrelay --dry-run=client -o yaml | kubectl apply -f -
 
 # Edit namespace/image tag in kustomization.yaml
-$EDITOR ./deploy/k8s/kustomization.yaml
+${EDITOR:-vi} ./deploy/k8s/kustomization.yaml
 # Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION})
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
 
 # Create config.yaml from the project sample
+# Guard against MMRELAY_VERSION="latest" by defaulting to main for the sample config ref.
 MMRELAY_CONFIG_REF="${MMRELAY_VERSION}"
 if [ "${MMRELAY_VERSION}" = "latest" ]; then
   MMRELAY_CONFIG_REF="main"
 fi
 curl -Lo ./config.yaml https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/${MMRELAY_CONFIG_REF}/src/mmrelay/tools/sample_config.yaml
-$EDITOR ./config.yaml
+${EDITOR:-vi} ./config.yaml
 
 # The default manifest sets MMRELAY_CREDENTIALS_PATH=/data/credentials.json,
 # so credentials will persist on the PVC. You can override this by explicitly

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -15,9 +15,15 @@ The `MMRELAY_VERSION` variable controls which version of the manifests and confi
 
 - **Development/Testing**: Use `"main"` (default) for the latest changes. The k8s manifests are currently only available on the main branch and have not yet been included in a release.
 - **Production**: Use a specific release tag (e.g., `1.2.10`) once a release includes the k8s manifests. Pinning to a release ensures stability and reproducibility.
+- **Image tag**: Must be set to a specific tag (e.g., `1.2.9`, `latest`) in the kustomization.yaml. The `MMRELAY_VERSION` variable is only for downloading manifests and config, not for the container image tag.
 - **Digest overlay**: Requires a release tag with published image digests. The overlay is only available for production releases.
 
-Always ensure your manifests and container image use the same version for compatibility.
+**Important**: The `MMRELAY_VERSION` variable (used for downloading manifests) and the image `newTag` (used for the container image) are separate. For example:
+
+- Download manifests from `main` using `MMRELAY_VERSION=main`
+- Use image tag `1.2.9` or `latest` in kustomization.yaml
+
+The manifests from `main` will work with the `1.2.9` image tag, even though that release didn't include these manifests.
 
 ## Quick Start (static manifests)
 
@@ -38,12 +44,13 @@ curl -Lo ./mmrelay-k8s/overlays/digest/kustomization.yaml https://raw.githubuser
 # Ensure the namespace exists
 kubectl create namespace mmrelay --dry-run=client -o yaml | kubectl apply -f -
 
-# Edit namespace/image tag in kustomization.yaml if desired
+# Edit namespace/image tag in kustomization.yaml
 $EDITOR ./mmrelay-k8s/kustomization.yaml
+# IMPORTANT: Set the image newTag to a valid published tag (e.g., "1.2.9" or "latest").
+# Do NOT set newTag to "main" - that is only for downloading manifests.
+# The downloaded manifests from main will work with existing image tags like 1.2.9.
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
-# Note: If using "main" for MMRELAY_VERSION, update the newTag in kustomization.yaml
-# to match a specific image tag or use "latest" for development.
 
 # Create config.yaml from the project sample (downloaded from the same version as your manifests)
 curl -Lo ./config.yaml https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/${MMRELAY_VERSION}/src/mmrelay/tools/sample_config.yaml

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -48,14 +48,14 @@ curl -Lo ./mmrelay-k8s/overlays/digest/kustomization.yaml https://raw.githubuser
 kubectl create namespace mmrelay --dry-run=client -o yaml | kubectl apply -f -
 
 # Edit namespace/image tag in kustomization.yaml
-$EDITOR ./mmrelay-k8s/kustomization.yaml
+vi ./mmrelay-k8s/kustomization.yaml
 # Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION})
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
 
 # Create config.yaml from the project sample (downloaded from the same version as your image)
 curl -Lo ./config.yaml https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/${MMRELAY_VERSION}/src/mmrelay/tools/sample_config.yaml
-$EDITOR ./config.yaml
+vi ./config.yaml
 
 # The default manifest sets MMRELAY_CREDENTIALS_PATH=/data/credentials.json,
 # so credentials will persist on the PVC. You can override this by explicitly
@@ -66,10 +66,11 @@ $EDITOR ./config.yaml
 #     store_path: /data/store
 
 # Create a Matrix auth secret (environment-based auth)
+# The password is entered interactively and will not be shown or stored in shell history
 kubectl create secret generic mmrelay-matrix-auth \
-  --from-literal=MMRELAY_MATRIX_HOMESERVER=https://matrix.example.org \
-  --from-literal=MMRELAY_MATRIX_BOT_USER_ID=@bot:example.org \
-  --from-literal=MMRELAY_MATRIX_PASSWORD=your_password \
+  --from-literal=MMRELAY_MATRIX_HOMESERVER=$(read -p "Matrix homeserver URL (e.g., https://matrix.example.org): "; echo "$REPLY") \
+  --from-literal=MMRELAY_MATRIX_BOT_USER_ID=$(read -p "Matrix bot user ID (e.g., @bot:example.org): "; echo "$REPLY") \
+  --from-literal=MMRELAY_MATRIX_PASSWORD=$(read -s -p "Matrix password: "; echo "$REPLY") \
   --namespace mmrelay
 
 # Store config.yaml in a Kubernetes Secret

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -11,18 +11,18 @@ This guide uses the static manifests in `deploy/k8s/`. Download them, create a S
 
 ## Version Selection
 
-The `MMRELAY_VERSION` variable is the container image tag (e.g., `1.2.9`, `latest`). This is used for:
+The `MMRELAY_VERSION` variable is the container image tag (e.g., `1.2.10`). This is used for:
 
 - Setting the image tag in kustomization.yaml
 - Downloading the sample config.yaml
 
-The Kubernetes manifests are always downloaded from the `main` branch since they have not yet been included in a release.
+The Kubernetes manifests shipped starting with **1.2.10**. This guide downloads them
+from the `main` branch for convenience.
 
-- **Production**: Use a specific release tag (e.g., `1.2.9`) for stability and reproducibility.
-- **Development**: Use `latest` for the latest development changes.
-- **Digest overlay**: Requires a release tag with published image digests. The overlay is only available for production releases.
+- **Production**: Use a specific release tag (e.g., `1.2.10`) for stability and reproducibility.
+- **Digest overlay**: Requires a release tag with published image digests.
 
-**Important**: The manifests from `main` branch work with any existing image tag (`1.2.9`, `latest`, etc.), even though the release didn't include these manifests.
+**Important**: The manifests require MMRelay **1.2.10+**.
 
 ## Quick Start (static manifests)
 

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -39,7 +39,7 @@ BASE_URL="https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/m
 for manifest in pvc.yaml networkpolicy.yaml deployment.yaml kustomization.yaml overlays/digest/kustomization.yaml; do
   DEST_PATH="./deploy/k8s/${manifest}"
   mkdir -p "$(dirname "${DEST_PATH}")"
-  curl -Lo "${DEST_PATH}" "${BASE_URL}/${manifest}"
+  curl -fLo "${DEST_PATH}" "${BASE_URL}/${manifest}" || { echo "Error: Failed to download ${manifest}" >&2; exit 1; }
 done
 
 # Ensure the namespace exists

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -112,6 +112,15 @@ This keeps sensitive data out of the manifests so you can publish the manifests 
 
 ## Storage
 
+The deployment uses `/data` as the base directory for all persistent data:
+
+- **Credentials**: `/data/credentials.json` (auto-created on first login)
+- **Logs**: `/data/logs/mmrelay.log`
+- **Database**: `/data/mmrelay.db`
+- **E2EE store**: `/data/store/` (if encryption is enabled)
+
+This is configured in `deployment.yaml` via `--base-dir /data` and the PVC mount. All data persists across pod restarts.
+
 `./mmrelay-k8s/pvc.yaml` uses the cluster default StorageClass. If your cluster requires a specific StorageClass, add `storageClassName` there.
 
 ## Connection types

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -31,8 +31,8 @@ The Kubernetes manifests are always downloaded from the `main` branch since they
 mkdir -p mmrelay
 cd mmrelay
 
-# Set the version for the container image tag
-export MMRELAY_VERSION=1.2.9
+# Set the version for the container image tag (manifests require MMRelay 1.2.10 or later)
+export MMRELAY_VERSION=1.2.10
 
 # Download manifests from the main branch
 BASE_URL="https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/main/deploy/k8s"
@@ -47,7 +47,7 @@ kubectl create namespace mmrelay --dry-run=client -o yaml | kubectl apply -f -
 
 # Edit namespace/image tag in kustomization.yaml
 ${EDITOR:-vi} ./deploy/k8s/kustomization.yaml
-# Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION})
+# Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION}); manifests require 1.2.10+
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
 

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -51,8 +51,12 @@ $EDITOR ./deploy/k8s/kustomization.yaml
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
 
-# Create config.yaml from the project sample (downloaded from the same version as your image)
-curl -Lo ./config.yaml https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/${MMRELAY_VERSION}/src/mmrelay/tools/sample_config.yaml
+# Create config.yaml from the project sample
+MMRELAY_CONFIG_REF="${MMRELAY_VERSION}"
+if [ "${MMRELAY_VERSION}" = "latest" ]; then
+  MMRELAY_CONFIG_REF="main"
+fi
+curl -Lo ./config.yaml https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/${MMRELAY_CONFIG_REF}/src/mmrelay/tools/sample_config.yaml
 $EDITOR ./config.yaml
 
 # The default manifest sets MMRELAY_CREDENTIALS_PATH=/data/credentials.json,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+ignore_missing_imports = True
+python_version = 3.12
+
+[mypy-requests.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,29 @@
 [mypy]
-ignore_missing_imports = True
 python_version = 3.12
 
 [mypy-requests.*]
+ignore_missing_imports = True
+
+[mypy-nio.*]
+ignore_missing_imports = True
+
+[mypy-meshtastic.*]
+ignore_missing_imports = True
+
+[mypy-serial.*]
+ignore_missing_imports = True
+
+[mypy-pubsub.*]
+ignore_missing_imports = True
+
+[mypy-haversine.*]
+ignore_missing_imports = True
+
+[mypy-s2sphere.*]
+ignore_missing_imports = True
+
+[mypy-staticmaps.*]
+ignore_missing_imports = True
+
+[mypy-olm.*]
 ignore_missing_imports = True

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -64,10 +64,10 @@ _logger: logging.Logger | None = None
 def _get_logger() -> logging.Logger:
     """
     Return the module-level logger, creating it on first access.
-    
+
     Returns:
         logging.Logger: The module logger instance.
-    
+
     Raises:
         RuntimeError: If the logger could not be initialized.
     """

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -1552,9 +1552,6 @@ def handle_auth_login(args: argparse.Namespace) -> int:
                 print("=========================")
         except (OSError, PermissionError, ImportError, ValueError) as e:
             # Fallback if silent checking fails due to config file or import issues
-            from mmrelay.log_utils import get_logger
-
-            logger = get_logger("CLI")
             _get_logger().debug(f"Failed to silently check E2EE status: {e}")
             print("\nMatrix Bot Authentication")
             print("=========================")

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -62,7 +62,15 @@ _logger: logging.Logger | None = None
 
 
 def _get_logger() -> logging.Logger:
-    """Get or create the module logger."""
+    """
+    Return the module-level logger, creating it on first access.
+    
+    Returns:
+        logging.Logger: The module logger instance.
+    
+    Raises:
+        RuntimeError: If the logger could not be initialized.
+    """
     global _logger
     if _logger is None:
         _logger = get_logger(__name__)

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -6,6 +6,7 @@ import argparse
 import importlib
 import importlib.resources
 import ipaddress
+import logging
 import os
 import platform
 import re
@@ -57,14 +58,16 @@ from mmrelay.log_utils import get_logger
 from mmrelay.tools import get_sample_config_path
 
 # Lazy-initialized logger to avoid circular imports and filesystem access during import
-_logger: Any = None
+_logger: logging.Logger | None = None
 
 
-def _get_logger() -> Any:
+def _get_logger() -> logging.Logger:
     """Get or create the module logger."""
     global _logger
     if _logger is None:
         _logger = get_logger(__name__)
+    if _logger is None:
+        raise RuntimeError("Logger must be initialized")
     return _logger
 
 

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -85,6 +85,7 @@ def _get_logger() -> logging.Logger:
     global logger
     if logger is None:
         logger = get_logger(__name__)
+    assert logger is not None, "Logger must be initialized"
     return logger
 
 
@@ -618,9 +619,17 @@ async def logout_matrix_bot(password: str) -> bool:
         except asyncio.TimeoutError:
             _get_logger().error("Timeout while fetching user_id")
             print("❌ Timeout while fetching user_id")
+        except (
+            NioLocalTransportError,
+            NioRemoteTransportError,
+            NioLocalProtocolError,
+            NioRemoteProtocolError,
+        ) as e:
+            _get_logger().warning(f"Network error fetching user_id: {e}")
+            print(f"❌ Network error fetching user_id: {e}")
         except Exception as e:
-            _get_logger().exception("Error fetching user_id")
-            print(f"❌ Error fetching user_id: {e}")
+            _get_logger().exception("Unexpected error fetching user_id")
+            print(f"❌ Unexpected error fetching user_id: {e}")
         finally:
             if temp_client is not None:
                 try:

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -81,6 +81,15 @@ logger: logging.Logger | None = None
 
 
 def _get_logger() -> logging.Logger:
+    """
+    Lazily initializes and returns the module-level logger for this module.
+    
+    Returns:
+        logging.Logger: The module-scoped logger instance.
+    
+    Raises:
+        RuntimeError: If the logger cannot be initialized.
+    """
     global logger
     if logger is None:
         logger = get_logger(__name__)

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -84,7 +84,8 @@ def _get_logger() -> logging.Logger:
     global logger
     if logger is None:
         logger = get_logger(__name__)
-    assert logger is not None, "Logger must be initialized"
+    if logger is None:
+        raise RuntimeError("Logger must be initialized")
     return logger
 
 
@@ -620,10 +621,12 @@ async def logout_matrix_bot(password: str) -> bool:
             _get_logger().error("Timeout while fetching user_id")
             print("❌ Timeout while fetching user_id")
         except Exception as e:
+            _get_logger().exception("Error fetching user_id")
+            print(f"❌ Error fetching user_id: {e}")
             # Handle both network exceptions (when matrix-nio is installed) and
             # unexpected errors. When matrix-nio is not installed, the Nio types
-            # are aliased to Exception, so we check isinstance to route correctly.
-            if isinstance(
+            # are aliased to Exception, so guard with AsyncClient presence.
+            if AsyncClient is not None and isinstance(
                 e,
                 (
                     NioLocalTransportError,
@@ -635,7 +638,7 @@ async def logout_matrix_bot(password: str) -> bool:
                 _get_logger().warning(f"Network error fetching user_id: {e}")
                 print(f"❌ Network error fetching user_id: {e}")
             else:
-                _get_logger().exception("Unexpected error fetching user_id")
+                _get_logger().error("Unexpected error fetching user_id")
                 print(f"❌ Unexpected error fetching user_id: {e}")
         finally:
             if temp_client is not None:

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -83,10 +83,10 @@ logger: logging.Logger | None = None
 def _get_logger() -> logging.Logger:
     """
     Lazily initializes and returns the module-level logger for this module.
-    
+
     Returns:
         logging.Logger: The module-scoped logger instance.
-    
+
     Raises:
         RuntimeError: If the logger cannot be initialized.
     """

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -23,6 +23,7 @@ Usage:
 """
 
 import asyncio
+import logging
 import os
 import ssl
 from types import ModuleType
@@ -77,7 +78,14 @@ from mmrelay.constants.cli import (
 )
 from mmrelay.log_utils import get_logger
 
-logger = get_logger(__name__)
+logger: logging.Logger | None = None
+
+
+def _get_logger() -> logging.Logger:
+    global logger
+    if logger is None:
+        logger = get_logger(__name__)
+    return logger
 
 
 def get_command(command_key: str) -> str:
@@ -302,14 +310,16 @@ def _create_ssl_context() -> ssl.SSLContext | None:
         else:
             return ssl.create_default_context()
     except (ssl.SSLError, OSError, ValueError):
-        logger.warning(
+        _get_logger().warning(
             "Failed to create certifi-backed SSL context, falling back to system default",
             exc_info=True,
         )
         try:
             return ssl.create_default_context()
         except (ssl.SSLError, OSError, ValueError):
-            logger.error("Failed to create system default SSL context", exc_info=True)
+            _get_logger().error(
+                "Failed to create system default SSL context", exc_info=True
+            )
             return None
 
 
@@ -331,7 +341,7 @@ def _cleanup_local_session_data() -> bool:
 
     from mmrelay.config import get_base_dir, get_e2ee_store_dir
 
-    logger.info("Clearing local session data...")
+    _get_logger().info("Clearing local session data...")
     success = True
 
     # Remove credentials.json
@@ -341,12 +351,12 @@ def _cleanup_local_session_data() -> bool:
     if os.path.exists(credentials_path):
         try:
             os.remove(credentials_path)
-            logger.info(f"Removed credentials file: {credentials_path}")
+            _get_logger().info(f"Removed credentials file: {credentials_path}")
         except (OSError, PermissionError) as e:
-            logger.error(f"Failed to remove credentials file: {e}")
+            _get_logger().error(f"Failed to remove credentials file: {e}")
             success = False
     else:
-        logger.info("No credentials file found to remove")
+        _get_logger().info("No credentials file found to remove")
 
     # Clear E2EE store directory (default and any configured override)
     candidate_store_paths = {get_e2ee_store_dir()}
@@ -362,7 +372,7 @@ def _cleanup_local_session_data() -> bool:
             if override:
                 candidate_store_paths.add(override)
     except Exception as e:
-        logger.debug(
+        _get_logger().debug(
             f"Could not resolve configured E2EE store path: {type(e).__name__}"
         )
 
@@ -372,22 +382,24 @@ def _cleanup_local_session_data() -> bool:
             any_store_found = True
             try:
                 shutil.rmtree(store_path)
-                logger.info(f"Removed E2EE store directory: {store_path}")
+                _get_logger().info(f"Removed E2EE store directory: {store_path}")
             except (OSError, PermissionError) as e:
-                logger.error(
+                _get_logger().error(
                     f"Failed to remove E2EE store directory '{store_path}': {e}"
                 )
                 success = False
     if not any_store_found:
-        logger.info("No E2EE store directory found to remove")
+        _get_logger().info("No E2EE store directory found to remove")
 
     if success:
-        logger.info("✅ Logout completed successfully!")
-        logger.info("All Matrix sessions and local data have been cleared.")
-        logger.info("Run 'mmrelay auth login' to authenticate again.")
+        _get_logger().info("✅ Logout completed successfully!")
+        _get_logger().info("All Matrix sessions and local data have been cleared.")
+        _get_logger().info("Run 'mmrelay auth login' to authenticate again.")
     else:
-        logger.warning("Logout completed with some errors.")
-        logger.warning("Some files may not have been removed due to permission issues.")
+        _get_logger().warning("Logout completed with some errors.")
+        _get_logger().warning(
+            "Some files may not have been removed due to permission issues."
+        )
 
     return success
 
@@ -409,7 +421,7 @@ def _handle_matrix_error(
     Returns:
         bool: `True` indicating the exception was handled and reported.
     """
-    log_func = logger.error if log_level == "error" else logger.warning
+    log_func = _get_logger().error if log_level == "error" else _get_logger().warning
     emoji = "❌" if log_level == "error" else "⚠️ "
     is_verification = "verification" in context.lower()
 
@@ -514,7 +526,7 @@ def _handle_matrix_error(
     else:  # error_category == "other"
         if is_verification:
             log_func(f"{context} failed: {error_detail or 'Unknown error'}")
-            logger.debug(f"Full error details: {exception}")
+            _get_logger().debug(f"Full error details: {exception}")
             print(f"{emoji} {context} failed: {error_detail or 'Unknown error'}")
         else:
             log_func(
@@ -548,14 +560,14 @@ async def logout_matrix_bot(password: str) -> bool:
 
     # Check if matrix-nio is available
     if AsyncClient is None:
-        logger.error("Matrix-nio library not available. Cannot perform logout.")
+        _get_logger().error("Matrix-nio library not available. Cannot perform logout.")
         print("❌ Matrix-nio library not available. Cannot perform logout.")
         return False
 
     # Load current credentials
     credentials = load_credentials()
     if not credentials:
-        logger.info("No active session found. Already logged out.")
+        _get_logger().info("No active session found. Already logged out.")
         print("ℹ️  No active session found. Already logged out.")
         return True
 
@@ -566,7 +578,9 @@ async def logout_matrix_bot(password: str) -> bool:
 
     # If user_id is missing, try to fetch it using the access token
     if not user_id and access_token and homeserver:
-        logger.info("user_id missing from credentials, attempting to fetch it...")
+        _get_logger().info(
+            "user_id missing from credentials, attempting to fetch it..."
+        )
         print("🔍 user_id missing from credentials, attempting to fetch it...")
 
         temp_client = None
@@ -587,7 +601,7 @@ async def logout_matrix_bot(password: str) -> bool:
 
             user_id = getattr(whoami_response, "user_id", None)
             if user_id:
-                logger.info(f"Successfully fetched user_id: {user_id}")
+                _get_logger().info(f"Successfully fetched user_id: {user_id}")
                 print(f"✅ Successfully fetched user_id: {user_id}")
 
                 # Update credentials with the fetched user_id
@@ -595,17 +609,17 @@ async def logout_matrix_bot(password: str) -> bool:
                 from mmrelay.config import save_credentials
 
                 save_credentials(credentials)
-                logger.info("Updated credentials.json with fetched user_id")
+                _get_logger().info("Updated credentials.json with fetched user_id")
                 print("✅ Updated credentials.json with fetched user_id")
             else:
-                logger.error("Failed to fetch user_id from whoami response")
+                _get_logger().error("Failed to fetch user_id from whoami response")
                 print("❌ Failed to fetch user_id from whoami response")
 
         except asyncio.TimeoutError:
-            logger.error("Timeout while fetching user_id")
+            _get_logger().error("Timeout while fetching user_id")
             print("❌ Timeout while fetching user_id")
         except Exception as e:
-            logger.exception("Error fetching user_id")
+            _get_logger().exception("Error fetching user_id")
             print(f"❌ Error fetching user_id: {e}")
         finally:
             if temp_client is not None:
@@ -613,14 +627,14 @@ async def logout_matrix_bot(password: str) -> bool:
                     await temp_client.close()
                 except Exception:
                     # Ignore close failures but keep a trace for diagnostics.
-                    logger.debug(
+                    _get_logger().debug(
                         "Ignoring error while closing temporary Matrix client during logout",
                         exc_info=True,
                     )
 
     if not all([homeserver, user_id, access_token, device_id]):
-        logger.error("Invalid credentials found. Cannot verify logout.")
-        logger.info("Proceeding with local cleanup only...")
+        _get_logger().error("Invalid credentials found. Cannot verify logout.")
+        _get_logger().info("Proceeding with local cleanup only...")
         print("⚠️  Invalid credentials found. Cannot verify logout.")
         print("Proceeding with local cleanup only...")
 
@@ -640,7 +654,7 @@ async def logout_matrix_bot(password: str) -> bool:
     access_token_str = cast(str, access_token)
     device_id_str = cast(str, device_id)
 
-    logger.info(f"Verifying password for {user_id}...")
+    _get_logger().info(f"Verifying password for {user_id}...")
     print(f"🔐 Verifying password for {user_id}...")
 
     temp_client = None
@@ -648,7 +662,7 @@ async def logout_matrix_bot(password: str) -> bool:
         # Create SSL context using certifi's certificates
         ssl_context = _create_ssl_context()
         if ssl_context is None:
-            logger.warning(
+            _get_logger().warning(
                 "Failed to create SSL context for password verification; falling back to default system SSL"
             )
 
@@ -665,7 +679,7 @@ async def logout_matrix_bot(password: str) -> bool:
             )
 
             if hasattr(response, "access_token"):
-                logger.info("Password verified successfully.")
+                _get_logger().info("Password verified successfully.")
                 print("✅ Password verified successfully.")
 
                 # Immediately logout the temporary session
@@ -675,16 +689,16 @@ async def logout_matrix_bot(password: str) -> bool:
                         timeout=MATRIX_LOGIN_TIMEOUT,
                     )
                 except asyncio.TimeoutError:
-                    logger.warning(
+                    _get_logger().warning(
                         "Timeout during temporary session logout, continuing..."
                     )
             else:
-                logger.error("Password verification failed.")
+                _get_logger().error("Password verification failed.")
                 print("❌ Password verification failed.")
                 return False
 
         except asyncio.TimeoutError:
-            logger.error(
+            _get_logger().error(
                 "Password verification timed out. Please check your network connection."
             )
             print(
@@ -700,13 +714,13 @@ async def logout_matrix_bot(password: str) -> bool:
                     await temp_client.close()
                 except (OSError, asyncio.TimeoutError):
                     # Avoid masking the original error; log for diagnostics only.
-                    logger.debug(
+                    _get_logger().debug(
                         "Ignoring error while closing temporary Matrix client after password verification",
                         exc_info=True,
                     )
 
         # Now logout the main session
-        logger.info("Logging out from Matrix server...")
+        _get_logger().info("Logging out from Matrix server...")
         print("🚪 Logging out from Matrix server...")
         main_client = None
         try:
@@ -724,7 +738,7 @@ async def logout_matrix_bot(password: str) -> bool:
                     timeout=MATRIX_LOGIN_TIMEOUT,
                 )
             except asyncio.TimeoutError:
-                logger.warning(
+                _get_logger().warning(
                     "Timeout during Matrix server logout, proceeding with local cleanup."
                 )
                 print(
@@ -732,22 +746,22 @@ async def logout_matrix_bot(password: str) -> bool:
                 )
             else:
                 if hasattr(logout_response, "transport_response"):
-                    logger.info("Successfully logged out from Matrix server.")
+                    _get_logger().info("Successfully logged out from Matrix server.")
                     print("✅ Successfully logged out from Matrix server.")
                 else:
-                    logger.warning(
+                    _get_logger().warning(
                         "Logout response unclear, proceeding with local cleanup."
                     )
                     print("⚠️  Logout response unclear, proceeding with local cleanup.")
         except Exception as e:
             _handle_matrix_error(e, "Server logout", "warning")
-            logger.debug(f"Logout error details: {e}")
+            _get_logger().debug(f"Logout error details: {e}")
         finally:
             if main_client is not None:
                 try:
                     await main_client.close()
                 except (OSError, asyncio.TimeoutError):
-                    logger.debug(
+                    _get_logger().debug(
                         "Ignoring error while closing main Matrix client",
                         exc_info=True,
                     )
@@ -766,6 +780,6 @@ async def logout_matrix_bot(password: str) -> bool:
         return success
 
     except Exception as e:
-        logger.exception("Error during logout process")
+        _get_logger().exception("Error during logout process")
         print(f"❌ Error during logout process: {e}")
         return False

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -37,14 +37,14 @@ except ImportError:
 # Import Matrix-related modules for logout functionality
 try:
     # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-    from nio import AsyncClient  # type: ignore[import-untyped]
-    from nio.exceptions import (  # type: ignore[import-untyped]
+    from nio import AsyncClient
+    from nio.exceptions import (
         LocalProtocolError,
         LocalTransportError,
         RemoteProtocolError,
         RemoteTransportError,
     )
-    from nio.responses import LoginError, LogoutError  # type: ignore[import-untyped]
+    from nio.responses import LoginError, LogoutError
 
     # Create aliases for backward compatibility
     NioLoginError = LoginError

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -45,7 +45,11 @@ def get_base_dir() -> str:
     """
     Determine the filesystem base directory used to store the application's files.
 
-    If the module-level `custom_data_dir` is set, that path is returned. On Linux and macOS the directory is `~/.<APP_NAME>`; on Windows the platform-specific user data directory for the application is returned.
+    If the module-level `custom_data_dir` is set, that path is returned. If the
+    MMRELAY_BASE_DIR (or deprecated MMRELAY_DATA_DIR) environment variable is
+    set, that path is used. On Linux and macOS the directory is `~/.<APP_NAME>`;
+    on Windows the platform-specific user data directory for the application is
+    returned.
 
     Returns:
         The filesystem path to the application's base data directory.
@@ -53,6 +57,10 @@ def get_base_dir() -> str:
     # If a custom data directory has been set, use that
     if custom_data_dir:
         return custom_data_dir
+
+    env_base_dir = os.getenv("MMRELAY_BASE_DIR") or os.getenv("MMRELAY_DATA_DIR")
+    if env_base_dir:
+        return os.path.abspath(os.path.expanduser(env_base_dir))
 
     if sys.platform in ["linux", "darwin"]:
         # Use ~/.mmrelay for Linux and Mac

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -13,8 +13,6 @@ from pathlib import Path
 from typing import Any, cast
 
 from aiohttp import ClientError
-
-# matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio import (
     MegolmEvent,
     ReactionEvent,

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -15,14 +15,14 @@ from typing import Any, cast
 from aiohttp import ClientError
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MegolmEvent,
     ReactionEvent,
     RoomMessageEmote,
     RoomMessageNotice,
     RoomMessageText,
 )
-from nio.events.room_events import RoomMemberEvent  # type: ignore[import-untyped]
+from nio.events.room_events import RoomMemberEvent
 
 # Import version from package
 # Import meshtastic_utils as a module to set event_loop

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -47,8 +47,6 @@ from nio import (
     UploadError,
     UploadResponse,
 )
-
-# matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio.events.room_events import (
     RoomMemberEvent,
 )

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     pass
 
 # matrix-nio is not marked py.typed in our environment, so mypy treats it as untyped.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     AsyncClient,
     AsyncClientConfig,
     DiscoveryInfoError,
@@ -49,7 +49,7 @@ from nio import (  # type: ignore[import-untyped]
 )
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio.events.room_events import (  # type: ignore[import-untyped]
+from nio.events.room_events import (
     RoomMemberEvent,
 )
 
@@ -57,7 +57,7 @@ from nio.events.room_events import (  # type: ignore[import-untyped]
 try:
     from nio import InviteMemberEvent  # pyright: ignore[reportMissingImports]
 except ImportError:
-    from nio.events.invite_events import (  # type: ignore[import-untyped]
+    from nio.events.invite_events import (
         InviteMemberEvent,
     )
 
@@ -1223,7 +1223,7 @@ async def _handle_detection_sensor_packet(
     if not meshtastic_interface:
         return
 
-    import meshtastic.protobuf.portnums_pb2  # type: ignore[import-untyped]
+    import meshtastic.protobuf.portnums_pb2
 
     success = queue_message(
         meshtastic_interface.sendData,
@@ -1770,7 +1770,7 @@ async def connect_matrix(
                 Returns:
                     The SyncResponse object returned by the matrix client's sync call.
                 """
-                import nio.responses as nio_responses  # type: ignore[import-untyped]
+                import nio.responses as nio_responses
 
                 original_descriptor = vars(nio_responses.SyncResponse).get(
                     "_get_invite_state"
@@ -2250,7 +2250,7 @@ async def login_matrix_bot(
 
             # Test the API call that matrix-nio will make
             try:
-                from nio.api import Api  # type: ignore[import-untyped]
+                from nio.api import Api
 
                 method, path, data = Api.login(
                     user=localpart,

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -2242,7 +2242,6 @@ async def login_matrix_bot(
             logger.debug(f"Attempting login to {homeserver} as {username}")
             logger.debug("Login parameters:")
             logger.debug(f"  device_name: {device_name}")
-            logger.debug(f"  password length: {len(password) if password else 0}")
             logger.debug(f"  client.user: {client.user}")
             logger.debug(f"  client.homeserver: {client.homeserver}")
 
@@ -2282,7 +2281,7 @@ async def login_matrix_bot(
             # Debug: Log the response type and safe attributes only
             logger.debug(f"Login response type: {type(response).__name__}")
 
-            # Check specific attributes that should be present, masking sensitive data
+            # Check specific attributes that should be present
             for attr in [
                 "user_id",
                 "device_id",
@@ -2292,15 +2291,10 @@ async def login_matrix_bot(
             ]:
                 if hasattr(response, attr):
                     value = getattr(response, attr)
-                    if attr == "access_token" and value:
-                        # Mask access token for security
-                        masked_value = (
-                            f"{value[:8]}...{value[-4:]}"
-                            if len(value) > 12
-                            else "***masked***"
-                        )
+                    if attr == "access_token":
+                        # Only log presence of access token, never the value
                         logger.debug(
-                            f"Response.{attr}: {masked_value} (type: {type(value).__name__})"
+                            f"Response.{attr}: {'present' if value else 'not present'} (type: {type(value).__name__})"
                         )
                     else:
                         logger.debug(

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -14,14 +14,14 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Awaitable, Callable, Coroutine, cast
 
 # meshtastic is not marked py.typed; keep import-untyped for strict mypy.
-import meshtastic  # type: ignore[import-untyped]
-import meshtastic.ble_interface  # type: ignore[import-untyped]
-import meshtastic.serial_interface  # type: ignore[import-untyped]
-import meshtastic.tcp_interface  # type: ignore[import-untyped]
-import serial  # type: ignore[import-untyped]  # For serial port exceptions
-import serial.tools.list_ports  # type: ignore[import-untyped]  # Import serial tools for port listing
-from meshtastic.protobuf import mesh_pb2, portnums_pb2  # type: ignore[import-untyped]
-from pubsub import pub  # type: ignore[import-untyped]
+import meshtastic
+import meshtastic.ble_interface
+import meshtastic.serial_interface
+import meshtastic.tcp_interface
+import serial  # For serial port exceptions
+import serial.tools.list_ports  # Import serial tools for port listing
+from meshtastic.protobuf import mesh_pb2, portnums_pb2
+from pubsub import pub
 
 from mmrelay.config import get_meshtastic_config_value
 from mmrelay.constants.config import (
@@ -2566,7 +2566,7 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
     emoji_flag = "emoji" in decoded and decoded["emoji"] == EMOJI_FLAG_VALUE
 
     # Determine if this is a direct message to the relay node
-    from meshtastic.mesh_interface import BROADCAST_NUM  # type: ignore[import-untyped]
+    from meshtastic.mesh_interface import BROADCAST_NUM
 
     if not getattr(interface, "myInfo", None):
         logger.warning("Meshtastic interface missing myInfo; cannot determine node id")

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -8,8 +8,6 @@ from typing import Any
 
 # markdown has stubs in our env; avoid import-untyped so mypy --strict stays clean.
 import markdown
-
-# matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio import (
     MatrixRoom,
     ReactionEvent,

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -10,7 +10,7 @@ from typing import Any
 import markdown
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/debug_plugin.py
+++ b/src/mmrelay/plugins/debug_plugin.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/drop_plugin.py
+++ b/src/mmrelay/plugins/drop_plugin.py
@@ -3,8 +3,6 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from haversine import haversine
-
-# matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio import (
     MatrixRoom,
     ReactionEvent,

--- a/src/mmrelay/plugins/drop_plugin.py
+++ b/src/mmrelay/plugins/drop_plugin.py
@@ -2,10 +2,10 @@ import asyncio
 import re
 from typing import TYPE_CHECKING, Any
 
-from haversine import haversine  # type: ignore[import-untyped]
+from haversine import haversine
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,
@@ -20,7 +20,7 @@ from mmrelay.meshtastic_utils import connect_meshtastic
 from mmrelay.plugins.base_plugin import BasePlugin
 
 if TYPE_CHECKING:
-    from meshtastic.mesh_interface import MeshInterface  # type: ignore[import-untyped]
+    from meshtastic.mesh_interface import MeshInterface
 
 
 class Plugin(BasePlugin):

--- a/src/mmrelay/plugins/health_plugin.py
+++ b/src/mmrelay/plugins/health_plugin.py
@@ -3,7 +3,7 @@ import statistics
 from typing import TYPE_CHECKING, Any
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,
@@ -14,7 +14,7 @@ from nio import (  # type: ignore[import-untyped]
 from mmrelay.plugins.base_plugin import BasePlugin
 
 if TYPE_CHECKING:
-    from meshtastic.mesh_interface import MeshInterface  # type: ignore[import-untyped]
+    from meshtastic.mesh_interface import MeshInterface
 
 
 class Plugin(BasePlugin):

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -1,7 +1,8 @@
 import asyncio
+import importlib
 import os
 import re
-from typing import Any, cast
+from typing import Any, TYPE_CHECKING, cast
 
 import PIL.ImageDraw
 import s2sphere
@@ -41,13 +42,16 @@ def precision_bits_to_meters(bits: int) -> float | None:
     return S2_PRECISION_BITS_TO_METERS_CONSTANT * 0.5**bits
 
 
+if TYPE_CHECKING:
+    import cairo as cairo  # type: ignore[import-not-found]
+
 _cairo: Any | None
 try:
-    import cairo as _cairo
+    _cairo = importlib.import_module("cairo")
 except ImportError:  # pragma: no cover - optional dependency
     _cairo = None
 
-cairo: Any | None = _cairo
+cairo: Any | None = _cairo  # type: ignore[no-redef]
 
 
 logger = get_logger(__name__)

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -416,8 +416,8 @@ class Plugin(BasePlugin):
 
     def get_matrix_commands(self) -> list[str]:
         """
-        Return the Matrix command names registered by this plugin.
-
+        List the Matrix command names registered by this plugin.
+        
         Returns:
             list[str]: Command names the plugin handles; empty list if the plugin has no configured name.
         """

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -4,11 +4,11 @@ import re
 from typing import Any, cast
 
 import PIL.ImageDraw
-import s2sphere  # type: ignore[import-untyped]
-import staticmaps  # type: ignore[import-untyped]
+import s2sphere
+import staticmaps
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     AsyncClient,
     MatrixRoom,
     ReactionEvent,
@@ -42,7 +42,7 @@ def precision_bits_to_meters(bits: int) -> float | None:
 
 
 try:
-    import cairo  # type: ignore[import-not-found]
+    import cairo
 except ImportError:  # pragma: no cover - optional dependency
     cairo = None
 
@@ -406,7 +406,7 @@ class Plugin(BasePlugin):
     def get_matrix_commands(self) -> list[str]:
         """
         Return the Matrix command names registered by this plugin.
-        
+
         Returns:
             list[str]: Command names the plugin handles; empty list if the plugin has no configured name.
         """
@@ -417,7 +417,7 @@ class Plugin(BasePlugin):
     def get_mesh_commands(self) -> list[str]:
         """
         List mesh-specific command names handled by this plugin.
-        
+
         Returns:
             list[str]: Command name strings handled by the plugin; empty list if the plugin does not handle any mesh commands.
         """

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -41,10 +41,13 @@ def precision_bits_to_meters(bits: int) -> float | None:
     return S2_PRECISION_BITS_TO_METERS_CONSTANT * 0.5**bits
 
 
+_cairo: Any | None
 try:
-    import cairo
+    import cairo as _cairo
 except ImportError:  # pragma: no cover - optional dependency
-    cairo = None
+    _cairo = None
+
+cairo: Any | None = _cairo
 
 
 logger = get_logger(__name__)
@@ -173,7 +176,11 @@ class TextLabel(staticmaps.Object):  # type: ignore[misc]
         x, y = renderer.transformer().ll2pixel(self.latlng())
 
         ctx = renderer.context()
-        ctx.select_font_face("Sans", cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_NORMAL)
+        ctx.select_font_face(
+            "Sans",
+            getattr(cairo, "FONT_SLANT_NORMAL", 0),
+            getattr(cairo, "FONT_WEIGHT_NORMAL", 0),
+        )
 
         ctx.set_font_size(self._font_size)
         x_bearing, y_bearing, tw, th, _, _ = ctx.text_extents(self._text)

--- a/src/mmrelay/plugins/mesh_relay_plugin.py
+++ b/src/mmrelay/plugins/mesh_relay_plugin.py
@@ -7,10 +7,10 @@ import json
 import re
 from typing import Any, Iterable, cast
 
-from meshtastic import mesh_pb2  # type: ignore[import-untyped]
+from meshtastic import mesh_pb2
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/nodes_plugin.py
+++ b/src/mmrelay/plugins/nodes_plugin.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -2,10 +2,10 @@ import asyncio
 import re
 from typing import Any
 
-from meshtastic.mesh_interface import BROADCAST_NUM  # type: ignore[import-untyped]
+from meshtastic.mesh_interface import BROADCAST_NUM
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -6,7 +6,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -4,11 +4,11 @@ import re
 from datetime import datetime
 from typing import Any
 
-import requests  # type: ignore[import-untyped]
-from meshtastic.mesh_interface import BROADCAST_NUM  # type: ignore[import-untyped]
+import requests
+from meshtastic.mesh_interface import BROADCAST_NUM
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from nio import (  # type: ignore[import-untyped]
+from nio import (
     MatrixRoom,
     ReactionEvent,
     RoomMessageEmote,

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -6,8 +6,6 @@ from typing import Any
 
 import requests
 from meshtastic.mesh_interface import BROADCAST_NUM
-
-# matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio import (
     MatrixRoom,
     ReactionEvent,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2223,12 +2223,16 @@ class TestValidateE2EEDependencies(unittest.TestCase):
         )
 
     @patch("os.path.exists")
-    @patch("mmrelay.cli.logger")
-    def test_validate_credentials_json_file_read_error(self, mock_logger, mock_exists):
+    @patch("mmrelay.cli._get_logger")
+    def test_validate_credentials_json_file_read_error(
+        self, mock_get_logger, mock_exists
+    ):
         """Test validation when credentials.json cannot be read due to permissions or other IO error."""
         # Setup mocks
         config_path = "/home/user/.mmrelay/config.yaml"
         mock_exists.return_value = True
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
 
         # Mock file read error
         with patch("builtins.open", side_effect=IOError("Permission denied")):
@@ -2243,16 +2247,18 @@ class TestValidateE2EEDependencies(unittest.TestCase):
 
     @patch("os.path.exists")
     @patch("builtins.open", new_callable=mock_open)
-    @patch("mmrelay.cli.logger")
+    @patch("mmrelay.cli._get_logger")
     def test_validate_credentials_json_invalid_json(
-        self, mock_logger, mock_file, mock_exists
+        self, mock_get_logger, mock_file, mock_exists
     ):
         """Test validation when credentials.json contains invalid JSON."""
         # Setup mocks
         config_path = "/home/user/.mmrelay/config.yaml"
         mock_exists.return_value = True
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
         # Mock file with invalid JSON
-        mock_file.return_value.read.return_value = "{invalid json"
+        mock_file.return_value.read.return_value = "{invalid json}"
 
         # Import and call function
         from mmrelay.cli import _validate_credentials_json

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -513,7 +513,7 @@ class TestLogoutMatrixBot:
 
             result = await logout_matrix_bot(password="test_password")
 
-            mock_logger.exception.assert_called_once()
+            mock_logger.warning.assert_called_once()
             mock_temp_client.close.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -623,7 +623,11 @@ class TestLogoutMatrixBot:
 
     @pytest.mark.asyncio
     async def test_logout_matrix_bot_temp_session_logout_timeout(self):
-        """Test logout when temporary session logout times out (lines 691-698)."""
+        """
+        Verify logout_matrix_bot continues when a temporary session logout times out.
+        
+        Asserts that a TimeoutError raised by the temporary client's logout is handled by logging a warning and that logout_matrix_bot completes successfully (returns True).
+        """
         from mmrelay.cli_utils import logout_matrix_bot
 
         mock_credentials = {
@@ -748,7 +752,11 @@ class TestLogoutMatrixBot:
 
     @pytest.mark.asyncio
     async def test_logout_matrix_bot_server_logout_unclear_response(self):
-        """Test logout when server logout response is unclear (lines 752-755)."""
+        """
+        Verify that logout_matrix_bot proceeds with local cleanup and returns True when the server's logout response is not clearly structured.
+        
+        Asserts that a warning "Logout response unclear, proceeding with local cleanup." is logged and the function completes successfully.
+        """
         from mmrelay.cli_utils import logout_matrix_bot
 
         mock_credentials = {

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -625,7 +625,7 @@ class TestLogoutMatrixBot:
     async def test_logout_matrix_bot_temp_session_logout_timeout(self):
         """
         Verify logout_matrix_bot continues when a temporary session logout times out.
-        
+
         Asserts that a TimeoutError raised by the temporary client's logout is handled by logging a warning and that logout_matrix_bot completes successfully (returns True).
         """
         from mmrelay.cli_utils import logout_matrix_bot
@@ -754,7 +754,7 @@ class TestLogoutMatrixBot:
     async def test_logout_matrix_bot_server_logout_unclear_response(self):
         """
         Verify that logout_matrix_bot proceeds with local cleanup and returns True when the server's logout response is not clearly structured.
-        
+
         Asserts that a warning "Logout response unclear, proceeding with local cleanup." is logged and the function completes successfully.
         """
         from mmrelay.cli_utils import logout_matrix_bot


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR updates Kubernetes documentation and manifests, tightens type checking, refactors logging to avoid import-time side effects, improves secrets/password handling and Matrix logout error handling, and adds extensive tests for CLI/logout behavior. Most changes are internal and non‑breaking, but tests and tooling that patch module-level loggers need small updates (see migration notes).

## Key changes

Features
- Docs: Add "Version Selection" guidance (MMRELAY_VERSION semantics; image tag vs manifest retrieval; digest-overlay notes).
- Docs/Workflow: Move manifest references from ./mmrelay-k8s/ → ./deploy/k8s/ and switch static-manifest guidance to a download-based workflow using BASE_URL and MMRELAY_VERSION; use curl -f for manifest downloads.
- Docs: Map config retrieval "latest" → main and update sample_config.yaml reference logic.
- Docs: Interactive secrets creation prompts for Matrix homeserver, bot user ID, and password (non-echoed); use $EDITOR for edits.
- Docs/Storage: Document /data contents (credentials, logs, DB, E2EE store) and recommend mounting a PVC at /data.
- Kubernetes manifest: Set MMRELAY_BASE_DIR=/data in the container; update livenessProbe to a Python timestamp-style check; fix config download URL and handling of "latest".
- Config: Respect MMRELAY_BASE_DIR (and deprecated MMRELAY_DATA_DIR) environment variables to override base data directory.
- Tests: Add/expand async tests for logout_matrix_bot (timeouts, SSL failures, session cleanup), password verification, and lazy logger behavior; update tests to patch _get_logger().

Fixes
- CLI: Ensure newline after silent password input; prefer $EDITOR over hardcoded vi for editing secrets/config.
- Matrix/logout: Improve exception handling (use isinstance checks for aliased exceptions) and make cleanup more robust.
- Docs: Correct config download URL handling and clarify manifest vs image-tag usage.
- Packaging/typing: Add mypy.ini and migrate from broad in-code ignores to per-module mypy exceptions.

Refactors
- Logging: Replace eager module-level loggers with a lazy initializer pattern (_logger + _get_logger()) in cli.py and cli_utils.py; update call sites accordingly.
- Tests: Update tests to patch mmrelay.cli._get_logger and mmrelay.cli_utils._get_logger instead of concrete logger objects.
- Typing/import hygiene: Remove many # type: ignore[import-untyped] annotations across modules to improve type-checking visibility.
- Cairo rendering: Use getattr defaults for cairo font constants to avoid AttributeError when Cairo is absent.
- Minor type-safety and linting improvements throughout.

Breaking changes / migration notes
- Public APIs (function/class signatures) were not changed; runtime compatibility is preserved.
- Tests, mocks, or tooling that previously patched module-level logger objects must now patch the lazy getter (mmrelay.cli._get_logger or mmrelay.cli_utils._get_logger).
- Kubernetes users should:
  - Use deploy/k8s/ (not ./mmrelay-k8s/) for manifest workflows.
  - Set MMRELAY_VERSION/BASE_URL when downloading manifests (the docs show how).
  - Mount persistent storage at /data and rely on MMRELAY_BASE_DIR=/data in the container (MMRELAY_DATA_DIR is still accepted but deprecated).
- If CI or local scripts rely on the previous hardcoded editor or on logging fixtures, update them to the new behavior described above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->