### PR TITLE
Fix path regressions and add Rich library to packaging

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -56,7 +56,7 @@ jobs:
           pip install pyinstaller
 
       - name: Build executable
-        run: pyinstaller --name=mmrelay.exe --onefile --console src/mmrelay/main.py
+        run: pyinstaller --name=mmrelay.exe --onefile --console --hidden-import=rich._unicode_data src/mmrelay/main.py
 
       - name: Build installer
         uses: nadeemjazmawe/inno-setup-action-cli@v6.0.5

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -56,7 +56,7 @@ jobs:
           pip install pyinstaller
 
       - name: Build executable
-        run: pyinstaller --name=mmrelay.exe --onefile --console --hidden-import=rich._unicode_data src/mmrelay/main.py
+        run: pyinstaller --name=mmrelay.exe --onefile --console --collect-all rich src/mmrelay/main.py
 
       - name: Build installer
         uses: nadeemjazmawe/inno-setup-action-cli@v6.0.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ LABEL org.opencontainers.image.title="Meshtastic Matrix Relay" \
 ENV PYTHONUNBUFFERED=1
 ENV MPLCONFIGDIR=/tmp/matplotlib
 ENV PATH=/usr/local/bin:/usr/bin:/bin
+ENV MMRELAY_DATA_DIR=/app/data
 ENV MMRELAY_CREDENTIALS_PATH=/app/data/credentials.json
 
 # Switch to non-root user
@@ -78,4 +79,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
 
 # Default command - uses config.yaml from volume mount
-CMD ["mmrelay", "--config", "/app/config.yaml", "--base-dir", "/app", "--logfile", "/app/data/logs/mmrelay.log"]
+CMD ["mmrelay", "--config", "/app/config.yaml", "--logfile", "/app/data/logs/mmrelay.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,4 +79,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
 
 # Default command - uses config.yaml from volume mount
-CMD ["mmrelay", "--config", "/app/config.yaml", "--logfile", "/app/data/logs/mmrelay.log"]
+CMD ["mmrelay", "--config", "/app/config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
 
 # Default command - uses config.yaml from volume mount
-CMD ["mmrelay", "--config", "/app/config.yaml", "--data-dir", "/app/data", "--logfile", "/app/logs/mmrelay.log"]
+CMD ["mmrelay", "--config", "/app/config.yaml", "--base-dir", "/app/data", "--logfile", "/app/logs/mmrelay.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
 
 # Default command - uses config.yaml from volume mount
-CMD ["mmrelay", "--config", "/app/config.yaml", "--base-dir", "/app/data", "--logfile", "/app/logs/mmrelay.log"]
+CMD ["mmrelay", "--config", "/app/config.yaml", "--base-dir", "/app", "--logfile", "/app/logs/mmrelay.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ LABEL org.opencontainers.image.title="Meshtastic Matrix Relay" \
 ENV PYTHONUNBUFFERED=1
 ENV MPLCONFIGDIR=/tmp/matplotlib
 ENV PATH=/usr/local/bin:/usr/bin:/bin
+ENV MMRELAY_CREDENTIALS_PATH=/app/data/credentials.json
 
 # Switch to non-root user
 USER mmrelay
@@ -77,4 +78,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
 
 # Default command - uses config.yaml from volume mount
-CMD ["mmrelay", "--config", "/app/config.yaml", "--base-dir", "/app", "--logfile", "/app/logs/mmrelay.log"]
+CMD ["mmrelay", "--config", "/app/config.yaml", "--base-dir", "/app", "--logfile", "/app/data/logs/mmrelay.log"]

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -499,7 +499,7 @@ If you want to opt in to the new layout (`base_dir` with data under
 `<base_dir>/data`), follow these steps:
 
 1. Update your volume mount to map your host directory to `/app` (not
-   `/app/data`), or add an additional `/app` mount so logs/store are persisted.
+   `/app/data`), or add a `/app` mount so logs/store are persisted.
 2. Set `MMRELAY_BASE_DIR=/app` (or add `--base-dir /app` to the command).
 3. If you want credentials in the new default location, move
    `credentials.json` to `/app/credentials.json` (or keep the old location and

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -504,9 +504,7 @@ If you want to opt in to the new layout (`base_dir` with data under
 3. If you want credentials in the new default location, move
    `credentials.json` to `/app/credentials.json` (or keep the old location and
    set `MMRELAY_CREDENTIALS_PATH=/app/data/credentials.json`).
-4. On first startup, MMRelay will attempt to migrate `meshtastic.sqlite`
-   (plus `-wal`/`-shm`) from `/app/meshtastic.sqlite` to
-   `/app/data/meshtastic.sqlite` if the new path is empty.
+4. On first startup, MMRelay will attempt to migrate legacy database files (including `-wal`/`-shm` sidecars) to the new location at `/app/data/meshtastic.sqlite`. This handles common legacy paths like `/app/data/data/meshtastic.sqlite` (from older Docker setups) and `/app/meshtastic.sqlite`.
 5. Logs and E2EE store files will default to `/app/logs` and `/app/store`.
    To keep them under `/app/data`, set `logging.filename` and
    `matrix.e2ee.store_path` accordingly.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -489,6 +489,28 @@ Look for messages like:
 - "Using credentials from ~/.mmrelay/credentials.json"
 - "Found X encrypted rooms out of Y total rooms"
 
+## Migrating to the New Layout (Optional)
+
+By default, the Docker image uses the legacy layout so existing setups keep
+working. That means `base_dir == data_dir` and everything lives under
+`/app/data`.
+
+If you want to opt in to the new layout (`base_dir` with data under
+`<base_dir>/data`), follow these steps:
+
+1. Update your volume mount to map your host directory to `/app` (not
+   `/app/data`), or add an additional `/app` mount so logs/store are persisted.
+2. Set `MMRELAY_BASE_DIR=/app` (or add `--base-dir /app` to the command).
+3. If you want credentials in the new default location, move
+   `credentials.json` to `/app/credentials.json` (or keep the old location and
+   set `MMRELAY_CREDENTIALS_PATH=/app/data/credentials.json`).
+4. On first startup, MMRelay will attempt to migrate `meshtastic.sqlite`
+   (plus `-wal`/`-shm`) from `/app/meshtastic.sqlite` to
+   `/app/data/meshtastic.sqlite` if the new path is empty.
+5. Logs and E2EE store files will default to `/app/logs` and `/app/store`.
+   To keep them under `/app/data`, set `logging.filename` and
+   `matrix.e2ee.store_path` accordingly.
+
 ## Updates
 
 **Prebuilt images:**

--- a/docs/dev/DATA_LAYOUT_MIGRATION.md
+++ b/docs/dev/DATA_LAYOUT_MIGRATION.md
@@ -1,0 +1,101 @@
+# Data Layout Migration Notes (v1.2.x)
+
+## Summary
+
+MMRelay currently supports two filesystem layouts:
+
+1. Legacy layout (v1.2.9 and earlier):
+   - base_dir == data_dir
+   - Linux/macOS default: `~/.mmrelay`
+   - Common files:
+     - `~/.mmrelay/credentials.json`
+     - `~/.mmrelay/meshtastic.sqlite` (+ `-wal`, `-shm`)
+     - `~/.mmrelay/logs/`
+     - `~/.mmrelay/plugins/`
+     - `~/.mmrelay/store/`
+
+2. New layout (v1.2.10+ opt-in):
+   - base_dir is the root; data lives under `<base_dir>/data`
+   - Common files:
+     - `<base_dir>/credentials.json`
+     - `<base_dir>/data/meshtastic.sqlite` (+ `-wal`, `-shm`)
+     - `<base_dir>/logs/`
+     - `<base_dir>/plugins/`
+     - `<base_dir>/store/`
+
+The current release prioritizes backward compatibility and safe upgrades.
+
+## Current Behavior (as of v1.2.11)
+
+### Directory resolution
+
+- `base_dir`:
+  - `MMRELAY_BASE_DIR` / `--base-dir` takes precedence.
+  - Legacy override `MMRELAY_DATA_DIR` / `--data-dir` is respected.
+  - Linux/macOS default: `~/.mmrelay`
+  - Windows default: `platformdirs.user_data_dir(APP_NAME, APP_AUTHOR)`
+
+- `data_dir`:
+  - If `MMRELAY_DATA_DIR` is set, use that path (or its legacy `data/` child if it already contains data).
+  - Otherwise:
+    - Linux/macOS default: `<base_dir>/data`
+    - Windows default: platformdirs user data dir **unless** new layout is explicitly enabled.
+
+### Credential lookup
+
+- Order:
+  1. Explicit path (`MMRELAY_CREDENTIALS_PATH`, `credentials_path` in config)
+  2. Config-adjacent path
+  3. Base/data fallbacks
+
+This matches runtime lookup and the `mmrelay auth status` CLI.
+
+### Docker defaults
+
+- Docker uses the legacy layout by default to avoid breaking existing installs.
+- The image sets `MMRELAY_DATA_DIR=/app/data` and relies on the dynamic log path.
+- This keeps:
+  - `credentials.json` at `/app/data/credentials.json`
+  - DB at `/app/data/meshtastic.sqlite`
+  - logs under `/app/data/logs`
+
+### Database migration
+
+- Migration is executed inside `get_db_path()`.
+- When new layout is explicitly enabled and the new DB path does not exist:
+  - We select the most recently updated legacy DB (including `-wal`/`-shm`) and move it to the new location.
+  - This includes migrating the `-wal` and `-shm` sidecars when present.
+
+This is intentionally _inside_ `get_db_path()` to ensure any code path that needs the DB triggers migration, even if it does not go through `main.py`.
+
+## Why We Kept Migration in get_db_path()
+
+For safety in this release, we avoid introducing ordering dependencies. Moving migration to startup (e.g., `main.py`) risks missing migrations in non-standard entry points or tooling that calls DB helpers directly.
+
+Keeping the migration in `get_db_path()`:
+
+- Ensures migration occurs when the DB is actually needed.
+- Avoids breaking unexpected execution paths.
+- Preserves backwards-compatible behavior with minimal risk.
+
+## Future Cleanup (Potential Breaking Changes)
+
+If we want to fully unify the layout in a future major release, the safest path looks like this:
+
+1. Deprecate and remove `MMRELAY_DATA_DIR` / `--data-dir`.
+2. Make the new layout the only layout (base_dir root + `<base_dir>/data`).
+3. Move migration to an explicit startup step or a dedicated command (e.g., `mmrelay config migrate-layout`).
+4. Update Docker defaults to mount the host directory at `/app` and drop legacy fallbacks.
+5. Require credentials at `<base_dir>/credentials.json` (or explicit path).
+6. Update all docs and samples to match the unified layout.
+
+This would be a breaking change, so it should be staged with clear warnings and a release note migration guide.
+
+## Optional Opt-In Today
+
+To use the new layout now (without breaking legacy users):
+
+1. Set `MMRELAY_BASE_DIR=/app` (or use `--base-dir /app`).
+2. Ensure a persistent mount at `/app` (not just `/app/data`).
+3. Move `meshtastic.sqlite` to `<base_dir>/data/meshtastic.sqlite` if needed.
+4. Move `credentials.json` to `<base_dir>/credentials.json` (or set `MMRELAY_CREDENTIALS_PATH`).

--- a/docs/dev/DATA_LAYOUT_MIGRATION.md
+++ b/docs/dev/DATA_LAYOUT_MIGRATION.md
@@ -50,6 +50,16 @@ The current release prioritizes backward compatibility and safe upgrades.
 
 This matches runtime lookup and the `mmrelay auth status` CLI.
 
+### Credential saving
+
+- Saving is intentionally conservative for safety:
+  - If an explicit path is provided, it is always used.
+  - Otherwise, we prefer the config directory (if known) and then `base_dir`.
+  - We only fall back to the `data_dir` path if earlier candidates are not writable.
+
+This keeps legacy installs stable and avoids unexpectedly writing credentials into a
+new location without explicit opt-in.
+
 ### Docker defaults
 
 - Docker uses the legacy layout by default to avoid breaking existing installs.
@@ -90,6 +100,16 @@ If we want to fully unify the layout in a future major release, the safest path 
 6. Update all docs and samples to match the unified layout.
 
 This would be a breaking change, so it should be staged with clear warnings and a release note migration guide.
+
+## Known Rough Edges (Still Needs Work)
+
+These areas are still evolving and should not be considered final:
+
+- The layout is not fully uniform yet (credentials vs data/store/logs).
+- Save vs. load paths are intentionally conservative but still need a unified long-term policy.
+- Migration currently lives in `get_db_path()` for safety; an explicit migration step is preferable.
+- Docker defaults remain legacy-first; a fully new-layout container defaults plan is pending.
+- Windows layout behavior differs between legacy/new modes and needs consolidation.
 
 ## Optional Opt-In Today
 

--- a/scripts/mmrelay.iss
+++ b/scripts/mmrelay.iss
@@ -213,7 +213,7 @@ begin
   // Create setup-auth.bat for easy authentication setup
   batch_file := '@echo off' + #13#10 +
                 'echo Setting up Matrix authentication...' + #13#10 +
-                '"' + sAppDir + '\mmrelay.exe" auth login --base-dir "' + sAppDir + '"' + #13#10 +
+                '"' + sAppDir + '\mmrelay.exe" --base-dir "' + sAppDir + '" auth login' + #13#10 +
                 'pause';
 
   if Not SaveStringToFile(sAppDir + '\setup-auth.bat', batch_file, false) then
@@ -224,7 +224,7 @@ begin
   // Create logout.bat for easy authentication cleanup
   batch_file := '@echo off' + #13#10 +
                 'echo Logging out from Matrix authentication...' + #13#10 +
-                '"' + sAppDir + '\mmrelay.exe" auth logout --base-dir "' + sAppDir + '"' + #13#10 +
+                '"' + sAppDir + '\mmrelay.exe" --base-dir "' + sAppDir + '" auth logout' + #13#10 +
                 'pause';
 
   if Not SaveStringToFile(sAppDir + '\logout.bat', batch_file, false) then

--- a/scripts/mmrelay.iss
+++ b/scripts/mmrelay.iss
@@ -213,7 +213,7 @@ begin
   // Create setup-auth.bat for easy authentication setup
   batch_file := '@echo off' + #13#10 +
                 'echo Setting up Matrix authentication...' + #13#10 +
-                '"' + sAppDir + '\mmrelay.exe" auth login --data-dir "' + sAppDir + '"' + #13#10 +
+                '"' + sAppDir + '\mmrelay.exe" auth login --base-dir "' + sAppDir + '"' + #13#10 +
                 'pause';
 
   if Not SaveStringToFile(sAppDir + '\setup-auth.bat', batch_file, false) then
@@ -224,7 +224,7 @@ begin
   // Create logout.bat for easy authentication cleanup
   batch_file := '@echo off' + #13#10 +
                 'echo Logging out from Matrix authentication...' + #13#10 +
-                '"' + sAppDir + '\mmrelay.exe" auth logout --data-dir "' + sAppDir + '"' + #13#10 +
+                '"' + sAppDir + '\mmrelay.exe" auth logout --base-dir "' + sAppDir + '"' + #13#10 +
                 'pause';
 
   if Not SaveStringToFile(sAppDir + '\logout.bat', batch_file, false) then

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -2,4 +2,4 @@
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
 
-__version__ = "1.2.10"
+__version__ = "1.2.11"

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -2,4 +2,4 @@
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
 
-__version__ = "1.2.11"
+__version__ = "1.2.10"

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -1590,8 +1590,8 @@ def handle_auth_status(args: argparse.Namespace) -> int:
     """
     Display Matrix authentication status by locating and validating a credentials.json file.
 
-    Searches for credentials.json adjacent to each discovered config file (in preference order),
-    then falls back to the application's base directory. If a readable credentials.json is found,
+    Searches for credentials.json in the same locations as the main runtime (explicit path,
+    config-adjacent files, then base/data directory fallbacks). If a readable credentials.json is found,
     prints its path and the `homeserver`, `user_id`, and `device_id` values and reports validity.
 
     Parameters:

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -1621,7 +1621,6 @@ def handle_auth_status(args: argparse.Namespace) -> int:
     candidate_paths = get_credentials_search_paths(
         explicit_path=explicit_path,
         config_paths=config_paths,
-        include_base_data=False,
     )
 
     for credentials_path in candidate_paths:

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -1616,7 +1616,7 @@ def handle_auth_status(args: argparse.Namespace) -> int:
     print("============================")
 
     config_paths = get_config_paths(args)
-    config_data = load_config(args=args)
+    config_data = load_config(args=args, config_paths=config_paths)
     explicit_path = get_explicit_credentials_path(config_data)
     candidate_paths = get_credentials_search_paths(
         explicit_path=explicit_path,

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -1621,6 +1621,7 @@ def handle_auth_status(args: argparse.Namespace) -> int:
     candidate_paths = get_credentials_search_paths(
         explicit_path=explicit_path,
         config_paths=config_paths,
+        include_base_data=False,
     )
 
     for credentials_path in candidate_paths:

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -280,8 +280,11 @@ def get_data_dir(*, create: bool = True) -> str:
         else:
             data_dir = data_override
     else:
-        base_dir = get_base_dir()
-        data_dir = os.path.join(base_dir, "data")
+        if sys.platform == "win32" and not is_new_layout_enabled():
+            data_dir = platformdirs.user_data_dir(APP_NAME, APP_AUTHOR)
+        else:
+            base_dir = get_base_dir()
+            data_dir = os.path.join(base_dir, "data")
 
     if create:
         try:

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -883,9 +883,9 @@ def save_credentials(
 
             # Verify the file was actually created
             if os.path.exists(candidate):
-                logger.debug(f"Verified credentials.json exists at {candidate}")
+                logger.debug("Verified credentials.json exists at %s", candidate)
             else:
-                logger.error(f"Failed to create credentials.json at {candidate}")
+                logger.error("Failed to create credentials.json at %s", candidate)
             return None
 
         if last_error:
@@ -898,7 +898,7 @@ def save_credentials(
             logger.error(
                 "On Windows, ensure the application has write permissions to the user data directory"
             )
-            logger.error(f"Attempted path: {config_dir}")
+            logger.error("Attempted path: %s", config_dir)
 
 
 # Use structured logging to align with the rest of the codebase.

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -278,11 +278,12 @@ def get_data_dir() -> str:
         else:
             data_dir = data_override
     else:
-        base_dir = get_base_dir()
         if sys.platform in ["linux", "darwin"]:
+            base_dir = get_base_dir()
             data_dir = os.path.join(base_dir, "data")
         else:
             if is_new_layout_enabled():
+                base_dir = get_base_dir()
                 data_dir = os.path.join(base_dir, "data")
             else:
                 data_dir = platformdirs.user_data_dir(APP_NAME, APP_AUTHOR)

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -1033,15 +1033,20 @@ def set_config(module: Any, passed_config: dict[str, Any]) -> dict[str, Any]:
     return passed_config
 
 
-def load_config(config_file: str | None = None, args: Any = None) -> dict[str, Any]:
+def load_config(
+    config_file: str | None = None,
+    args: Any = None,
+    config_paths: list[str] | None = None,
+) -> dict[str, Any]:
     """
     Load the application configuration from a YAML file or from environment variables.
 
-    If `config_file` is provided and readable, that file is used; otherwise candidate locations from `get_config_paths(args)` are searched in order and the first readable YAML file is loaded. Empty or null YAML content is treated as an empty dictionary. Environment-derived overrides are merged into the loaded configuration. The function updates the module-level `relay_config` and `config_path` to reflect the resulting configuration source.
+    If `config_file` is provided and readable, that file is used; otherwise candidate locations from `config_paths` or `get_config_paths(args)` are searched in order and the first readable YAML file is loaded. Empty or null YAML content is treated as an empty dictionary. Environment-derived overrides are merged into the loaded configuration. The function updates the module-level `relay_config` and `config_path` to reflect the resulting configuration source.
 
     Parameters:
-        config_file (str | None): Path to a specific YAML configuration file to load. If `None`, candidate paths from `get_config_paths(args)` are used.
-        args: Parsed command-line arguments forwarded to `get_config_paths()` to influence search order.
+        config_file (str | None): Path to a specific YAML configuration file to load. If `None`, candidate paths from `config_paths` or `get_config_paths(args)` are used.
+        args: Parsed command-line arguments forwarded to `get_config_paths()` to influence search order when `config_paths` is not provided.
+        config_paths: Optional list of config paths to search instead of calling `get_config_paths(args)`.
 
     Returns:
         dict: The resulting configuration dictionary. Returns an empty dict if no configuration is found or a file read/parse error occurs.
@@ -1066,7 +1071,8 @@ def load_config(config_file: str | None = None, args: Any = None) -> dict[str, A
             return {}
 
     # Otherwise, search for a config file
-    config_paths = get_config_paths(args)
+    if config_paths is None:
+        config_paths = get_config_paths(args)
 
     # Try each config path in order until we find one that exists
     for path in config_paths:

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -1,4 +1,5 @@
 import json
+import ntpath
 import os
 import re
 import sys
@@ -389,7 +390,7 @@ def get_log_dir() -> str:
         log_dir = os.path.join(get_base_dir(), "logs")
     else:
         if _has_any_dir_override():
-            log_dir = os.path.join(get_base_dir(), "logs")
+            log_dir = ntpath.join(get_base_dir(), "logs")
         else:
             log_dir = platformdirs.user_log_dir(APP_NAME, APP_AUTHOR)
 
@@ -413,9 +414,9 @@ def get_e2ee_store_dir() -> str:
         store_dir = os.path.join(get_base_dir(), "store")
     else:
         if _has_any_dir_override():
-            store_dir = os.path.join(get_base_dir(), "store")
+            store_dir = ntpath.join(get_base_dir(), "store")
         else:
-            store_dir = os.path.join(
+            store_dir = ntpath.join(
                 platformdirs.user_data_dir(APP_NAME, APP_AUTHOR), "store"
             )
 
@@ -802,8 +803,6 @@ def load_credentials() -> dict[str, Any] | None:
                 if not debug_dir or debug_dir in seen:
                     continue
                 seen.add(debug_dir)
-                if not os.path.exists(debug_dir):
-                    continue
                 try:
                     files = os.listdir(debug_dir)
                     logger.debug("Directory contents of %s: %s", debug_dir, files)

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -951,8 +951,7 @@ def save_credentials(
         if sys.platform == "win32":
             logger.exception(
                 "Error saving credentials.json to %s. On Windows, ensure the application "
-                "has write permissions to the user data directory. Attempted path: %s",
-                config_dir,
+                "has write permissions to the user data directory.",
                 config_dir,
             )
         else:

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -184,6 +184,7 @@ def get_credentials_search_paths(
     Parameters:
         explicit_path (str | None): Optional explicit file or directory path.
         config_paths (Iterable[str] | None): Optional iterable of config file paths.
+        include_base_data (bool): When True, include base/data directory fallbacks.
 
     Returns:
         list[str]: Ordered candidate credential file paths.
@@ -258,9 +259,10 @@ def get_data_dir(*, create: bool = True) -> str:
     If the legacy data-dir override is set (MMRELAY_DATA_DIR/--data-dir), that path
     is used directly unless a legacy "<override>/data" directory already contains
     data (database/plugins/store), in which case that legacy directory is used to
-    preserve existing layouts. Without an override, the legacy layout is used
-    (data_dir == base_dir) unless the new layout is explicitly enabled via
-    MMRELAY_BASE_DIR/--base-dir, in which case "<base_dir>/data" is used.
+    preserve existing layouts. Without an override, Linux/macOS use
+    "<base_dir>/data". On Windows, the platform-specific user data directory is
+    used unless the new layout is explicitly enabled via MMRELAY_BASE_DIR/--base-dir,
+    in which case "<base_dir>/data" is used.
 
     Returns:
         Absolute path to the data directory.

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -139,13 +139,23 @@ def _migrate_legacy_db_if_needed(
                     legacy_path,
                     default_path,
                 )
+                existing = [
+                    path for path in (default_path, legacy_path) if os.path.exists(path)
+                ]
+                if existing:
+                    chosen = max(existing, key=_active_mtime)
+                    logger.warning(
+                        "Using database at %s after partial rollback.", chosen
+                    )
+                    return chosen
+                return legacy_path
             else:
                 logger.warning(
                     "Database migration rolled back due to sidecar failures. "
                     "Database remains at %s.",
                     legacy_path,
                 )
-            return legacy_path
+                return legacy_path
         logger.info(
             "Migrated database from legacy location %s to %s",
             legacy_path,

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -187,13 +187,13 @@ def _should_log_to_file(args: argparse.Namespace | None) -> bool:
 
 def _resolve_log_file(args: argparse.Namespace | None) -> str:
     """
-    Determine the log file path, preferring a CLI-provided value, then the configuration, and falling back to the default log directory.
-
+    Choose the log file path using the following precedence: CLI `args.logfile`, configuration `logging.filename`, or the default "<log_dir>/mmrelay.log".
+    
     Parameters:
-        args: An argparse-like namespace or object; may be None. If present and has a truthy `logfile` attribute, that value is used.
-
+        args (argparse.Namespace | None): Optional argparse-like namespace; if present and has a truthy `logfile` attribute, that value is selected.
+    
     Returns:
-        str: Filesystem path to the log file chosen according to the precedence: `args.logfile`, `config["logging"]["filename"]`, or the default "<log_dir>/mmrelay.log".
+        str: Filesystem path selected for logging.
     """
     logfile = getattr(args, "logfile", None) if args is not None else None
     if isinstance(logfile, str) and logfile:
@@ -208,8 +208,12 @@ def _resolve_log_file(args: argparse.Namespace | None) -> str:
 
 def get_log_dir() -> str:
     """
-    Lazily resolve the log directory to avoid circular imports during startup.
-    """
+    Return the filesystem directory to use for application logs, resolved lazily.
+    
+    This function obtains the log directory from the application's configuration helper if available; if the configuration helper cannot be imported, it falls back to the current working directory.
+    
+    Returns:
+        log_dir (str): Path to the directory where logs should be written."""
     try:
         from mmrelay.config import get_log_dir as _get_log_dir
     except ImportError:
@@ -222,14 +226,12 @@ def _configure_logger(
 ) -> logging.Logger:
     """
     Configure a logger's level and attach console and optional rotating file handlers based on the application's configuration and optional CLI arguments.
-
-    Updates internal generation tracking for the logger and, when configuring the main application logger, updates the module-level log file path.
-
+    
     Parameters:
         args (argparse.Namespace | None): Optional CLI arguments that can force or override file logging and influence the resolved logfile path.
-
+    
     Returns:
-        logging.Logger: The same logger instance after applying the configuration.
+        logging.Logger: The configured logger instance.
     """
     global log_file_path
 

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -543,15 +543,13 @@ async def main(config: dict[str, Any]) -> None:
 
 def run_main(args: Any) -> int:
     """
-    Start the application: load configuration, validate required keys, and run the main async runner.
-
-    Loads and applies configuration (optionally overriding logging level from args), initializes module configuration, verifies required configuration sections (required keys are ["meshtastic", "matrix_rooms"] when credentials.json is present, otherwise ["matrix", "meshtastic", "matrix_rooms"]), and executes the main async entrypoint. Returns process exit codes: 0 for successful completion or user interrupt, 1 for configuration errors or unhandled exceptions.
-
+    Load configuration, validate required keys, configure logging and modules, and run the main async application loop.
+    
     Parameters:
-        args: Parsed command-line arguments (may be None). Recognized option used here: `log_level` to override the configured logging level.
-
+        args (Any): Parsed command-line arguments (may be None). Recognized option: `log_level` to override the configured logging level.
+    
     Returns:
-        int: Exit code (0 on success or user-initiated interrupt, 1 on failure such as invalid config or runtime error).
+        int: Exit code — `0` on successful completion or user-initiated interrupt, `1` for configuration errors or unhandled runtime exceptions.
     """
     # Load configuration
     from mmrelay.config import load_config

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -625,7 +625,7 @@ def run_main(args: Any) -> int:
             data_dir,
         )
         config_rich_logger.warning(
-            "To migrate to the new layout, see docs/DOCKER.md: Migrating to the new layout."
+            "To migrate to the new layout, see docs/DOCKER.md: Migrating to the New Layout."
         )
 
     # Check if config exists and has the required keys

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -599,7 +599,12 @@ def run_main(args: Any) -> int:
     log_utils.configure_component_debug_logging()
 
     # Get config path and log file path for logging
-    from mmrelay.config import config_path
+    from mmrelay.config import (
+        config_path,
+        get_base_dir,
+        get_data_dir,
+        is_legacy_layout_enabled,
+    )
     from mmrelay.log_utils import log_file_path
 
     # Create a logger with a different name to avoid conflicts with the one in config.py
@@ -610,6 +615,18 @@ def run_main(args: Any) -> int:
         config_rich_logger.info(f"Config file location: {config_path}")
     if log_file_path:
         config_rich_logger.info(f"Log file location: {log_file_path}")
+
+    if is_legacy_layout_enabled():
+        base_dir = get_base_dir()
+        data_dir = get_data_dir()
+        config_rich_logger.warning(
+            "Legacy data layout detected (base_dir=%s, data_dir=%s). This layout is deprecated and will be removed in a future release.",
+            base_dir,
+            data_dir,
+        )
+        config_rich_logger.warning(
+            "To migrate to the new layout, see docs/DOCKER.md: Migrating to the new layout."
+        )
 
     # Check if config exists and has the required keys
     # Note: matrix section is optional if credentials.json exists

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -1322,7 +1322,7 @@ async def connect_matrix(
             candidate_paths.append(os.path.join(config_dir, "credentials.json"))
 
         candidate_paths.append(os.path.join(get_base_dir(), "credentials.json"))
-        # Also check data directory (for Docker setups where ~/.mmrelay is mounted to /app/data)
+        # Also check data directory (backward compatibility for setups mounted to /app/data)
         candidate_paths.append(os.path.join(get_data_dir(), "credentials.json"))
 
         for candidate in candidate_paths:

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -71,6 +71,7 @@ from mmrelay.cli_utils import (
 )
 from mmrelay.config import (
     get_base_dir,
+    get_data_dir,
     get_e2ee_store_dir,
     get_meshtastic_config_value,
     load_credentials,
@@ -1321,6 +1322,8 @@ async def connect_matrix(
             candidate_paths.append(os.path.join(config_dir, "credentials.json"))
 
         candidate_paths.append(os.path.join(get_base_dir(), "credentials.json"))
+        # Also check data directory (for Docker setups where ~/.mmrelay is mounted to /app/data)
+        candidate_paths.append(os.path.join(get_data_dir(), "credentials.json"))
 
         for candidate in candidate_paths:
             if not os.path.isfile(candidate):

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -88,7 +88,9 @@ def _get_plugin_root_dirs() -> list[str]:
         if data_dir and data_dir != base_dir:
             data_root = os.path.join(data_dir, "plugins")
             if data_root not in roots:
-                if os.path.isdir(data_root) and not os.path.isdir(roots[0]):
+                if os.path.isdir(data_root) and (
+                    not roots or not os.path.isdir(roots[0])
+                ):
                     roots.insert(0, data_root)
                 else:
                     roots.append(data_root)

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -17,7 +17,13 @@ from types import ModuleType
 from typing import Any, Iterator, NamedTuple, NoReturn
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
-from mmrelay.config import get_app_path, get_base_dir, get_data_dir
+from mmrelay.config import (
+    get_app_path,
+    get_base_dir,
+    get_data_dir,
+    is_legacy_layout_enabled,
+    is_new_layout_enabled,
+)
 from mmrelay.constants.plugins import (
     COMMIT_HASH_PATTERN,
     DEFAULT_ALLOWED_COMMUNITY_HOSTS,
@@ -66,17 +72,18 @@ _PLUGIN_DEPS_DIR: str | None = None
 
 def _get_plugin_root_dirs() -> list[str]:
     base_dir = get_base_dir()
-    data_dir = get_data_dir()
     roots: list[str] = []
     if base_dir:
         roots.append(os.path.join(base_dir, "plugins"))
-    if data_dir and data_dir != base_dir:
-        data_root = os.path.join(data_dir, "plugins")
-        if data_root not in roots:
-            if os.path.isdir(data_root) and not os.path.isdir(roots[0]):
-                roots.insert(0, data_root)
-            else:
-                roots.append(data_root)
+    if is_new_layout_enabled() or is_legacy_layout_enabled():
+        data_dir = get_data_dir(create=False)
+        if data_dir and data_dir != base_dir:
+            data_root = os.path.join(data_dir, "plugins")
+            if data_root not in roots:
+                if os.path.isdir(data_root) and not os.path.isdir(roots[0]):
+                    roots.insert(0, data_root)
+                else:
+                    roots.append(data_root)
     return roots
 
 

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -71,6 +71,14 @@ _PLUGIN_DEPS_DIR: str | None = None
 
 
 def _get_plugin_root_dirs() -> list[str]:
+    """
+    Compute an ordered list of candidate plugin root directories.
+    
+    When a base directory exists, returns base_dir/plugins. If either the new or legacy layout is enabled and a distinct data directory exists, includes data_dir/plugins as well; the data directory is inserted at the front if it exists on disk while the base plugins path does not, otherwise it is appended. Duplicate paths are avoided.
+    
+    Returns:
+        list[str]: Ordered list of plugin root directory paths.
+    """
     base_dir = get_base_dir()
     roots: list[str] = []
     if base_dir:
@@ -807,18 +815,15 @@ def _install_requirements_for_repo(repo_path: str, repo_name: str) -> None:
 
 def _get_plugin_dirs(plugin_type: str) -> list[str]:
     """
-    Get an ordered list of existing plugin directories for the given plugin type.
-
-    Prefers the per-user directory (base_dir/plugins/<type>) and also includes the local
-    application directory (app_path/plugins/<type>) for backward compatibility. The function
-    attempts to create each directory if missing and omits any paths that cannot be created
-    or accessed.
-
+    Compute ordered plugin directories for the given plugin type.
+    
+    Prefers per-root user plugin directories (created if missing) for each discovered plugin root and includes the local application `plugins/<type>` directory for backward compatibility; any directory that cannot be created or accessed is omitted.
+    
     Parameters:
         plugin_type (str): Plugin category, e.g. "custom" or "community".
-
+    
     Returns:
-        list[str]: Ordered list of plugin directories to search (user directory first when available, then local directory).
+        list[str]: Ordered list of filesystem paths to plugin directories (per-root user dirs first, then the local app directory).
     """
     dirs = []
 

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -830,7 +830,7 @@ def _get_plugin_dirs(plugin_type: str) -> list[str]:
             os.makedirs(user_dir, exist_ok=True)
             dirs.append(user_dir)
         except (OSError, PermissionError) as e:
-            logger.warning(f"Cannot create user plugin directory {user_dir}: {e}")
+            logger.warning("Cannot create user plugin directory %s: %s", user_dir, e)
 
     # Check local directory (backward compatibility)
     local_dir = os.path.join(get_app_path(), "plugins", plugin_type)

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -73,9 +73,9 @@ _PLUGIN_DEPS_DIR: str | None = None
 def _get_plugin_root_dirs() -> list[str]:
     """
     Compute an ordered list of candidate plugin root directories.
-    
+
     When a base directory exists, returns base_dir/plugins. If either the new or legacy layout is enabled and a distinct data directory exists, includes data_dir/plugins as well; the data directory is inserted at the front if it exists on disk while the base plugins path does not, otherwise it is appended. Duplicate paths are avoided.
-    
+
     Returns:
         list[str]: Ordered list of plugin root directory paths.
     """
@@ -816,19 +816,22 @@ def _install_requirements_for_repo(repo_path: str, repo_name: str) -> None:
 def _get_plugin_dirs(plugin_type: str) -> list[str]:
     """
     Compute ordered plugin directories for the given plugin type.
-    
+
     Prefers per-root user plugin directories (created if missing) for each discovered plugin root and includes the local application `plugins/<type>` directory for backward compatibility; any directory that cannot be created or accessed is omitted.
-    
+
     Parameters:
         plugin_type (str): Plugin category, e.g. "custom" or "community".
-    
+
     Returns:
         list[str]: Ordered list of filesystem paths to plugin directories (per-root user dirs first, then the local app directory).
     """
     dirs = []
 
     for root_dir in _get_plugin_root_dirs():
-        user_dir = os.path.join(root_dir, plugin_type)
+        if os.path.basename(root_dir) == "plugins":
+            user_dir = os.path.join(root_dir, plugin_type)
+        else:
+            user_dir = root_dir
         if user_dir in dirs:
             continue
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -610,22 +610,28 @@ ensure_builtins_not_mocked()
 @pytest.fixture(autouse=True)
 def reset_custom_data_dir():
     """
-    Autouse pytest fixture that resets mmrelay.config.custom_data_dir to None for each test and restores its original value afterwards.
+    Autouse pytest fixture that resets mmrelay.config custom dir overrides to None for each test and restores their original values afterwards.
 
-    Before the test runs, stores the current value of mmrelay.config.custom_data_dir (if any) and sets it to None to ensure tests do not share or depend on a persistent custom data directory. After the test yields, the original value is restored.
+    Before the test runs, stores the current values of mmrelay.config.custom_data_dir
+    and mmrelay.config.custom_base_dir (if any) and sets them to None to ensure tests
+    do not share or depend on persistent overrides. After the test yields, the original
+    values are restored.
     """
     import mmrelay.config
 
     # Store original value
     original_custom_data_dir = getattr(mmrelay.config, "custom_data_dir", None)
+    original_custom_base_dir = getattr(mmrelay.config, "custom_base_dir", None)
 
     # Reset to None before test
     mmrelay.config.custom_data_dir = None
+    mmrelay.config.custom_base_dir = None
 
     yield
 
     # Restore original value after test
     mmrelay.config.custom_data_dir = original_custom_data_dir
+    mmrelay.config.custom_base_dir = original_custom_base_dir
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -547,7 +547,7 @@ class TestMainFunction(unittest.TestCase):
         self, mock_run_main, mock_parse, mock_expanduser, mock_makedirs
     ):
         """
-        Verify that --base-dir expands user paths and sets custom_data_dir.
+        Verify that --base-dir expands user paths and sets custom_base_dir.
         """
         args = MagicMock()
         args.command = None
@@ -564,16 +564,16 @@ class TestMainFunction(unittest.TestCase):
 
         import mmrelay.config
 
-        original_custom_data_dir = mmrelay.config.custom_data_dir
+        original_custom_base_dir = mmrelay.config.custom_base_dir
         try:
             result = main()
 
             self.assertEqual(result, 0)
             mock_expanduser.assert_called_once_with("~/mmrelay")
             mock_makedirs.assert_called_once_with("/home/test/mmrelay", exist_ok=True)
-            self.assertEqual(mmrelay.config.custom_data_dir, "/home/test/mmrelay")
+            self.assertEqual(mmrelay.config.custom_base_dir, "/home/test/mmrelay")
         finally:
-            mmrelay.config.custom_data_dir = original_custom_data_dir
+            mmrelay.config.custom_base_dir = original_custom_base_dir
 
 
 class TestCLIValidationFunctions(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1808,7 +1808,7 @@ class TestAuthStatus(unittest.TestCase):
         # Verify results
         self.assertEqual(result, 1)
         mock_get_paths.assert_called_once_with(self.mock_args)
-        mock_exists.assert_called_once_with("/home/user/.mmrelay/credentials.json")
+        mock_exists.assert_any_call("/home/user/.mmrelay/credentials.json")
 
         # Check printed output
         mock_print.assert_any_call("Matrix Authentication Status")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1808,7 +1808,7 @@ class TestAuthStatus(unittest.TestCase):
         # Verify results
         self.assertEqual(result, 1)
         mock_get_paths.assert_called_once_with(self.mock_args)
-        mock_exists.assert_any_call("/home/user/.mmrelay/credentials.json")
+        mock_exists.assert_called_once_with("/home/user/.mmrelay/credentials.json")
 
         # Check printed output
         mock_print.assert_any_call("Matrix Authentication Status")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1842,7 +1842,7 @@ class TestAuthStatus(unittest.TestCase):
         # Verify results
         self.assertEqual(result, 1)
         mock_get_paths.assert_called_once_with(self.mock_args)
-        mock_exists.assert_called_once_with("/home/user/.mmrelay/credentials.json")
+        mock_exists.assert_any_call("/home/user/.mmrelay/credentials.json")
 
         # Check error output
         mock_print.assert_any_call("Matrix Authentication Status")

--- a/tests/test_cli_edge_cases.py
+++ b/tests/test_cli_edge_cases.py
@@ -376,6 +376,7 @@ class TestCLIEdgeCases(unittest.TestCase):
                     result = handle_cli_commands(args)
 
                 # Verify the base directory was set and created
+                self.assertIsNone(result)
                 self.assertEqual(
                     mmrelay.config.custom_base_dir, os.path.abspath(base_dir)
                 )
@@ -413,6 +414,7 @@ class TestCLIEdgeCases(unittest.TestCase):
                         result = handle_cli_commands(args)
 
                 # Verify the data directory was set and created
+                self.assertIsNone(result)
                 self.assertEqual(
                     mmrelay.config.custom_data_dir, os.path.abspath(data_dir)
                 )

--- a/tests/test_cli_edge_cases.py
+++ b/tests/test_cli_edge_cases.py
@@ -14,6 +14,7 @@ Tests edge cases and error handling including:
 
 import os
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -346,6 +347,79 @@ class TestCLIEdgeCases(unittest.TestCase):
         with patch("mmrelay.cli.generate_sample_config", return_value=False):
             result = handle_cli_commands(args)
             self.assertEqual(result, 1)
+
+    def test_handle_cli_commands_with_base_dir(self):
+        """Test that --base-dir argument sets custom_base_dir and creates directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_dir = os.path.join(temp_dir, "custom_base")
+
+            args = MagicMock()
+            args.version = False
+            args.install_service = False
+            args.generate_config = False
+            args.check_config = False
+            args.base_dir = base_dir
+            args.data_dir = None
+            args.command = None
+
+            # Reset the global config variables
+            import mmrelay.config
+
+            original_base = mmrelay.config.custom_base_dir
+            original_data = mmrelay.config.custom_data_dir
+
+            try:
+                mmrelay.config.custom_base_dir = None
+                mmrelay.config.custom_data_dir = None
+
+                with patch("mmrelay.cli.logger"):
+                    result = handle_cli_commands(args)
+
+                # Verify the base directory was set and created
+                self.assertEqual(
+                    mmrelay.config.custom_base_dir, os.path.abspath(base_dir)
+                )
+                self.assertTrue(os.path.exists(base_dir))
+            finally:
+                mmrelay.config.custom_base_dir = original_base
+                mmrelay.config.custom_data_dir = original_data
+
+    def test_handle_cli_commands_with_data_dir(self):
+        """Test that deprecated --data-dir argument sets custom_data_dir and creates directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            data_dir = os.path.join(temp_dir, "custom_data")
+
+            args = MagicMock()
+            args.version = False
+            args.install_service = False
+            args.generate_config = False
+            args.check_config = False
+            args.base_dir = None
+            args.data_dir = data_dir
+            args.command = None
+
+            # Reset the global config variables
+            import mmrelay.config
+
+            original_base = mmrelay.config.custom_base_dir
+            original_data = mmrelay.config.custom_data_dir
+
+            try:
+                mmrelay.config.custom_base_dir = None
+                mmrelay.config.custom_data_dir = None
+
+                with patch("mmrelay.cli.logger"):
+                    with patch("sys.stderr"):  # Suppress deprecation warning
+                        result = handle_cli_commands(args)
+
+                # Verify the data directory was set and created
+                self.assertEqual(
+                    mmrelay.config.custom_data_dir, os.path.abspath(data_dir)
+                )
+                self.assertTrue(os.path.exists(data_dir))
+            finally:
+                mmrelay.config.custom_base_dir = original_base
+                mmrelay.config.custom_data_dir = original_data
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1155,7 +1155,7 @@ class TestCredentials(unittest.TestCase):
 
             save_credentials(credentials)
 
-            _mock_makedirs.assert_called_once()
+            _mock_makedirs.assert_any_call("/fake/dir", "credentials.json")
             _mock_open.assert_called_once()
             call_args = _mock_open.call_args
             final_path = call_args[0][0]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1586,7 +1586,11 @@ class TestConfigUncoveredLines(unittest.TestCase):
         """Test save_credentials verification (line 693)."""
         log_debug = []
         with patch.object(
-            mmrelay.config.logger, "debug", side_effect=lambda x: log_debug.append(x)
+            mmrelay.config.logger,
+            "debug",
+            side_effect=lambda msg, *args, **_kwargs: log_debug.append(
+                msg % args if args else msg
+            ),
         ):
             save_credentials({"access_token": "test"})
             self.assertTrue(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1140,8 +1140,8 @@ class TestCredentials(unittest.TestCase):
     def test_save_credentials_from_matrix_config_not_dict(
         self,
         _mock_open,
-        _mock_makedirs,
         _mock_join,
+        _mock_makedirs,
         _mock_get_base_dir,
     ):
         """Test save_credentials when matrix config is not a dict."""
@@ -1150,12 +1150,14 @@ class TestCredentials(unittest.TestCase):
         from mmrelay import config as config_module
 
         original_relay_config = config_module.relay_config.copy()
+        original_config_path = config_module.config_path
         try:
             config_module.relay_config = {"matrix": "not_a_dict"}
+            config_module.config_path = None
 
             save_credentials(credentials)
 
-            _mock_makedirs.assert_any_call("/fake/dir", "credentials.json")
+            _mock_makedirs.assert_any_call("/fake/dir", exist_ok=True)
             _mock_open.assert_called_once()
             call_args = _mock_open.call_args
             final_path = call_args[0][0]
@@ -1166,6 +1168,7 @@ class TestCredentials(unittest.TestCase):
             )
         finally:
             config_module.relay_config = original_relay_config
+            config_module.config_path = original_config_path
 
     @patch("mmrelay.config.get_base_dir", return_value="/actual/directory")
     @patch("mmrelay.config.os.makedirs")

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -11,6 +11,7 @@ Tests edge cases and error handling including:
 - Configuration file search priority
 """
 
+import json
 import os
 import sys
 import tempfile
@@ -21,9 +22,17 @@ from unittest.mock import MagicMock, mock_open, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mmrelay.config import (
+    _get_env_data_dir,
     get_app_path,
     get_config_paths,
+    get_credentials_search_paths,
+    get_data_dir,
+    get_e2ee_store_dir,
+    get_explicit_credentials_path,
+    get_log_dir,
     load_config,
+    load_credentials,
+    save_credentials,
     set_config,
 )
 
@@ -313,6 +322,239 @@ class TestConfigEdgeCases(unittest.TestCase):
 
                     # Should log error messages
                     mock_logger.error.assert_called()
+
+    def test_get_env_data_dir_not_set(self):
+        """Test _get_env_data_dir returns None when MMRELAY_DATA_DIR is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = _get_env_data_dir()
+            self.assertIsNone(result)
+
+    def test_get_env_data_dir_set(self):
+        """Test _get_env_data_dir returns expanded path when MMRELAY_DATA_DIR is set."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch.dict(os.environ, {"MMRELAY_DATA_DIR": temp_dir}):
+                result = _get_env_data_dir()
+                self.assertEqual(result, temp_dir)
+
+    def test_get_env_data_dir_with_tilde(self):
+        """Test _get_env_data_dir expands user home directory."""
+        with patch.dict(os.environ, {"MMRELAY_DATA_DIR": "~/test_data"}):
+            result = _get_env_data_dir()
+            self.assertTrue(result.endswith("test_data"))
+            self.assertFalse(result.startswith("~"))
+
+    def test_get_credentials_search_paths_with_explicit_path(self):
+        """Test get_credentials_search_paths with explicit path."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            explicit_path = os.path.join(temp_dir, "creds.json")
+
+            result = get_credentials_search_paths(explicit_path=explicit_path)
+
+            # Explicit path should be first
+            self.assertEqual(result[0], explicit_path)
+
+    def test_get_credentials_search_paths_with_directory(self):
+        """Test get_credentials_search_paths treats directory paths correctly."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = get_credentials_search_paths(
+                explicit_path=temp_dir + os.sep, include_base_data=False
+            )
+
+            # Should append credentials.json to directory
+            self.assertTrue(any("credentials.json" in path for path in result))
+
+    def test_get_credentials_search_paths_with_config_paths(self):
+        """Test get_credentials_search_paths with config file paths."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = os.path.join(temp_dir, "config.yaml")
+
+            result = get_credentials_search_paths(
+                config_paths=[config_path], include_base_data=False
+            )
+
+            # Should include credentials.json in same dir as config
+            expected_creds = os.path.join(temp_dir, "credentials.json")
+            self.assertIn(expected_creds, result)
+
+    def test_get_explicit_credentials_path_from_env(self):
+        """Test get_explicit_credentials_path reads from environment variable."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            creds_path = os.path.join(temp_dir, "env_creds.json")
+
+            with patch.dict(os.environ, {"MMRELAY_CREDENTIALS_PATH": creds_path}):
+                result = get_explicit_credentials_path(None)
+                self.assertEqual(result, creds_path)
+
+    def test_get_explicit_credentials_path_from_config(self):
+        """Test get_explicit_credentials_path reads from config."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            creds_path = os.path.join(temp_dir, "config_creds.json")
+            config = {"credentials_path": creds_path}
+
+            result = get_explicit_credentials_path(config)
+            self.assertEqual(result, creds_path)
+
+    def test_get_explicit_credentials_path_from_matrix_config(self):
+        """Test get_explicit_credentials_path reads from matrix section."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            creds_path = os.path.join(temp_dir, "matrix_creds.json")
+            config = {"matrix": {"credentials_path": creds_path}}
+
+            result = get_explicit_credentials_path(config)
+            self.assertEqual(result, creds_path)
+
+    def test_get_explicit_credentials_path_no_config(self):
+        """Test get_explicit_credentials_path returns None when no config provided."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = get_explicit_credentials_path(None)
+            self.assertIsNone(result)
+
+    def test_get_data_dir_with_legacy_data(self):
+        """Test get_data_dir detects and uses legacy data directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create legacy structure with data subdirectory
+            legacy_data_dir = os.path.join(temp_dir, "data")
+            legacy_db = os.path.join(legacy_data_dir, "meshtastic.sqlite")
+
+            os.makedirs(legacy_data_dir, exist_ok=True)
+
+            # Create a legacy database file to trigger legacy detection
+            with open(legacy_db, "w") as f:
+                f.write("legacy db")
+
+            with patch("mmrelay.config.custom_data_dir", temp_dir):
+                with patch("mmrelay.config._get_env_data_dir", return_value=None):
+                    result = get_data_dir(create=False)
+
+                    # Should use legacy data dir when legacy db exists
+                    self.assertEqual(result, legacy_data_dir)
+
+    def test_get_data_dir_without_legacy_data(self):
+        """Test get_data_dir uses override directly when no legacy data exists."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # No legacy data files
+
+            with patch("mmrelay.config.custom_data_dir", temp_dir):
+                with patch("mmrelay.config._get_env_data_dir", return_value=None):
+                    with patch("mmrelay.config.os.makedirs"):
+                        result = get_data_dir()
+
+                        # Should use the override directly
+                        self.assertEqual(result, temp_dir)
+
+    def test_get_log_dir_windows_with_override(self):
+        """Test get_log_dir on Windows with directory override."""
+        with patch("mmrelay.config.sys.platform", "win32"):
+            with patch("mmrelay.config._has_any_dir_override", return_value=True):
+                with patch("mmrelay.config.get_base_dir", return_value="C:\\mmrelay"):
+                    with patch("mmrelay.config.os.makedirs"):
+                        result = get_log_dir()
+
+                        # Should use base_dir/logs with override
+                        self.assertEqual(result, "C:\\mmrelay\\logs")
+
+    def test_get_e2ee_store_dir_windows_without_override(self):
+        """Test get_e2ee_store_dir on Windows without directory override."""
+        with patch("mmrelay.config.sys.platform", "win32"):
+            with patch("mmrelay.config._has_any_dir_override", return_value=False):
+                with patch(
+                    "mmrelay.config.platformdirs.user_data_dir",
+                    return_value="C:\\Users\\test\\AppData\\Local\\mmrelay",
+                ):
+                    with patch("mmrelay.config.os.makedirs"):
+                        result = get_e2ee_store_dir()
+
+                        # Should use platformdirs with store subdirectory
+                        self.assertEqual(
+                            result, "C:\\Users\\test\\AppData\\Local\\mmrelay\\store"
+                        )
+
+    def test_get_e2ee_store_dir_windows_with_override(self):
+        """Test get_e2ee_store_dir on Windows with directory override."""
+        with patch("mmrelay.config.sys.platform", "win32"):
+            with patch("mmrelay.config._has_any_dir_override", return_value=True):
+                with patch("mmrelay.config.get_base_dir", return_value="C:\\mmrelay"):
+                    with patch("mmrelay.config.os.makedirs"):
+                        result = get_e2ee_store_dir()
+
+                        # Should use base_dir/store with override
+                        self.assertEqual(result, "C:\\mmrelay\\store")
+
+    def test_load_credentials_windows_debug(self):
+        """Test load_credentials on Windows logs directory contents."""
+        with patch("mmrelay.config.sys.platform", "win32"):
+            with patch("mmrelay.config.os.path.exists", return_value=False):
+                with patch("mmrelay.config.get_base_dir", return_value="C:\\mmrelay"):
+                    with patch(
+                        "mmrelay.config.os.listdir",
+                        return_value=["file1.txt", "file2.json"],
+                    ) as mock_listdir:
+                        with patch("mmrelay.config.logger") as mock_logger:
+                            # Reset credentials state
+                            import mmrelay.config
+
+                            original_config = mmrelay.config.relay_config
+                            original_config_path = mmrelay.config.config_path
+                            mmrelay.config.relay_config = {}
+                            mmrelay.config.config_path = None
+
+                            try:
+                                load_credentials()
+
+                                # Should log directory contents on Windows
+                                debug_calls = [
+                                    call
+                                    for call in mock_logger.debug.call_args_list
+                                    if "Directory contents" in str(call)
+                                ]
+                                self.assertGreaterEqual(len(debug_calls), 1)
+                            finally:
+                                mmrelay.config.relay_config = original_config
+                                mmrelay.config.config_path = original_config_path
+
+    def test_save_credentials_writes_to_file(self):
+        """Test save_credentials actually writes JSON to file."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            creds_path = os.path.join(temp_dir, "credentials.json")
+            credentials = {
+                "user_id": "@test:matrix.org",
+                "access_token": "secret_token",
+            }
+
+            from mmrelay import config as config_module
+
+            original_relay_config = config_module.relay_config.copy()
+            original_config_path = config_module.config_path
+
+            try:
+                config_module.relay_config = {}
+                config_module.config_path = None
+
+                with patch.dict(os.environ, {"MMRELAY_CREDENTIALS_PATH": creds_path}):
+                    save_credentials(credentials)
+
+                # Verify file was written
+                self.assertTrue(os.path.exists(creds_path))
+
+                with open(creds_path, "r") as f:
+                    saved_creds = json.load(f)
+
+                self.assertEqual(saved_creds["user_id"], "@test:matrix.org")
+                self.assertEqual(saved_creds["access_token"], "secret_token")
+            finally:
+                config_module.relay_config = original_relay_config
+                config_module.config_path = original_config_path
+
+    def test_save_credentials_exception_handling(self):
+        """Test save_credentials handles exceptions gracefully."""
+        credentials = {"user_id": "test"}
+
+        with patch("mmrelay.config.os.makedirs", side_effect=OSError("Disk full")):
+            with patch("mmrelay.config.logger") as mock_logger:
+                result = save_credentials(credentials)
+
+                # Should log exception and not raise
+                mock_logger.exception.assert_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -16,7 +16,7 @@ import os
 import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -488,7 +488,7 @@ class TestConfigEdgeCases(unittest.TestCase):
                     with patch(
                         "mmrelay.config.os.listdir",
                         return_value=["file1.txt", "file2.json"],
-                    ) as mock_listdir:
+                    ):
                         with patch("mmrelay.config.logger") as mock_logger:
                             # Reset credentials state
                             import mmrelay.config
@@ -551,7 +551,7 @@ class TestConfigEdgeCases(unittest.TestCase):
 
         with patch("mmrelay.config.os.makedirs", side_effect=OSError("Disk full")):
             with patch("mmrelay.config.logger") as mock_logger:
-                result = save_credentials(credentials)
+                save_credentials(credentials)
 
                 # Should log exception and not raise
                 mock_logger.exception.assert_called()

--- a/tests/test_db_utils_edge_cases.py
+++ b/tests/test_db_utils_edge_cases.py
@@ -539,7 +539,6 @@ class TestDBUtilsEdgeCases(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             data_dir = os.path.join(temp_dir, "data")
             base_dir = temp_dir
-            default_path = os.path.join(data_dir, "meshtastic.sqlite")
             legacy_base_path = os.path.join(base_dir, "meshtastic.sqlite")
             legacy_data_path = os.path.join(base_dir, "data", "meshtastic.sqlite")
 
@@ -576,7 +575,6 @@ class TestDBUtilsEdgeCases(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             data_dir = os.path.join(temp_dir, "data")
             base_dir = temp_dir
-            default_path = os.path.join(data_dir, "meshtastic.sqlite")
             # Use legacy_base_path which is at base_dir, not inside data/ subdirectory
             legacy_base_path = os.path.join(base_dir, "meshtastic.sqlite")
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1582,14 +1582,14 @@ class TestRunMainFunction(unittest.TestCase):
     @patch("mmrelay.config.os.makedirs")
     def test_run_main_legacy_layout_warning(
         self,
-        mock_makedirs,
+        _mock_makedirs,
         mock_get_log_dir,
         mock_get_data_dir,
         mock_get_base_dir,
         mock_is_legacy_layout_enabled,
         mock_load_credentials,
         mock_load_config,
-        mock_print_banner,
+        _mock_print_banner,
     ):
         """Test that warning messages are logged when legacy layout is enabled."""
         mock_config = {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1575,6 +1575,60 @@ class TestRunMainFunction(unittest.TestCase):
     @patch("mmrelay.main.print_banner")
     @patch("mmrelay.config.load_config")
     @patch("mmrelay.config.load_credentials")
+    @patch("mmrelay.config.is_legacy_layout_enabled")
+    @patch("mmrelay.config.get_base_dir")
+    @patch("mmrelay.config.get_data_dir")
+    @patch("mmrelay.config.get_log_dir")
+    @patch("mmrelay.config.os.makedirs")
+    def test_run_main_legacy_layout_warning(
+        self,
+        mock_makedirs,
+        mock_get_log_dir,
+        mock_get_data_dir,
+        mock_get_base_dir,
+        mock_is_legacy_layout_enabled,
+        mock_load_credentials,
+        mock_load_config,
+        mock_print_banner,
+    ):
+        """Test that warning messages are logged when legacy layout is enabled."""
+        mock_config = {
+            "matrix": {"homeserver": "https://matrix.org"},
+            "meshtastic": {"connection_type": "serial"},
+            "matrix_rooms": [{"id": "!room:matrix.org", "meshtastic_channel": 0}],
+        }
+        mock_load_config.return_value = mock_config
+        mock_load_credentials.return_value = None
+        mock_is_legacy_layout_enabled.return_value = True
+        mock_get_base_dir.return_value = "/test/base/dir"
+        mock_get_data_dir.return_value = "/test/data/dir"
+        mock_get_log_dir.return_value = "/test/log/dir"
+
+        mock_args = MagicMock()
+        mock_args.data_dir = None
+        mock_args.log_level = None
+
+        with patch("mmrelay.main.asyncio.run") as mock_asyncio_run:
+            mock_asyncio_run.side_effect = _close_coro_if_possible
+            with patch("mmrelay.main.get_logger") as mock_get_logger:
+                mock_config_logger = MagicMock()
+                mock_get_logger.return_value = mock_config_logger
+                result = run_main(mock_args)
+
+        self.assertEqual(result, 0)
+        # Verify warning was called with legacy layout message
+        mock_config_logger.warning.assert_any_call(
+            "Legacy data layout detected (base_dir=%s, data_dir=%s). This layout is deprecated and will be removed in a future release.",
+            "/test/base/dir",
+            "/test/data/dir",
+        )
+        mock_config_logger.warning.assert_any_call(
+            "To migrate to the new layout, see docs/DOCKER.md: Migrating to the New Layout."
+        )
+
+    @patch("mmrelay.main.print_banner")
+    @patch("mmrelay.config.load_config")
+    @patch("mmrelay.config.load_credentials")
     @patch("mmrelay.main.asyncio.run")
     def test_run_main_keyboard_interrupt(
         self,

--- a/tests/test_matrix_utils_auth.py
+++ b/tests/test_matrix_utils_auth.py
@@ -1076,6 +1076,10 @@ def test_save_credentials(
 ):
     """Test credentials saving."""
     mock_get_base_dir.return_value = "/test/config"
+    import mmrelay.config as config_module
+
+    original_config_path = config_module.config_path
+    config_module.config_path = None
 
     test_credentials = {
         "homeserver": "https://matrix.example.org",
@@ -1084,7 +1088,10 @@ def test_save_credentials(
         "device_id": "TEST_DEVICE",
     }
 
-    save_credentials(test_credentials)
+    try:
+        save_credentials(test_credentials)
+    finally:
+        config_module.config_path = original_config_path
 
     _mock_makedirs.assert_called_once_with("/test/config", exist_ok=True)
     _mock_open.assert_called_once()

--- a/tests/test_matrix_utils_auth.py
+++ b/tests/test_matrix_utils_auth.py
@@ -1074,7 +1074,11 @@ def test_load_credentials_file_not_exists(mock_exists, mock_get_base_dir):
 def test_save_credentials(
     _mock_exists, _mock_makedirs, mock_json_dump, _mock_open, mock_get_base_dir
 ):
-    """Test credentials saving."""
+    """
+    Verify that save_credentials writes the provided credentials JSON to the resolved config directory.
+    
+    This test sets the module-level config_path to None to force resolution via the base directory fixture, then calls save_credentials with a credentials dict and asserts that the target directory is created, the credentials file is opened, and json.dump is called with the credentials and an indent of 2.
+    """
     mock_get_base_dir.return_value = "/test/config"
     import mmrelay.config as config_module
 

--- a/tests/test_plugin_loader_edge_cases.py
+++ b/tests/test_plugin_loader_edge_cases.py
@@ -565,7 +565,6 @@ class Plugin:
             base_dir = os.path.join(temp_dir, "base")
             data_dir = os.path.join(base_dir, "data")
             data_root = os.path.join(data_dir, "plugins")
-            base_root = os.path.join(base_dir, "plugins")
 
             # Only create data plugins directory
             os.makedirs(data_root, exist_ok=True)
@@ -596,9 +595,9 @@ class Plugin:
             ):
                 with patch("os.makedirs") as mock_makedirs:
                     # Make local directory creation fail
-                    def side_effect(path, exist_ok=False):
-                        if "app" in path:  # Local app directory
-                            raise OSError("Cannot create directory")
+                    def side_effect(_path, **_kwargs):
+                        if "app" in _path:  # Local app directory
+                            raise OSError()
                         return None
 
                     mock_makedirs.side_effect = side_effect
@@ -625,9 +624,9 @@ class Plugin:
             ):
                 with patch("os.makedirs") as mock_makedirs:
                     # Make local directory creation fail with PermissionError
-                    def side_effect(path, exist_ok=False):
-                        if "app" in path:  # Local app directory
-                            raise PermissionError("Permission denied")
+                    def side_effect(_path, **_kwargs):
+                        if "app" in _path:  # Local app directory
+                            raise PermissionError()
                         return None
 
                     mock_makedirs.side_effect = side_effect

--- a/tests/test_plugin_loader_edge_cases.py
+++ b/tests/test_plugin_loader_edge_cases.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mmrelay.plugin_loader import (
+    _get_plugin_dirs,
+    _get_plugin_root_dirs,
     get_community_plugin_dirs,
     get_custom_plugin_dirs,
     load_plugins,
@@ -506,6 +508,141 @@ class Plugin:
                     plugins = load_plugins(config)
                     # Should handle duplicates (may keep both or prefer one) + core plugins
                     self.assertGreaterEqual(len(plugins), 1)
+
+    def test_get_plugin_root_dirs_with_new_layout(self):
+        """Test _get_plugin_root_dirs when new layout is enabled."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_dir = os.path.join(temp_dir, "base")
+            data_dir = os.path.join(base_dir, "data")
+
+            os.makedirs(data_dir, exist_ok=True)
+
+            with patch("mmrelay.plugin_loader.get_base_dir", return_value=base_dir):
+                with patch(
+                    "mmrelay.plugin_loader.is_new_layout_enabled", return_value=True
+                ):
+                    with patch(
+                        "mmrelay.plugin_loader.is_legacy_layout_enabled",
+                        return_value=False,
+                    ):
+                        with patch(
+                            "mmrelay.plugin_loader.get_data_dir", return_value=data_dir
+                        ):
+                            result = _get_plugin_root_dirs()
+
+                            # Should include base_dir/plugins and data_dir/plugins
+                            self.assertIn(os.path.join(base_dir, "plugins"), result)
+                            self.assertIn(os.path.join(data_dir, "plugins"), result)
+
+    def test_get_plugin_root_dirs_with_legacy_layout(self):
+        """Test _get_plugin_root_dirs when legacy layout is enabled."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_dir = os.path.join(temp_dir, "base")
+            data_dir = os.path.join(base_dir, "data")
+
+            os.makedirs(data_dir, exist_ok=True)
+
+            with patch("mmrelay.plugin_loader.get_base_dir", return_value=base_dir):
+                with patch(
+                    "mmrelay.plugin_loader.is_new_layout_enabled", return_value=False
+                ):
+                    with patch(
+                        "mmrelay.plugin_loader.is_legacy_layout_enabled",
+                        return_value=True,
+                    ):
+                        with patch(
+                            "mmrelay.plugin_loader.get_data_dir", return_value=data_dir
+                        ):
+                            result = _get_plugin_root_dirs()
+
+                            # Should include base_dir/plugins and data_dir/plugins
+                            self.assertIn(os.path.join(base_dir, "plugins"), result)
+                            self.assertIn(os.path.join(data_dir, "plugins"), result)
+
+    def test_get_plugin_root_dirs_data_root_preferred(self):
+        """Test _get_plugin_root_dirs puts data_root at front when it exists and base doesn't."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_dir = os.path.join(temp_dir, "base")
+            data_dir = os.path.join(base_dir, "data")
+            data_root = os.path.join(data_dir, "plugins")
+            base_root = os.path.join(base_dir, "plugins")
+
+            # Only create data plugins directory
+            os.makedirs(data_root, exist_ok=True)
+
+            with patch("mmrelay.plugin_loader.get_base_dir", return_value=base_dir):
+                with patch(
+                    "mmrelay.plugin_loader.is_new_layout_enabled", return_value=True
+                ):
+                    with patch(
+                        "mmrelay.plugin_loader.is_legacy_layout_enabled",
+                        return_value=False,
+                    ):
+                        with patch(
+                            "mmrelay.plugin_loader.get_data_dir", return_value=data_dir
+                        ):
+                            result = _get_plugin_root_dirs()
+
+                            # Data root should be first since it exists and base doesn't
+                            self.assertEqual(result[0], data_root)
+
+    def test_get_plugin_dirs_local_directory_error(self):
+        """Test _get_plugin_dirs handles errors when creating local directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin_type = "custom"
+
+            with patch(
+                "mmrelay.plugin_loader._get_plugin_root_dirs", return_value=[temp_dir]
+            ):
+                with patch("os.makedirs") as mock_makedirs:
+                    # Make local directory creation fail
+                    def side_effect(path, exist_ok=False):
+                        if "app" in path:  # Local app directory
+                            raise OSError("Cannot create directory")
+                        return None
+
+                    mock_makedirs.side_effect = side_effect
+
+                    with patch(
+                        "mmrelay.plugin_loader.get_app_path", return_value="/fake/app"
+                    ):
+                        with patch("mmrelay.plugin_loader.logger") as mock_logger:
+                            result = _get_plugin_dirs(plugin_type)
+
+                            # Should still return the root directory
+                            self.assertEqual(len(result), 1)
+                            self.assertIn(temp_dir, result)
+                            # Should log debug about local directory creation failure
+                            mock_logger.debug.assert_called()
+
+    def test_get_plugin_dirs_local_permission_error(self):
+        """Test _get_plugin_dirs handles PermissionError when creating local directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin_type = "community"
+
+            with patch(
+                "mmrelay.plugin_loader._get_plugin_root_dirs", return_value=[temp_dir]
+            ):
+                with patch("os.makedirs") as mock_makedirs:
+                    # Make local directory creation fail with PermissionError
+                    def side_effect(path, exist_ok=False):
+                        if "app" in path:  # Local app directory
+                            raise PermissionError("Permission denied")
+                        return None
+
+                    mock_makedirs.side_effect = side_effect
+
+                    with patch(
+                        "mmrelay.plugin_loader.get_app_path", return_value="/fake/app"
+                    ):
+                        with patch("mmrelay.plugin_loader.logger") as mock_logger:
+                            result = _get_plugin_dirs(plugin_type)
+
+                            # Should still return the root directory
+                            self.assertEqual(len(result), 1)
+                            self.assertIn(temp_dir, result)
+                            # Should log debug about local directory creation failure
+                            mock_logger.debug.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR fixes Docker path-resolution regressions, improves and centralizes config/data/credential resolution and layout migration behavior, broadens plugin/data-directory discovery, reduces noisy logging and avoids circular-imports during logger initialization, ensures the Rich library is included in Windows PyInstaller builds, adds developer documentation for data-layout migration, applies small Docker/installer tweaks, updates tests (Windows and migration edge cases), and bumps the package version.

Changes

Features
- Packaging
  - Include Rich in Windows single-file PyInstaller builds (--collect-all rich).
- Config and path helpers
  - New helpers and API surface: CredentialsPathError, get_credentials_search_paths(...), get_explicit_credentials_path(...), is_new_layout_enabled(), is_legacy_layout_enabled().
  - get_base_dir(), refined get_data_dir(create=True), and load_config(..., config_paths=None) updated to respect overrides, env vars, and layout modes.
  - Environment and Docker-aware overrides supported: MMRELAY_BASE_DIR, MMRELAY_DATA_DIR, MMRELAY_CREDENTIALS_PATH.
- Plugin resolution
  - Plugin/plugin-deps discovery now considers multiple root candidates (base/data), prefers writable roots for deps, and appends chosen deps dir to sys.path.
- Documentation
  - Adds docs/dev/DATA_LAYOUT_MIGRATION.md and Docker migration guidance.

Fixes
- Credential discovery & saving
  - Centralized credentials-path resolution used across CLI, matrix utilities, and auth/status.
  - save_credentials normalizes paths, tries prioritized candidate locations (prefers config dir, then base/data dirs), robustly creates dirs, and logs clearer errors; credential-loading debug output deduplicated.
  - Removed redundant directory-exists check in credential loading.
- Windows path regressions
  - Normalizes Windows paths (os.path.normpath), uses platformdirs for legacy Windows data dir, and provides Windows-specific guidance in credential error logs.
- DB migration & path selection
  - get_db_path and db utilities perform layout-aware selection and can migrate legacy DB files (including -wal/-shm sidecars) to the new default path when new layout is enabled.
  - Added rollback behavior when sidecar moves fail and improved migration logging and error handling.
- CLI / installer
  - Directory overrides applied consistently via _apply_dir_overrides(); --base-dir maps to custom_base_dir and deprecated --data-dir remains recognized with a deprecation warning.
  - Installer scripts updated to use --base-dir flags where appropriate.
- Logging
  - Lazy-load configuration during logger initialization to avoid circular imports.
  - Switch toward structured logging with lazy %-style formatting; reduced noisy debug output.

Refactors
- Centralization
  - Moved base/data/env/override and credential/config resolution into src/mmrelay/config.py and updated callers (cli, matrix_utils, db_utils, plugin_loader, tests).
- DB utilities
  - Extracted migration and selection logic to helpers (_active_mtime, _migrate_legacy_db_if_needed) and added selection by modification time across candidates.
- Plugin loader
  - Broadened root handling and clearer candidate ordering (avoid duplicates, prefer data/plugins when distinct).
- Tests and fixtures
  - Updated tests and fixtures to track custom_base_dir (alongside custom_data_dir) and added many edge-case tests for Windows path handling, legacy migrations, credentials, plugin resolution, and DB migration.
- Misc
  - Dockerfile/CMD tweaks, scripts updated, and version bumped to 1.2.11.

Breaking changes / Migration notes
- Layout semantics
  - Project now models base + data layouts. Prefer --base-dir or MMRELAY_BASE_DIR for new-layout behavior; legacy MMRELAY_DATA_DIR/custom_data_dir remain supported but may resolve differently.
- Automatic DB migration
  - Enabling the new layout can trigger in-place migration of legacy DB files (and -wal/-shm sidecars) to the new data directory. Migrations are non-fatal and logged, but back up DB files before switching layouts in production if you need to be conservative.
- Credentials location
  - Credentials saving/lookup consults an ordered set of candidate locations (config dir preferred, then base/data). If credentials.json cannot be found, check these locations per the new docs.
- Docker
  - Docker defaults set MMRELAY_DATA_DIR and MMRELAY_CREDENTIALS_PATH and CMD was simplified; ensure container volume mounts and env vars align with your chosen layout.
- Tests/automation
  - Automation or tests that assumed a single data-dir layout should be updated to use the new helpers or to account for base_dir vs data_dir distinctions and multiple candidate search paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->