### PR TITLE
refactor(config): simplify data directory resolution logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ LABEL org.opencontainers.image.title="Meshtastic Matrix Relay" \
 ENV PYTHONUNBUFFERED=1
 ENV MPLCONFIGDIR=/tmp/matplotlib
 ENV PATH=/usr/local/bin:/usr/bin:/bin
-ENV MMRELAY_DATA_DIR=/app/data
-ENV MMRELAY_CREDENTIALS_PATH=/app/data/credentials.json
+ENV MMRELAY_BASE_DIR=/data
+ENV MMRELAY_CREDENTIALS_PATH=/data/credentials.json
 
 # Switch to non-root user
 USER mmrelay
@@ -78,5 +78,5 @@ USER mmrelay
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD if [ -n "$MMRELAY_READY_FILE" ]; then test -f "$MMRELAY_READY_FILE"; else pgrep -f mmrelay >/dev/null 2>&1; fi
 
-# Default command - uses config.yaml from volume mount
-CMD ["mmrelay", "--config", "/app/config.yaml"]
+# Default command - uses config.yaml from volume mount with explicit base dir
+CMD ["mmrelay", "--config", "/app/config.yaml", "--base-dir", "/data"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refactors the application's data directory resolution logic by removing legacy layout detection and standardizing on a single `base_dir` concept. The changes simplify path resolution throughout the codebase while fixing an error handling issue in credential saving.

## Changes by Category

**Refactors:**
- **Data directory resolution** (config.py): Simplified `get_data_dir()` to remove legacy layout introspection. New resolution order is: explicit `MMRELAY_DATA_DIR` environment override → Windows default paths using `base_dir` → `base_dir/data` for other platforms
- **Plugin discovery** (plugin_loader.py): Reworked `_get_plugin_root_dirs()` to always include `base_dir/plugins` as primary location, with `data_dir/plugins` added only when overrides are explicitly configured. Removed dependency on legacy/new layout detection
- **Environment configuration** (Dockerfile): Replaced `MMRELAY_DATA_DIR` with `MMRELAY_BASE_DIR` and made `--base-dir /data` explicit in the default command

**Fixes:**
- **Error handling** (config.py): Fixed potential uninitialized variable in `save_credentials()` error logging by introducing a stable `error_location` variable in Windows/non-Windows error paths

## Breaking Changes

- **Environment variable renamed**: `MMRELAY_DATA_DIR` is replaced by `MMRELAY_BASE_DIR`. Docker users should use `MMRELAY_BASE_DIR=/data` instead of `MMRELAY_DATA_DIR=/app/data`
- **Credentials path**: Changed from `/app/data/credentials.json` to `/data/credentials.json` in Docker
- **Default command**: Now includes explicit `--base-dir /data` argument (previously implicit)

Migration: Update any scripts or deployments using `MMRELAY_DATA_DIR` to use `MMRELAY_BASE_DIR` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->