### PR TITLE
Enhance BLE client disconnection safety with null-safe operations

### DIFF
--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1455,8 +1455,7 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
         # For BLE interfaces, explicitly disconnect the underlying BleakClient
         # to prevent stale connections in BlueZ (official library bug)
         # Check that client attribute exists AND is not None (handles forked lib close race)
-        client_obj = getattr(iface, "client", None)
-        if client_obj is not None:
+        if getattr(iface, "client", None) is not None:
             logger.debug(f"Explicitly disconnecting BLE client ({reason})")
 
             # Retry logic for client disconnect

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1473,11 +1473,11 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
                     # Check _exit_handler on the client object safely
                     client_exit_handler = getattr(client_obj, "_exit_handler", None)
                     if client_exit_handler:
-                        with contextlib.suppress(Exception):
+                        with contextlib.suppress(ValueError):
                             atexit.unregister(client_exit_handler)
                         with contextlib.suppress(AttributeError, TypeError):
                             client_obj._exit_handler = None
-                    with contextlib.suppress(Exception):
+                    with contextlib.suppress(ValueError):
                         atexit.unregister(disconnect_method)
 
                     if inspect.iscoroutinefunction(disconnect_method):

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1476,10 +1476,8 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
                     if client_exit_handler:
                         with contextlib.suppress(Exception):
                             atexit.unregister(client_exit_handler)
-                        try:
+                        with contextlib.suppress(AttributeError, TypeError):
                             client_obj._exit_handler = None
-                        except Exception:
-                            pass
                     with contextlib.suppress(Exception):
                         atexit.unregister(disconnect_method)
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1454,21 +1454,32 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
 
         # For BLE interfaces, explicitly disconnect the underlying BleakClient
         # to prevent stale connections in BlueZ (official library bug)
-        if hasattr(iface, "client"):
+        # Check that client attribute exists AND is not None (handles forked lib close race)
+        client_obj = getattr(iface, "client", None)
+        if client_obj is not None:
             logger.debug(f"Explicitly disconnecting BLE client ({reason})")
 
             # Retry logic for client disconnect
             max_client_retries = 2
             for attempt in range(max_client_retries):
+                # Re-check client before each attempt (may become None during close)
+                client_obj = getattr(iface, "client", None)
+                if client_obj is None:
+                    logger.debug(
+                        f"BLE client became None before attempt {attempt + 1} ({reason}), skipping"
+                    )
+                    break
                 try:
-                    disconnect_method = iface.client.disconnect
-                    if (
-                        hasattr(iface.client, "_exit_handler")
-                        and iface.client._exit_handler
-                    ):
+                    disconnect_method = client_obj.disconnect
+                    # Check _exit_handler on the client object safely
+                    client_exit_handler = getattr(client_obj, "_exit_handler", None)
+                    if client_exit_handler:
                         with contextlib.suppress(Exception):
-                            atexit.unregister(iface.client._exit_handler)
-                        iface.client._exit_handler = None
+                            atexit.unregister(client_exit_handler)
+                        try:
+                            client_obj._exit_handler = None
+                        except Exception:
+                            pass
                     with contextlib.suppress(Exception):
                         atexit.unregister(disconnect_method)
 

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -3042,7 +3042,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         _disconnect_ble_interface(None)
 
     @patch("mmrelay.meshtastic_utils.logger")
-    def test_disconnect_ble_interface_client_none(self, mock_logger):
+    def test_disconnect_ble_interface_client_none(self, _mock_logger):
         """Test _disconnect_ble_interface handles client=None (forked lib race)."""
         from mmrelay.meshtastic_utils import _disconnect_ble_interface
 
@@ -3064,18 +3064,21 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_interface handles client becoming None during disconnect."""
         from mmrelay.meshtastic_utils import _disconnect_ble_interface
 
+        class _SimulatedDisconnectError(RuntimeError):
+            """Test-specific error for simulated disconnect failures."""
+
         # Mock interface where client becomes None during disconnect attempts
         mock_iface = Mock()
         mock_client = Mock()
-        mock_client.disconnect = Mock(side_effect=Exception("First attempt fails"))
+        mock_client.disconnect = Mock(side_effect=_SimulatedDisconnectError())
         mock_client._exit_handler = None
         mock_iface.client = mock_client
         mock_iface.close = Mock()
 
         # Simulate client becoming None after first disconnect attempt
-        def side_effect_make_none(*args, **kwargs):
+        def side_effect_make_none(*_args, **_kwargs):
             mock_iface.client = None
-            raise Exception("Simulated disconnect failure")
+            raise _SimulatedDisconnectError()
 
         mock_client.disconnect.side_effect = side_effect_make_none
 

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -3070,7 +3070,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         # Mock interface where client becomes None during disconnect attempts
         mock_iface = Mock()
         mock_client = Mock()
-        mock_client.disconnect = Mock(side_effect=_SimulatedDisconnectError())
         mock_client._exit_handler = None
         mock_iface.client = mock_client
         mock_iface.close = Mock()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR makes BLE client disconnect logic more defensive to avoid exceptions when the BLE client reference becomes None during shutdown or a concurrent close (a "forked lib close race"). It replaces direct attribute access with null-safe retrievals, re-checks the client before each retry attempt, and adds tests that exercise client=None and client-becomes-None scenarios.

## Key Changes

Fixes:
- Guard BLE client access in _disconnect_ble_interface by using client_obj = getattr(iface, "client", None) instead of relying on iface.client directly.
- Re-fetch the client object before each disconnect retry and skip further attempts if the client has become None to avoid race-related exceptions.
- Use the cached client_obj when calling disconnect/close and when unregistering the client’s _exit_handler so the same checked reference is used for operations.
- Add logging and a control path that explicitly handles the case where the client becomes None during disconnect.

Refactors:
- Inline the getattr check for readability/conciseness.
- Reformat a long global declaration for improved readability.
- Use contextlib.suppress in atexit-related cleanup (keeps exception suppression targeted).

Tests:
- Added test_disconnect_ble_interface_client_none: verifies iface.close() is still invoked when iface.client is initially None.
- Added test_disconnect_ble_interface_client_becomes_none_during_disconnect: simulates client.disconnect raising and iface.client becoming None mid-sequence; asserts graceful handling, a debug log entry about the client becoming None, and that iface.close() is still called.

Other:
- Minor line-count changes: src/mmrelay/meshtastic_utils.py (+16/-8), tests/test_meshtastic_utils.py (+51).
- Commit message: refactor(ble): simplify client check and format global declarations; removed an obsolete disconnect mock from a test.

Breaking changes / migration:
- None. Changes are defensive and backward-compatible; no public API or migration steps required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->