### PR TITLE
Expand E2EE security documentation

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -28,14 +28,14 @@ lint:
     - actionlint@1.7.11
     - bandit@1.9.3
     - black@26.1.0
-    - checkov@3.2.504
+    - checkov@3.2.506
     - git-diff-check
-    - isort@7.0.0
+    - isort@8.0.0
     - markdownlint@0.47.0
     - osv-scanner@2.3.3
     - prettier@3.8.1
-    - ruff@0.15.1
-    - trufflehog@3.93.1
+    - ruff@0.15.2
+    - trufflehog@3.93.4
     - yamllint@1.38.0
   ignore:
     - linters: [ALL]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 - Relays messages to/from an MQTT broker, if configured in the Meshtastic firmware
 - ✨️ _Bidirectional replies and reactions support_ ✨️
 - ✨️ _Native Docker support_ ✨️
-- 🔐 **Matrix End-to-End Encryption (E2EE) support** 🔐
+- 🔐 **Supports encrypted Matrix rooms (Matrix E2EE)** 🔐
 - 📁 **Unified directory structure** 📁 **NEW in v1.3!**
+
+> **Encryption note**: MMRelay can join **encrypted Matrix rooms** (Matrix E2EE). MMRelay is a bridge, so messages are decrypted/re-encrypted at the relay when crossing between Meshtastic and Matrix.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 - 🔐 **Supports encrypted Matrix rooms (Matrix E2EE)** 🔐
 - 📁 **Unified directory structure** 📁 **NEW in v1.3!**
 
-> **Encryption note**: MMRelay can join **encrypted Matrix rooms** (Matrix E2EE). MMRelay is a bridge, so messages are decrypted/re-encrypted at the relay when crossing between Meshtastic and Matrix.
+> **Encryption note**: MMRelay supports encrypted Matrix rooms (Matrix E2EE). For details on how this works and its security implications, see the [E2EE Setup Guide](docs/E2EE.md).
 
 ## Documentation
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -247,6 +247,17 @@ The `credentials.json` file contains:
 
 **Important**: Keep this file secure as it contains your Matrix access credentials.
 
+## Device Verification Status
+
+In your Matrix client (Element, etc.), MMRelay's messages will show as encrypted but with a warning about unverified devices. This is expected:
+
+- **Encrypted messages**: Show a red shield with "Encrypted by a device not verified by its owner"
+- **Unencrypted messages**: Show a red shield with "Not encrypted" warning
+
+**Why devices appear unverified**: Matrix clients use interactive verification (emoji comparisons, QR codes) to confirm device identity. The matrix-nio library doesn't support this verification protocol, so MMRelay devices cannot be verified. The messages are still encrypted — this just means you can't cryptographically confirm the device identity through the usual Matrix verification flow.
+
+If messages show as completely unencrypted in encrypted rooms, check your MMRelay version and configuration.
+
 ## Troubleshooting
 
 ### Common Issues
@@ -312,15 +323,6 @@ INFO Matrix: Performing initial sync to initialize rooms...
 INFO Matrix: Initial sync completed. Found X rooms.
 ```
 
-#### Verify Message Encryption
-
-In your Matrix client (Element, etc.):
-
-- **Encrypted messages**: Show with a red shield and a "Encrypted by a device not verified by its owner" (it's the best we've been able to do at the moment, due to upstream verification issues in `matrix-nio`)
-- **Unencrypted messages**: Show with a red shield and "Not encrypted" warning.
-
-If messages from MMRelay show as unencrypted in encrypted rooms, check your MMRelay version and configuration.
-
 ## Backward Compatibility
 
 E2EE support is fully backward compatible:
@@ -339,51 +341,6 @@ E2EE support is fully backward compatible:
 
 > **Note**: The Olm/Megolm encryption library (libolm) was deprecated in July 2024. Matrix.org considers it safe for practical use but recommends migrating to vodozemac. matrix-nio (which MMRelay uses) still depends on libolm, though migration work is in progress. We'll continue using the current encryption while it remains supported and stable.
 
-## Docker E2EE Setup
-
-MMRelay supports E2EE in Docker environments using environment variables for easy configuration.
-
-### Prerequisites
-
-- **Linux/macOS host**: E2EE is not supported on Windows due to library limitations
-- **E2EE-enabled image**: Use the official image `ghcr.io/jeremiah-k/mmrelay:latest`
-
-> **Production deployment**: The `:latest` tag is mutable and may change. For production deployments, pin a specific version tag or digest to ensure reproducible deployments.
-
-### Quick Docker E2EE Setup
-
-#### Method 1: Auth System + Docker (Recommended)
-
-For complete Docker E2EE setup instructions with environment variables for operational settings, see the [Docker Guide E2EE Setup section](DOCKER.md#method-1-auth-system--environment-variables-recommended-for-e2ee).
-
-#### Method 2: Mount Credentials File
-
-```bash
-# On host: Create credentials using auth login
-mmrelay auth login
-
-# Then mount the credentials file
-```
-
-```yaml
-volumes:
-  - ${MMRELAY_HOST_HOME:-$HOME}/.mmrelay:/data # Includes matrix/credentials.json and matrix/store
-```
-
-### Configuration
-
-Ensure E2EE is enabled in your `config.yaml`:
-
-```yaml
-matrix:
-  e2ee:
-    enabled: true
-```
-
-The E2EE store directory is automatically created in the mounted data volume.
-
-For complete Docker setup instructions, see the [Docker Guide](DOCKER.md#method-1-auth-system--environment-variables-recommended-for-e2ee).
-
 ### Performance Impact
 
 E2EE adds minimal overhead:
@@ -392,5 +349,3 @@ E2EE adds minimal overhead:
 - **Message latency**: Negligible encryption/decryption time
 - **Memory usage**: Small increase for key storage
 - **Network usage**: Additional sync traffic for key management
-
-For questions or issues with E2EE support, please check the [GitHub Issues](https://github.com/jeremiah-k/meshtastic-matrix-relay/issues) or create a new issue with the `e2ee` label.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Welcome to the MMRelay documentation! This directory contains comprehensive guid
 
 - **[Installation Guide](INSTRUCTIONS.md)** - Complete setup instructions for MMRelay
 - **[Migration Guide for v1.3](MIGRATION_1.3.md)** - Upgrading from older versions to unified HOME model
-- **[E2EE Guide](E2EE.md)** - Matrix End-to-End Encryption setup and usage
+- **[E2EE Guide](E2EE.md)** - Encrypted Matrix rooms (Matrix E2EE) setup and usage
 - **[Docker Guide](DOCKER.md)** - Docker deployment and configuration
 - **[Helm Guide](HELM.md)** - Kubernetes Helm chart deployment guide
 
@@ -74,4 +74,4 @@ docs/
 - **Current Version**: v1.3+
 - **Python Requirement**: 3.10+
 - **Supported Platforms**: Linux, macOS, Windows (E2EE not available on Windows)
-- **Key Features**: Meshtastic ↔ Matrix relay, E2EE support, Docker deployment, Plugin system
+- **Key Features**: Meshtastic ↔ Matrix relay, encrypted Matrix rooms (Matrix E2EE), Docker deployment, Plugin system


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR updates documentation across the README and E2EE guide to clarify how MMRelay handles encryption when participating in encrypted Matrix rooms. The key clarification is that while MMRelay can operate in Matrix E2EE rooms, messages are decrypted and re-encrypted at the relay when crossing between Meshtastic and Matrix, rather than providing end-to-end encryption across the entire path. The changes also include several minor dependency version updates.

## Key Changes

**Documentation Updates**
- Updated terminology in README to emphasize "encrypted Matrix rooms (Matrix E2EE)" support with added encryption note block
- Revised E2EE.md introduction to explicitly state that MMRelay can participate in encrypted Matrix rooms but that messages are decrypted/re-encrypted at the relay boundary
- Added new "What E2EE means and does not mean" section clarifying:
  - Matrix-side protection between MMRelay and other Matrix clients (using Olm/Megolm)
  - That E2EE does not provide end-to-end encryption from Meshtastic to Matrix
  - That plaintext is accessible on the relay host
- Added comprehensive "Security Considerations" section covering trust model, Meshtastic encryption implications, credentials and key storage details, and recommendations for access control
- Added deprecation notes regarding libolm and ongoing migration to vodozemac in two locations (Backward Compatibility and Technical Details sections)
- Expanded Docker E2EE setup guidance with prerequisites and production deployment recommendations, including cautions about pinning versions instead of using :latest tag
- Updated docs/README.md to clarify E2EE Guide description and Key Features line

**Dependencies**
- Updated .trunk/trunk.yaml tool versions: checkov (3.2.504 → 3.2.506), isort (7.0.0 → 8.0.0), ruff (0.15.1 → 0.15.2), trufflehog (3.93.1 → 3.93.4)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->