### PR TITLE
Replace process-based health check with file-existence check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ USER mmrelay
 
 # Health check - ready file when configured, otherwise process detection
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD /bin/sh -c 'if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi'
+    CMD if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
 
 # Default command - uses config.yaml from volume mount
 CMD ["mmrelay", "--config", "/app/config.yaml", "--data-dir", "/app/data", "--logfile", "/app/logs/mmrelay.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ USER mmrelay
 
 # Health check - verifies application is ready via ready file
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD test -f /tmp/mmrelay/ready || exit 1
+    CMD test -f "$MMRELAY_READY_FILE"
 
 # Default command - uses config.yaml from volume mount
 CMD ["mmrelay", "--config", "/app/config.yaml", "--data-dir", "/app/data", "--logfile", "/app/logs/mmrelay.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,13 +68,14 @@ LABEL org.opencontainers.image.title="Meshtastic Matrix Relay" \
 ENV PYTHONUNBUFFERED=1
 ENV MPLCONFIGDIR=/tmp/matplotlib
 ENV PATH=/usr/local/bin:/usr/bin:/bin
+ENV MMRELAY_READY_FILE=/tmp/mmrelay/ready
 
 # Switch to non-root user
 USER mmrelay
 
-# Health check
+# Health check - verifies application is ready via ready file
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD pgrep -f mmrelay || exit 1
+    CMD test -f /tmp/mmrelay/ready || exit 1
 
 # Default command - uses config.yaml from volume mount
 CMD ["mmrelay", "--config", "/app/config.yaml", "--data-dir", "/app/data", "--logfile", "/app/logs/mmrelay.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,14 +68,13 @@ LABEL org.opencontainers.image.title="Meshtastic Matrix Relay" \
 ENV PYTHONUNBUFFERED=1
 ENV MPLCONFIGDIR=/tmp/matplotlib
 ENV PATH=/usr/local/bin:/usr/bin:/bin
-ENV MMRELAY_READY_FILE=/tmp/mmrelay/ready
 
 # Switch to non-root user
 USER mmrelay
 
-# Health check - verifies application is ready via ready file
+# Health check - ready file when configured, otherwise process detection
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD test -f "$MMRELAY_READY_FILE"
+    CMD /bin/sh -c 'if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi'
 
 # Default command - uses config.yaml from volume mount
 CMD ["mmrelay", "--config", "/app/config.yaml", "--data-dir", "/app/data", "--logfile", "/app/logs/mmrelay.log"]

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -321,12 +321,12 @@ MMRELAY_HOME=/path/to/your/data
 
 ## Health Checks
 
-The Docker image includes a built-in health check that verifies the application is ready to handle traffic. This is more reliable than simply checking if the process is running.
+The Docker image includes a built-in health check. By default it uses process detection (legacy behavior). You can opt in to the more reliable ready-file check by setting `MMRELAY_READY_FILE` to a writable path.
 
-**How it works:**
+**How it works (when ready-file mode is enabled):**
 
-- When MMRelay starts successfully, it creates a ready file at `/tmp/mmrelay/ready`
-- The health check (`test -f /tmp/mmrelay/ready`) verifies this file exists
+- When MMRelay starts successfully, it creates a ready file at the path you set (example: `/tmp/mmrelay/ready`)
+- The health check (`test -f "$MMRELAY_READY_FILE"`) verifies this file exists
 - The file is periodically updated (every 60 seconds by default) to show the application is still responsive
 - If the application crashes or fails to start, the ready file is not created/removed, and the container is marked as unhealthy
 
@@ -338,8 +338,10 @@ The Docker image includes a built-in health check that verifies the application 
 
 **Configuration (optional):**
 
-- The ready file path is set via `MMRELAY_READY_FILE=/tmp/mmrelay/ready` in the Dockerfile
+- Enable ready-file mode by setting `MMRELAY_READY_FILE` (example: `/tmp/mmrelay/ready`)
+- Ensure the path is writable; for read-only root filesystems, use a mounted path like `/app/data/mmrelay/ready`
 - To customize the heartbeat interval, set `MMRELAY_READY_HEARTBEAT_SECONDS` (default: 60)
+- The `docker-compose.yaml` includes commented examples under `environment` if you want to enable this in Compose
 
 ## Troubleshooting
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -341,7 +341,7 @@ The Docker image includes a built-in health check. By default it uses process de
 - Enable ready-file mode by setting `MMRELAY_READY_FILE` (example: `/tmp/mmrelay/ready`)
 - Ensure the path is writable; for read-only root filesystems, use a mounted path like `/app/data/mmrelay/ready`
 - To customize the heartbeat interval, set `MMRELAY_READY_HEARTBEAT_SECONDS` (default: 60)
-- The `docker-compose.yaml` includes commented examples under `environment` if you want to enable this in Compose
+- To enable this in Compose, add `MMRELAY_READY_FILE` to the `environment` section (e.g., `- MMRELAY_READY_FILE=/tmp/mmrelay/ready`)
 
 ## Troubleshooting
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -319,6 +319,28 @@ To use a different location, edit the `.env` file:
 MMRELAY_HOME=/path/to/your/data
 ```
 
+## Health Checks
+
+The Docker image includes a built-in health check that verifies the application is ready to handle traffic. This is more reliable than simply checking if the process is running.
+
+**How it works:**
+
+- When MMRelay starts successfully, it creates a ready file at `/tmp/mmrelay/ready`
+- The health check (`test -f /tmp/mmrelay/ready`) verifies this file exists
+- The file is periodically updated (every 60 seconds by default) to show the application is still responsive
+- If the application crashes or fails to start, the ready file is not created/removed, and the container is marked as unhealthy
+
+**Benefits:**
+
+- Tools like Watchtower wait for the health check to pass before considering an update successful
+- Docker compose shows health status in `docker compose ps`
+- Monitoring tools can detect when the app is truly ready vs. just running
+
+**Configuration (optional):**
+
+- The ready file path is set via `MMRELAY_READY_FILE=/tmp/mmrelay/ready` in the Dockerfile
+- To customize the heartbeat interval, set `MMRELAY_READY_HEARTBEAT_SECONDS` (default: 60)
+
 ## Troubleshooting
 
 ### Common Portainer Issues

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -11,18 +11,18 @@ This guide uses the static manifests in `deploy/k8s/`. Download them, create a S
 
 ## Version Selection
 
-The `MMRELAY_VERSION` variable is the container image tag (e.g., `1.2.9`). This is used for:
+The `MMRELAY_VERSION` variable is the container image tag (e.g., `1.2.10`). This is used for:
 
 - Setting the image tag in kustomization.yaml
 - Downloading the sample config.yaml
 
-The Kubernetes manifests shipped starting with **1.2.9**. This guide downloads them
+The Kubernetes manifests shipped starting with **1.2.10**. This guide downloads them
 from the `main` branch for convenience.
 
-- **Production**: Use a specific release tag (e.g., `1.2.9`) for stability and reproducibility.
+- **Production**: Use a specific release tag (e.g., `1.2.10`) for stability and reproducibility.
 - **Digest overlay**: Requires a release tag with published image digests.
 
-**Important**: The manifests require MMRelay **1.2.9+**.
+**Important**: The manifests require MMRelay **1.2.10+**.
 
 ## Quick Start (static manifests)
 
@@ -31,8 +31,8 @@ from the `main` branch for convenience.
 mkdir -p mmrelay
 cd mmrelay
 
-# Set the version for the container image tag (manifests require MMRelay 1.2.9 or later)
-export MMRELAY_VERSION=1.2.9
+# Set the version for the container image tag (manifests require MMRelay 1.2.10 or later)
+export MMRELAY_VERSION=1.2.10
 
 # Download manifests from the main branch
 BASE_URL="https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/main/deploy/k8s"
@@ -48,7 +48,7 @@ kubectl create namespace mmrelay --dry-run=client -o yaml | kubectl apply -f -
 
 # Edit namespace/image tag in kustomization.yaml
 ${EDITOR:-vi} ./deploy/k8s/kustomization.yaml
-# Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION}); manifests require 1.2.9+
+# Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION}); manifests require 1.2.10+
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
 

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -11,18 +11,18 @@ This guide uses the static manifests in `deploy/k8s/`. Download them, create a S
 
 ## Version Selection
 
-The `MMRELAY_VERSION` variable is the container image tag (e.g., `1.2.10`). This is used for:
+The `MMRELAY_VERSION` variable is the container image tag (e.g., `1.2.9`). This is used for:
 
 - Setting the image tag in kustomization.yaml
 - Downloading the sample config.yaml
 
-The Kubernetes manifests shipped starting with **1.2.10**. This guide downloads them
+The Kubernetes manifests shipped starting with **1.2.9**. This guide downloads them
 from the `main` branch for convenience.
 
-- **Production**: Use a specific release tag (e.g., `1.2.10`) for stability and reproducibility.
+- **Production**: Use a specific release tag (e.g., `1.2.9`) for stability and reproducibility.
 - **Digest overlay**: Requires a release tag with published image digests.
 
-**Important**: The manifests require MMRelay **1.2.10+**.
+**Important**: The manifests require MMRelay **1.2.9+**.
 
 ## Quick Start (static manifests)
 
@@ -31,8 +31,8 @@ from the `main` branch for convenience.
 mkdir -p mmrelay
 cd mmrelay
 
-# Set the version for the container image tag (manifests require MMRelay 1.2.10 or later)
-export MMRELAY_VERSION=1.2.10
+# Set the version for the container image tag (manifests require MMRelay 1.2.9 or later)
+export MMRELAY_VERSION=1.2.9
 
 # Download manifests from the main branch
 BASE_URL="https://raw.githubusercontent.com/jeremiah-k/meshtastic-matrix-relay/main/deploy/k8s"
@@ -48,7 +48,7 @@ kubectl create namespace mmrelay --dry-run=client -o yaml | kubectl apply -f -
 
 # Edit namespace/image tag in kustomization.yaml
 ${EDITOR:-vi} ./deploy/k8s/kustomization.yaml
-# Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION}); manifests require 1.2.10+
+# Set the image newTag to match your MMRELAY_VERSION (${MMRELAY_VERSION}); manifests require 1.2.9+
 # If you change the namespace above, update the --namespace/-n flags below to match
 # for secret creation and kubectl apply/get/log commands.
 

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -948,7 +948,6 @@ class TestLogUtils(unittest.TestCase):
 
         with patch("mmrelay.runtime_utils.is_running_as_service", return_value=False):
             # Force reimport
-            import importlib
 
             import mmrelay.log_utils as lu_reloaded
 
@@ -985,7 +984,6 @@ class TestLogUtils(unittest.TestCase):
             del sys.modules["mmrelay.log_utils"]
 
         with patch("mmrelay.runtime_utils.is_running_as_service", return_value=True):
-            import importlib
 
             import mmrelay.log_utils as lu_reloaded
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR adds an opt-in readiness-file health check to the Docker image while preserving the existing process-based health check, documents the new mode, and includes a small test cleanup. When MMRELAY_READY_FILE is set and the designated file exists the Docker HEALTHCHECK passes; if the environment variable is unset or empty, the HEALTHCHECK falls back to the legacy pgrep-based check.

Key Changes

Features:
- Introduced an opt-in ready-file health check controlled by MMRELAY_READY_FILE.
- Application now supports creating/updating a ready file while healthy and removing it on shutdown/crash (guarded as a no-op when MMRELAY_READY_FILE is unset).
- Added documentation (docs/DOCKER.md) with a "Health Checks" section describing:
  - How to enable ready-file mode (environment examples for Docker Compose).
  - Heartbeat behavior and the MMRELAY_READY_HEARTBEAT_SECONDS option (default 60s).
  - Writable-path considerations for read-only root filesystems.

Fixes:
- Docker HEALTHCHECK now conditionally checks the ready file when MMRELAY_READY_FILE is set, providing a reliable opt-in indicator compatible with tools like Watchtower and docker-compose health checks.

Refactors / Implementation details:
- Dockerfile HEALTHCHECK changed from:
  - pgrep -f mmrelay || exit 1
  to:
  - if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
  (preserves exit codes and Watchtower behavior; only changes output suppression when falling back).
- Ready-file operations implemented with attention to atomic writes, error handling, and permissions.
- Tests added/updated to cover ready-file creation, heartbeat updates, removal, and no-op behavior when MMRELAY_READY_FILE is unset.
- Minor test cleanup in tests/test_log_utils.py (removed explicit importlib usage; reimports via sys.modules manipulation).

Breaking Changes / Migration Notes

- Opt-in only: No behavior change by default. Existing Docker setups that do not set MMRELAY_READY_FILE continue to use the legacy pgrep-based health check unchanged.
- To enable ready-file mode, set MMRELAY_READY_FILE to a writable path (use a volume or writable directory); consider MMRELAY_READY_HEARTBEAT_SECONDS for heartbeat tuning.
- Watchtower and update mechanisms remain compatible; exit-code semantics are preserved so update behavior does not change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->