### PR TITLE
Add topic parameter and detection source fallback resolution

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,16 +25,16 @@ lint:
     - dotenv-linter@4.0.0
     - hadolint@2.14.0
     - taplo@0.10.0
-    - actionlint@1.7.10
+    - actionlint@1.7.11
     - bandit@1.9.3
     - black@26.1.0
-    - checkov@3.2.500
+    - checkov@3.2.504
     - git-diff-check
     - isort@7.0.0
     - markdownlint@0.47.0
-    - osv-scanner@2.3.2
+    - osv-scanner@2.3.3
     - prettier@3.8.1
-    - ruff@0.15.0
+    - ruff@0.15.1
     - trufflehog@3.93.1
     - yamllint@1.38.0
   ignore:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2361,9 +2361,9 @@ def on_lost_meshtastic_connection(
 ) -> None:
     """
     Mark the Meshtastic connection as lost, close the current client, and start an asynchronous reconnect.
-    
+
     If a shutdown is underway or a reconnect is already in progress this function returns immediately. When proceeding it sets the module-level `reconnecting` flag, attempts a best-effort close/cleanup of the current Meshtastic client/interface (with special handling for BLE interfaces), clears any in-flight BLE future state, and schedules the `reconnect()` coroutine on the global event loop.
-    
+
     Parameters:
         detection_source (str): Identifier for where or how the loss was detected; if `"unknown"`, the function will prefer an interface-provided `_last_disconnect_source`, then derive a name from `topic`, and finally fall back to `"meshtastic.connection.lost"`.
         topic (Any): Optional pubsub topic object (from pypubsub); when provided and `detection_source` is `"unknown"`, the topic's name will be used to derive the detection source.

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2387,11 +2387,14 @@ def on_lost_meshtastic_connection(
             interface_source = getattr(interface, "_last_disconnect_source", None)
             if isinstance(interface_source, str) and interface_source.strip():
                 detection_source = f"ble.{interface_source}"
-            elif topic is not None:
-                detection_source = str(
-                    getattr(topic, "getName", lambda: getattr(topic, "name", topic))()
-                )
+            elif topic is not pub.AUTO_TOPIC:
+                # Real topic object from pypubsub - extract its name
+                detection_source = str(topic)
             else:
+                # Called directly without a topic, or with AUTO_TOPIC sentinel
+                logger.debug(
+                    "_last_disconnect_source unavailable; using default detection source"
+                )
                 detection_source = "meshtastic.connection.lost"
 
         reconnecting = True

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1925,7 +1925,8 @@ def connect_meshtastic(
                             logger.debug(
                                 f"Creating new BLE interface for {ble_address} (sanitized: {sanitized_address})"
                             )
-                            # Check if auto_reconnect parameter is supported (forked version)
+                            # Detect whether this BLEInterface implementation supports
+                            # explicit auto_reconnect control.
                             ble_init_sig = inspect.signature(
                                 meshtastic.ble_interface.BLEInterface.__init__
                             )
@@ -1937,19 +1938,19 @@ def connect_meshtastic(
                                 "timeout": timeout,
                             }
 
-                            # Add auto_reconnect only if supported (forked version)
+                            # Configure auto_reconnect only when supported.
                             supports_auto_reconnect = (
                                 "auto_reconnect" in ble_init_sig.parameters
                             )
                             if supports_auto_reconnect:
                                 ble_kwargs["auto_reconnect"] = False
                                 logger.debug(
-                                    "Using forked meshtastic library with auto_reconnect=False "
-                                    "to ensure sequential connections"
+                                    "BLEInterface supports auto_reconnect; setting auto_reconnect=False "
+                                    "to ensure sequential reconnection control"
                                 )
                             else:
                                 logger.debug(
-                                    "Using official meshtastic library (auto_reconnect not available)"
+                                    "BLEInterface auto_reconnect parameter not available; using compatibility mode"
                                 )
                             if ble_scan_after_failure and not supports_auto_reconnect:
                                 logger.debug(
@@ -2092,10 +2093,9 @@ def connect_meshtastic(
 
                         iface = meshtastic_iface
 
-                    # Connect outside singleton-creation lock to avoid blocking other threads
-                    # Official version connects during init; forked version needs explicit
-                    # connect(). Skipping connect for official avoids calling connect() with
-                    # an implicit None address, which can fail reconnection.
+                    # Connect outside singleton-creation lock to avoid blocking other threads.
+                    # Interfaces that expose auto_reconnect support use explicit connect()
+                    # here; compatibility mode relies on constructor-managed connection.
                     if (
                         iface is not None
                         and supports_auto_reconnect
@@ -2186,8 +2186,8 @@ def connect_meshtastic(
                             ) from err
                     elif iface is not None and hasattr(iface, "connect"):
                         logger.debug(
-                            "Skipping explicit BLE connect for official library; "
-                            "interface connects during init for %s",
+                            "Skipping explicit BLE connect in compatibility mode; "
+                            "interface is expected to connect during initialization for %s",
                             ble_address,
                         )
 
@@ -2386,10 +2386,16 @@ def on_lost_meshtastic_connection(
         if detection_source == "unknown":
             interface_source = getattr(interface, "_last_disconnect_source", None)
             if isinstance(interface_source, str) and interface_source.strip():
-                detection_source = f"ble.{interface_source}"
+                detection_source = interface_source
+                logger.debug(
+                    "Using interface-provided detection source: %s", detection_source
+                )
             elif topic is not pub.AUTO_TOPIC:
                 # Real topic object from pypubsub - extract its name
-                detection_source = str(topic)
+                detection_source = getattr(topic, "getName", lambda: str(topic))()
+                logger.debug(
+                    "Using pubsub topic-derived detection source: %s", detection_source
+                )
             else:
                 # Called directly without a topic, or with AUTO_TOPIC sentinel
                 logger.debug(

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2385,8 +2385,10 @@ def on_lost_meshtastic_connection(
             return
         if detection_source == "unknown":
             interface_source = getattr(interface, "_last_disconnect_source", None)
-            if isinstance(interface_source, str) and interface_source.strip():
-                detection_source = interface_source
+            if isinstance(interface_source, str) and (
+                stripped := interface_source.strip()
+            ):
+                detection_source = stripped
                 logger.debug(
                     "Using interface-provided detection source: %s", detection_source
                 )

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2360,18 +2360,13 @@ def on_lost_meshtastic_connection(
     topic: Any = pub.AUTO_TOPIC,
 ) -> None:
     """
-    Mark the Meshtastic connection as lost, close the current client, and initiate an asynchronous reconnect.
-
-    If a shutdown is in progress or a reconnect is already underway this function returns immediately. Otherwise it:
-    - sets the module-level `reconnecting` flag,
-    - attempts to close and clear the module-level `meshtastic_client` (handles already-closed file descriptors),
-    - resolves a meaningful detection source when the caller provides "unknown" (preferring BLE interface
-      `_last_disconnect_source`, then pubsub topic name),
-    - schedules the reconnect() coroutine on the global event loop if that loop exists and is open.
-
+    Mark the Meshtastic connection as lost, close the current client, and start an asynchronous reconnect.
+    
+    If a shutdown is underway or a reconnect is already in progress this function returns immediately. When proceeding it sets the module-level `reconnecting` flag, attempts a best-effort close/cleanup of the current Meshtastic client/interface (with special handling for BLE interfaces), clears any in-flight BLE future state, and schedules the `reconnect()` coroutine on the global event loop.
+    
     Parameters:
-        detection_source (str): Identifier for where or how the loss was detected; used in log messages.
-        topic (Any): Optional pubsub topic object when invoked via pypubsub.
+        detection_source (str): Identifier for where or how the loss was detected; if `"unknown"`, the function will prefer an interface-provided `_last_disconnect_source`, then derive a name from `topic`, and finally fall back to `"meshtastic.connection.lost"`.
+        topic (Any): Optional pubsub topic object (from pypubsub); when provided and `detection_source` is `"unknown"`, the topic's name will be used to derive the detection source.
     """
     global meshtastic_client, meshtastic_iface, reconnecting, shutting_down, event_loop, reconnect_task, _ble_future, _ble_future_address
     with meshtastic_lock:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2383,7 +2383,11 @@ def on_lost_meshtastic_connection(
             if isinstance(interface_source, str) and (
                 stripped := interface_source.strip()
             ):
-                detection_source = stripped
+                # Strip 'ble.' prefix to make detection source library-agnostic
+                if stripped.startswith("ble."):
+                    detection_source = stripped[4:]
+                else:
+                    detection_source = stripped
                 logger.debug(
                     "Using interface-provided detection source: %s", detection_source
                 )

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1081,9 +1081,8 @@ class TestConnectionLossHandling(unittest.TestCase):
         mmrelay.meshtastic_utils.shutting_down = False
 
         # Simulate official library interface (no _last_disconnect_source)
-        mock_interface = MagicMock()
-        # Explicitly ensure the attribute doesn't exist
-        del mock_interface._last_disconnect_source
+        mock_interface = Mock(spec=[])
+        # No _last_disconnect_source attribute on purpose (official lib shape)
 
         on_lost_meshtastic_connection(
             mock_interface, detection_source="unknown", topic=pub.AUTO_TOPIC

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1172,9 +1172,21 @@ class TestConnectionLossHandling(unittest.TestCase):
         # Create a mock topic object (simulating pypubsub Topic with getName())
         class MockTopic:
             def getName(self):
+                """
+                Get the canonical name for the Meshtastic connection-lost topic.
+                
+                Returns:
+                    str: The topic name "meshtastic.connection.lost".
+                """
                 return "meshtastic.connection.lost"
 
             def __str__(self):
+                """
+                Provide a sentinel string indicating this __str__ implementation is not intended for use.
+                
+                Returns:
+                    str: The sentinel string "should.not.be.used".
+                """
                 return "should.not.be.used"
 
         mock_topic = MockTopic()
@@ -1206,6 +1218,12 @@ class TestConnectionLossHandling(unittest.TestCase):
         # Test with a simple object that has __str__
         class SimpleTopic:
             def __str__(self):
+                """
+                Provide a human-readable string representation of the topic.
+                
+                Returns:
+                    str: The literal string "custom.topic.name" representing this topic.
+                """
                 return "custom.topic.name"
 
         simple_topic = SimpleTopic()

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1093,31 +1093,6 @@ class TestConnectionLossHandling(unittest.TestCase):
         self.assertIn("meshtastic.connection.lost", error_call)
 
     @patch("mmrelay.meshtastic_utils.logger")
-    def test_on_lost_meshtastic_connection_explicit_detection_source_preserved(
-        self, mock_logger
-    ):
-        """
-        Test that whitespace-only _last_disconnect_source is ignored and fallback is used.
-        """
-        from pubsub import pub
-
-        import mmrelay.meshtastic_utils
-
-        mmrelay.meshtastic_utils.reconnecting = False
-        mmrelay.meshtastic_utils.shutting_down = False
-
-        mock_interface = MagicMock()
-        mock_interface._last_disconnect_source = "   "  # Whitespace only
-
-        on_lost_meshtastic_connection(
-            mock_interface, detection_source="unknown", topic=pub.AUTO_TOPIC
-        )
-
-        # Should fall back to default detection source
-        error_call = mock_logger.error.call_args[0][0]
-        self.assertIn("meshtastic.connection.lost", error_call)
-
-    @patch("mmrelay.meshtastic_utils.logger")
     def test_on_lost_meshtastic_connection_auto_topic_fallback(self, mock_logger):
         """
         Test that pub.AUTO_TOPIC sentinel triggers default detection source and debug logging.

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -1174,7 +1174,7 @@ class TestConnectionLossHandling(unittest.TestCase):
             def getName(self):
                 """
                 Get the canonical name for the Meshtastic connection-lost topic.
-                
+
                 Returns:
                     str: The topic name "meshtastic.connection.lost".
                 """
@@ -1183,7 +1183,7 @@ class TestConnectionLossHandling(unittest.TestCase):
             def __str__(self):
                 """
                 Provide a sentinel string indicating this __str__ implementation is not intended for use.
-                
+
                 Returns:
                     str: The sentinel string "should.not.be.used".
                 """
@@ -1220,7 +1220,7 @@ class TestConnectionLossHandling(unittest.TestCase):
             def __str__(self):
                 """
                 Provide a human-readable string representation of the topic.
-                
+
                 Returns:
                     str: The literal string "custom.topic.name" representing this topic.
                 """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves how on_lost_meshtastic_connection determines and logs the detection source when a Meshtastic connection is lost. It adds a topic parameter and layered fallback logic so callers that pass "unknown" receive a more meaningful detection source. Tests were added to exercise the new resolution paths and related edge cases.

## Changes

Features:
- Added new optional parameter to on_lost_meshtastic_connection:
  - topic: Any = pub.AUTO_TOPIC
- Docstring updated to document the new topic parameter and the detection-source resolution behavior.
- Added unit tests covering detection-source derivation and related control-flow scenarios (BLE-derived source, AUTO_TOPIC behavior, topic name extraction, and explicit detection-source preservation).

Fixes:
- When detection_source == "unknown", detection_source is resolved with this precedence:
  - Use the BLE interface's _last_disconnect_source when present (trim whitespace and remove a redundant "ble." prefix if provided by the interface).
  - If no usable BLE source, derive a name from the pubsub topic (skip when topic == pub.AUTO_TOPIC; prefer topic.getName() when available, otherwise fall back to str(topic)).
  - If still unresolved, fall back to the default "meshtastic.connection.lost".
- Preserve explicitly supplied detection_source values (do not override when not "unknown").
- Added debug logging to indicate which resolution path was taken to aid diagnostics.

Refactors / clarity:
- Cleaned up topic-name extraction and AUTO_TOPIC sentinel checks.
- Removed library-specific wording and redundant prefixes from logs to be library-agnostic.
- Replaced MagicMock usage in tests with Mock(spec=[]) where appropriate to better model the official meshtastic library interfaces.

Migration Notes

- Backwards compatible: the new topic parameter defaults to pub.AUTO_TOPIC so existing callers do not need changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->