### PR TITLE
Add firmware version helpers; update health checks; nodes plugin fix

### DIFF
--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -657,12 +657,11 @@ def get_longname(meshtastic_id: int | str) -> str | None:
 
 def save_longname(meshtastic_id: int | str, longname: str) -> None:
     """
-    Persist the long display name for a Meshtastic node.
-
-    If an entry for the given node exists, its longname is updated; database errors are logged and suppressed.
+    Normalize a node ID and upsert its long display name.
 
     Parameters:
-        meshtastic_id (int | str): Identifier of the Meshtastic node; will be normalized to a string.
+        meshtastic_id (int | str): Identifier of the Meshtastic node; stored as a
+            string key.
         longname (str): Full display name to store for the node.
     """
     manager = _get_db_manager()
@@ -694,13 +693,15 @@ def _update_names_core(
     delete_stale_names: Callable[[set[str]], int],
 ) -> None:
     """
-    Update persisted node names and remove stale rows for one name type.
+    Persist one user name field from a node snapshot and prune stale rows.
 
     Parameters:
-        nodes (dict[str, Any]): Node mapping containing optional `user` dictionaries.
+        nodes (dict[str, Any]): Snapshot of node records containing optional
+            `user` dictionaries.
         name_key (str): User field to read (`"longName"` or `"shortName"`).
-        save_name (Callable[[str, str], None]): Function that persists one name.
-        delete_stale_names (Callable[[set[str]], int]): Function that removes stale rows.
+        save_name (Callable[[str, str], None]): Function used to persist one name.
+        delete_stale_names (Callable[[set[str]], int]): Function used to delete
+            rows whose Meshtastic IDs are absent from the snapshot.
     """
     if not nodes:
         return
@@ -726,14 +727,11 @@ def _update_names_core(
 
 def update_longnames(nodes: dict[str, Any]) -> None:
     """
-    Persist long names from node user entries into the database.
-
-    For each node in `nodes` that contains a `"user"` mapping with a present `"longName"`, save it under the user's `"id"` by calling `save_longname`. Nodes with missing `"longName"` are skipped to avoid overwriting existing database entries with placeholder values.
-
-    After updating, removes stale entries from the database that are no longer present in the device's nodedb.
+    Persist each node's `longName` and prune stale longname rows.
 
     Parameters:
-        nodes (dict[str, Any]): Mapping of node identifiers to node dictionaries; each node dictionary may include a `"user"` dict with an `"id"` key and an optional `"longName"` key.
+        nodes (dict[str, Any]): Mapping of node identifiers to node dictionaries;
+            each node may expose a `user` dict with `id` and `longName`.
     """
     _update_names_core(
         nodes,
@@ -812,15 +810,18 @@ def _delete_stale_names_core(
     cursor: sqlite3.Cursor, table: str, current_ids: set[str]
 ) -> int:
     """
-    Delete entries from a names table that are not in the current set of node IDs.
+    Delete rows whose `meshtastic_id` is missing from the current node snapshot.
 
     Parameters:
-        cursor (sqlite3.Cursor): Database cursor for executing queries.
-        table (str): Table name ('longnames' or 'shortnames').
-        current_ids (set[str]): Set of Meshtastic node IDs that are currently valid.
+        cursor (sqlite3.Cursor): Database cursor used to execute the delete.
+        table (str): Table name (`"longnames"` or `"shortnames"`).
+        current_ids (set[str]): Set of Meshtastic node IDs that should be kept.
 
     Returns:
         int: Number of rows deleted.
+
+    Raises:
+        ValueError: If `table` is not a supported names table.
     """
     sql_prefix_by_table = {
         "longnames": "DELETE FROM longnames WHERE meshtastic_id NOT IN (",
@@ -858,6 +859,9 @@ def _delete_stale_names(table_name: str, current_ids: set[str]) -> int:
     manager = _get_db_manager()
 
     def _delete(cursor: sqlite3.Cursor) -> int:
+        """
+        Delete stale name rows using the bound table name and current ID set.
+        """
         return _delete_stale_names_core(cursor, table_name, current_ids)
 
     try:
@@ -875,13 +879,14 @@ def _delete_stale_names(table_name: str, current_ids: set[str]) -> int:
 
 def delete_stale_longnames(current_ids: set[str]) -> int:
     """
-    Remove long name entries for nodes no longer in the device's nodedb.
+    Delete stored long names for nodes absent from the current snapshot.
 
     Parameters:
-        current_ids (set[str]): Set of Meshtastic node IDs currently known to the device.
+        current_ids (set[str]): Set of Meshtastic node IDs currently known to the
+            device.
 
     Returns:
-        int: Number of stale entries removed.
+        int: Number of rows removed from the longnames table.
     """
     return _delete_stale_names("longnames", current_ids)
 

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -841,11 +841,12 @@ def _delete_stale_names_core(
     return cursor.rowcount
 
 
-def delete_stale_longnames(current_ids: set[str]) -> int:
+def _delete_stale_names(table_name: str, current_ids: set[str]) -> int:
     """
-    Remove long name entries for nodes no longer in the device's nodedb.
+    Remove name entries for nodes no longer in the device's nodedb.
 
     Parameters:
+        table_name (str): The name of the table to prune ('longnames' or 'shortnames').
         current_ids (set[str]): Set of Meshtastic node IDs currently known to the device.
 
     Returns:
@@ -857,16 +858,32 @@ def delete_stale_longnames(current_ids: set[str]) -> int:
     manager = _get_db_manager()
 
     def _delete(cursor: sqlite3.Cursor) -> int:
-        return _delete_stale_names_core(cursor, "longnames", current_ids)
+        return _delete_stale_names_core(cursor, table_name, current_ids)
 
     try:
         deleted = manager.run_sync(_delete, write=True)
         if deleted > 0:
-            logger.debug("Removed %d stale longname entries", deleted)
+            # Derive singular name type from table name for logging
+            name_type = table_name.rstrip("s")
+            logger.debug("Removed %d stale %s entries", deleted, name_type)
         return deleted
     except sqlite3.Error:
-        logger.exception("Database error deleting stale longnames")
+        name_type = table_name.rstrip("s")
+        logger.exception("Database error deleting stale %ss", name_type)
         return 0
+
+
+def delete_stale_longnames(current_ids: set[str]) -> int:
+    """
+    Remove long name entries for nodes no longer in the device's nodedb.
+
+    Parameters:
+        current_ids (set[str]): Set of Meshtastic node IDs currently known to the device.
+
+    Returns:
+        int: Number of stale entries removed.
+    """
+    return _delete_stale_names("longnames", current_ids)
 
 
 def delete_stale_shortnames(current_ids: set[str]) -> int:
@@ -879,22 +896,7 @@ def delete_stale_shortnames(current_ids: set[str]) -> int:
     Returns:
         int: Number of stale entries removed.
     """
-    if not current_ids:
-        return 0
-
-    manager = _get_db_manager()
-
-    def _delete(cursor: sqlite3.Cursor) -> int:
-        return _delete_stale_names_core(cursor, "shortnames", current_ids)
-
-    try:
-        deleted = manager.run_sync(_delete, write=True)
-        if deleted > 0:
-            logger.debug("Removed %d stale shortname entries", deleted)
-        return deleted
-    except sqlite3.Error:
-        logger.exception("Database error deleting stale shortnames")
-        return 0
+    return _delete_stale_names("shortnames", current_ids)
 
 
 def update_shortnames(nodes: dict[str, Any]) -> None:

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -705,13 +705,16 @@ def update_longnames(nodes: dict[str, Any]) -> None:
         user = node.get("user")
         if user:
             meshtastic_id = user.get("id")
-            if not meshtastic_id:
+            if meshtastic_id is None or (
+                isinstance(meshtastic_id, str) and meshtastic_id == ""
+            ):
                 continue
-            current_ids.add(meshtastic_id)
+            id_key = str(meshtastic_id)
+            current_ids.add(id_key)
             longname = user.get("longName")
             # Only save if longName is present to avoid overwriting valid names with placeholders
             if longname:
-                save_longname(meshtastic_id, longname)
+                save_longname(id_key, longname)
 
     # Remove stale entries that are no longer in the device's nodedb
     if current_ids:
@@ -797,8 +800,12 @@ def _delete_stale_names_core(
     Returns:
         int: Number of rows deleted.
     """
-    allowed_tables = {"longnames", "shortnames"}
-    if table not in allowed_tables:
+    sql_by_table = {
+        "longnames": "DELETE FROM longnames WHERE meshtastic_id NOT IN ({})",
+        "shortnames": "DELETE FROM shortnames WHERE meshtastic_id NOT IN ({})",
+    }
+    delete_sql = sql_by_table.get(table)
+    if delete_sql is None:
         raise ValueError(f"Invalid table name: {table}")
 
     if not current_ids:
@@ -806,7 +813,7 @@ def _delete_stale_names_core(
 
     placeholders = ",".join("?" * len(current_ids))
     cursor.execute(
-        f"DELETE FROM {table} WHERE meshtastic_id NOT IN ({placeholders})",
+        delete_sql.format(placeholders),
         tuple(current_ids),
     )
     return cursor.rowcount
@@ -887,13 +894,16 @@ def update_shortnames(nodes: dict[str, Any]) -> None:
         user = node.get("user")
         if user:
             meshtastic_id = user.get("id")
-            if not meshtastic_id:
+            if meshtastic_id is None or (
+                isinstance(meshtastic_id, str) and meshtastic_id == ""
+            ):
                 continue
-            current_ids.add(meshtastic_id)
+            id_key = str(meshtastic_id)
+            current_ids.add(id_key)
             shortname = user.get("shortName")
             # Only save if shortName is present to avoid overwriting valid names with placeholders
             if shortname:
-                save_shortname(meshtastic_id, shortname)
+                save_shortname(id_key, shortname)
 
     # Remove stale entries that are no longer in the device's nodedb
     if current_ids:

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -704,7 +704,9 @@ def update_longnames(nodes: dict[str, Any]) -> None:
     for node in nodes.values():
         user = node.get("user")
         if user:
-            meshtastic_id = user["id"]
+            meshtastic_id = user.get("id")
+            if not meshtastic_id:
+                continue
             current_ids.add(meshtastic_id)
             longname = user.get("longName")
             # Only save if longName is present to avoid overwriting valid names with placeholders
@@ -880,7 +882,9 @@ def update_shortnames(nodes: dict[str, Any]) -> None:
     for node in nodes.values():
         user = node.get("user")
         if user:
-            meshtastic_id = user["id"]
+            meshtastic_id = user.get("id")
+            if not meshtastic_id:
+                continue
             current_ids.add(meshtastic_id)
             shortname = user.get("shortName")
             # Only save if shortName is present to avoid overwriting valid names with placeholders

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -4,7 +4,7 @@ import json
 import os
 import sqlite3
 import threading
-from typing import Any, Dict, Tuple, cast
+from typing import Any, Callable, Dict, Tuple, cast
 
 from mmrelay.constants.database import (
     DEFAULT_BUSY_TIMEOUT_MS,
@@ -686,16 +686,21 @@ def save_longname(meshtastic_id: int | str, longname: str) -> None:
         logger.exception("Database error saving longname for %s", meshtastic_id)
 
 
-def update_longnames(nodes: dict[str, Any]) -> None:
+def _update_names_core(
+    nodes: dict[str, Any],
+    *,
+    name_key: str,
+    save_name: Callable[[str, str], None],
+    delete_stale_names: Callable[[set[str]], int],
+) -> None:
     """
-    Persist long names from node user entries into the database.
-
-    For each node in `nodes` that contains a `"user"` mapping with a present `"longName"`, save it under the user's `"id"` by calling `save_longname`. Nodes with missing `"longName"` are skipped to avoid overwriting existing database entries with placeholder values.
-
-    After updating, removes stale entries from the database that are no longer present in the device's nodedb.
+    Update persisted node names and remove stale rows for one name type.
 
     Parameters:
-        nodes (dict[str, Any]): Mapping of node identifiers to node dictionaries; each node dictionary may include a `"user"` dict with an `"id"` key and an optional `"longName"` key.
+        nodes (dict[str, Any]): Node mapping containing optional `user` dictionaries.
+        name_key (str): User field to read (`"longName"` or `"shortName"`).
+        save_name (Callable[[str, str], None]): Function that persists one name.
+        delete_stale_names (Callable[[set[str]], int]): Function that removes stale rows.
     """
     if not nodes:
         return
@@ -711,14 +716,31 @@ def update_longnames(nodes: dict[str, Any]) -> None:
                 continue
             id_key = str(meshtastic_id)
             current_ids.add(id_key)
-            longname = user.get("longName")
-            # Only save if longName is present to avoid overwriting valid names with placeholders
-            if longname:
-                save_longname(id_key, longname)
+            name_value = user.get(name_key)
+            if name_value:
+                save_name(id_key, name_value)
 
-    # Remove stale entries that are no longer in the device's nodedb
     if current_ids:
-        delete_stale_longnames(current_ids)
+        delete_stale_names(current_ids)
+
+
+def update_longnames(nodes: dict[str, Any]) -> None:
+    """
+    Persist long names from node user entries into the database.
+
+    For each node in `nodes` that contains a `"user"` mapping with a present `"longName"`, save it under the user's `"id"` by calling `save_longname`. Nodes with missing `"longName"` are skipped to avoid overwriting existing database entries with placeholder values.
+
+    After updating, removes stale entries from the database that are no longer present in the device's nodedb.
+
+    Parameters:
+        nodes (dict[str, Any]): Mapping of node identifiers to node dictionaries; each node dictionary may include a `"user"` dict with an `"id"` key and an optional `"longName"` key.
+    """
+    _update_names_core(
+        nodes,
+        name_key="longName",
+        save_name=save_longname,
+        delete_stale_names=delete_stale_longnames,
+    )
 
 
 def get_shortname(meshtastic_id: int | str) -> str | None:
@@ -886,28 +908,12 @@ def update_shortnames(nodes: dict[str, Any]) -> None:
     Parameters:
         nodes (Mapping): Mapping of node identifiers to node objects; nodes without a `user` entry are ignored.
     """
-    if not nodes:
-        return
-
-    current_ids: set[str] = set()
-    for node in nodes.values():
-        user = node.get("user")
-        if user:
-            meshtastic_id = user.get("id")
-            if meshtastic_id is None or (
-                isinstance(meshtastic_id, str) and meshtastic_id == ""
-            ):
-                continue
-            id_key = str(meshtastic_id)
-            current_ids.add(id_key)
-            shortname = user.get("shortName")
-            # Only save if shortName is present to avoid overwriting valid names with placeholders
-            if shortname:
-                save_shortname(id_key, shortname)
-
-    # Remove stale entries that are no longer in the device's nodedb
-    if current_ids:
-        delete_stale_shortnames(current_ids)
+    _update_names_core(
+        nodes,
+        name_key="shortName",
+        save_name=save_shortname,
+        delete_stale_names=delete_stale_shortnames,
+    )
 
 
 def _store_message_map_core(

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -692,18 +692,28 @@ def update_longnames(nodes: dict[str, Any]) -> None:
 
     For each node in `nodes` that contains a `"user"` mapping with a present `"longName"`, save it under the user's `"id"` by calling `save_longname`. Nodes with missing `"longName"` are skipped to avoid overwriting existing database entries with placeholder values.
 
+    After updating, removes stale entries from the database that are no longer present in the device's nodedb.
+
     Parameters:
         nodes (dict[str, Any]): Mapping of node identifiers to node dictionaries; each node dictionary may include a `"user"` dict with an `"id"` key and an optional `"longName"` key.
     """
-    if nodes:
-        for node in nodes.values():
-            user = node.get("user")
-            if user:
-                meshtastic_id = user["id"]
-                longname = user.get("longName")
-                # Only save if longName is present to avoid overwriting valid names with placeholders
-                if longname:
-                    save_longname(meshtastic_id, longname)
+    if not nodes:
+        return
+
+    current_ids: set[str] = set()
+    for node in nodes.values():
+        user = node.get("user")
+        if user:
+            meshtastic_id = user["id"]
+            current_ids.add(meshtastic_id)
+            longname = user.get("longName")
+            # Only save if longName is present to avoid overwriting valid names with placeholders
+            if longname:
+                save_longname(meshtastic_id, longname)
+
+    # Remove stale entries that are no longer in the device's nodedb
+    if current_ids:
+        delete_stale_longnames(current_ids)
 
 
 def get_shortname(meshtastic_id: int | str) -> str | None:
@@ -771,24 +781,115 @@ def save_shortname(meshtastic_id: int | str, shortname: str) -> None:
         logger.exception("Database error saving shortname for %s", meshtastic_id)
 
 
+def _delete_stale_names_core(
+    cursor: sqlite3.Cursor, table: str, current_ids: set[str]
+) -> int:
+    """
+    Delete entries from a names table that are not in the current set of node IDs.
+
+    Parameters:
+        cursor (sqlite3.Cursor): Database cursor for executing queries.
+        table (str): Table name ('longnames' or 'shortnames').
+        current_ids (set[str]): Set of Meshtastic node IDs that are currently valid.
+
+    Returns:
+        int: Number of rows deleted.
+    """
+    if not current_ids:
+        return 0
+
+    placeholders = ",".join("?" * len(current_ids))
+    cursor.execute(
+        f"DELETE FROM {table} WHERE meshtastic_id NOT IN ({placeholders})",
+        tuple(current_ids),
+    )
+    return cursor.rowcount
+
+
+def delete_stale_longnames(current_ids: set[str]) -> int:
+    """
+    Remove long name entries for nodes no longer in the device's nodedb.
+
+    Parameters:
+        current_ids (set[str]): Set of Meshtastic node IDs currently known to the device.
+
+    Returns:
+        int: Number of stale entries removed.
+    """
+    if not current_ids:
+        return 0
+
+    manager = _get_db_manager()
+
+    def _delete(cursor: sqlite3.Cursor) -> int:
+        return _delete_stale_names_core(cursor, "longnames", current_ids)
+
+    try:
+        deleted = manager.run_sync(_delete, write=True)
+        if deleted > 0:
+            logger.debug("Removed %d stale longname entries", deleted)
+        return deleted
+    except sqlite3.Error:
+        logger.exception("Database error deleting stale longnames")
+        return 0
+
+
+def delete_stale_shortnames(current_ids: set[str]) -> int:
+    """
+    Remove short name entries for nodes no longer in the device's nodedb.
+
+    Parameters:
+        current_ids (set[str]): Set of Meshtastic node IDs currently known to the device.
+
+    Returns:
+        int: Number of stale entries removed.
+    """
+    if not current_ids:
+        return 0
+
+    manager = _get_db_manager()
+
+    def _delete(cursor: sqlite3.Cursor) -> int:
+        return _delete_stale_names_core(cursor, "shortnames", current_ids)
+
+    try:
+        deleted = manager.run_sync(_delete, write=True)
+        if deleted > 0:
+            logger.debug("Removed %d stale shortname entries", deleted)
+        return deleted
+    except sqlite3.Error:
+        logger.exception("Database error deleting stale shortnames")
+        return 0
+
+
 def update_shortnames(nodes: dict[str, Any]) -> None:
     """
     Update persisted short names for nodes that include a user object.
 
     For each node in the provided mapping, if the node contains a `user` dictionary with a present `shortName`, the function uses `user["id"]` as the Meshtastic ID and stores the short name in the database. Nodes with missing `shortName` are skipped to avoid overwriting existing database entries with placeholder values.
 
+    After updating, removes stale entries from the database that are no longer present in the device's nodedb.
+
     Parameters:
         nodes (Mapping): Mapping of node identifiers to node objects; nodes without a `user` entry are ignored.
     """
-    if nodes:
-        for node in nodes.values():
-            user = node.get("user")
-            if user:
-                meshtastic_id = user["id"]
-                shortname = user.get("shortName")
-                # Only save if shortName is present to avoid overwriting valid names with placeholders
-                if shortname:
-                    save_shortname(meshtastic_id, shortname)
+    if not nodes:
+        return
+
+    current_ids: set[str] = set()
+    for node in nodes.values():
+        user = node.get("user")
+        if user:
+            meshtastic_id = user["id"]
+            current_ids.add(meshtastic_id)
+            shortname = user.get("shortName")
+            # Only save if shortName is present to avoid overwriting valid names with placeholders
+            if shortname:
+                save_shortname(meshtastic_id, shortname)
+
+    # Remove stale entries that are no longer in the device's nodedb
+    if current_ids:
+        delete_stale_shortnames(current_ids)
 
 
 def _store_message_map_core(

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -822,12 +822,12 @@ def _delete_stale_names_core(
     Returns:
         int: Number of rows deleted.
     """
-    sql_by_table = {
-        "longnames": "DELETE FROM longnames WHERE meshtastic_id NOT IN ({})",
-        "shortnames": "DELETE FROM shortnames WHERE meshtastic_id NOT IN ({})",
+    sql_prefix_by_table = {
+        "longnames": "DELETE FROM longnames WHERE meshtastic_id NOT IN (",
+        "shortnames": "DELETE FROM shortnames WHERE meshtastic_id NOT IN (",
     }
-    delete_sql = sql_by_table.get(table)
-    if delete_sql is None:
+    delete_sql_prefix = sql_prefix_by_table.get(table)
+    if delete_sql_prefix is None:
         raise ValueError(f"Invalid table name: {table}")
 
     if not current_ids:
@@ -835,7 +835,7 @@ def _delete_stale_names_core(
 
     placeholders = ",".join("?" * len(current_ids))
     cursor.execute(
-        delete_sql.format(placeholders),
+        f"{delete_sql_prefix}{placeholders})",
         tuple(current_ids),
     )
     return cursor.rowcount

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -797,6 +797,10 @@ def _delete_stale_names_core(
     Returns:
         int: Number of rows deleted.
     """
+    allowed_tables = {"longnames", "shortnames"}
+    if table not in allowed_tables:
+        raise ValueError(f"Invalid table name: {table}")
+
     if not current_ids:
         return 0
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -3048,7 +3048,6 @@ async def check_connection() -> None:
                             logger.debug(
                                 "Metadata parse failed but device responded to getMyNodeInfo(); skipping reconnect this cycle"
                             )
-                            continue
 
                 except Exception as e:
                     # Only trigger reconnection if we're not already reconnecting

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -990,13 +990,14 @@ def _extract_firmware_version_from_metadata(metadata_source: Any) -> str | None:
 
 def _extract_firmware_version_from_client(client: Any) -> str | None:
     """
-    Read firmware version from known client metadata locations.
+    Return the first normalized firmware version exposed on common client fields.
 
     Parameters:
-        client (Any): Meshtastic client object.
+        client (Any): Meshtastic client object to inspect.
 
     Returns:
-        str | None: Firmware version if present in any metadata location.
+        str | None: Firmware version if present on the client, local node, or
+            local interface metadata.
     """
     local_node = getattr(client, "localNode", None)
     local_iface = getattr(local_node, "iface", None) if local_node else None

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import atexit
 import contextlib
+import functools
 import importlib.util
 import inspect
 import io
@@ -1012,11 +1013,17 @@ def _extract_firmware_version_from_client(client: Any) -> str | None:
     return None
 
 
-def _get_device_metadata(client: Any) -> dict[str, Any]:
+def _get_device_metadata(
+    client: Any,
+    *,
+    force_refresh: bool = False,
+    raise_on_error: bool = False,
+) -> dict[str, Any]:
     """
     Retrieve firmware version and raw metadata output from a Meshtastic client.
 
-    Prefers structured metadata already present on the client/interface. If no
+    Prefers structured metadata already present on the client/interface unless
+    `force_refresh=True`. If no
     usable firmware version is cached, attempts to call
     `client.localNode.getMetadata()`, captures console output produced by that
     call, and extracts firmware version information from output and any updated
@@ -1024,6 +1031,11 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
 
     Parameters:
         client (Any): Meshtastic client object expected to expose localNode.getMetadata(); if absent, metadata retrieval is skipped.
+        force_refresh (bool): If `True`, always call `getMetadata()` even when
+            structured metadata is already cached. Health checks use this mode
+            intentionally because it issues an on-wire admin request.
+        raise_on_error (bool): If `True`, re-raise metadata probe failures after
+            logging so callers can treat failures as liveness errors.
 
     Returns:
         dict: {
@@ -1037,7 +1049,7 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
 
     try:
         cached_firmware = _extract_firmware_version_from_client(client)
-        if cached_firmware is not None:
+        if cached_firmware is not None and not force_refresh:
             result["firmware_version"] = cached_firmware
             result["success"] = True
             return result
@@ -1046,6 +1058,10 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
         if not getattr(client, "localNode", None) or not hasattr(
             client.localNode, "getMetadata"
         ):
+            if raise_on_error:
+                raise RuntimeError(
+                    "Meshtastic client has no localNode.getMetadata() for metadata probe"
+                )
             logger.debug(
                 "Meshtastic client has no localNode.getMetadata(); skipping metadata retrieval"
             )
@@ -1102,8 +1118,10 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
         future_error: Exception | None = None
         try:
             future.result(timeout=30.0)
-        except FuturesTimeoutError:
+        except FuturesTimeoutError as e:
             timed_out = True
+            if raise_on_error:
+                future_error = e
             logger.debug("getMetadata() timed out after 30 seconds")
             # If the worker is still running, restore stdio immediately so the
             # main process does not keep writing to the captured buffer.
@@ -1176,6 +1194,8 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
         logger.debug(
             "Could not retrieve device metadata via localNode.getMetadata()", exc_info=e
         )
+        if raise_on_error:
+            raise
 
     return result
 
@@ -3069,7 +3089,13 @@ async def check_connection() -> None:
       - `enabled` (bool, default True) — enable or disable checks.
       - `heartbeat_interval` (int, seconds, default 60) — interval between checks. For backward compatibility, a top-level `heartbeat_interval` under `config["meshtastic"]` is supported.
     - BLE connections are excluded from periodic checks because BLE libraries provide real-time disconnect detection; this function returns early for BLE.
-    - For non-BLE connections, performs a liveness probe using `client.getMyNodeInfo()`. If the probe fails and no reconnection is already in progress, calls on_lost_meshtastic_connection(...) to initiate reconnection.
+    - For non-BLE connections, performs a forced metadata admin probe via
+      `localNode.getMetadata()` (through `_get_device_metadata(force_refresh=True)`).
+      If the probe fails and no reconnection is already in progress, calls
+      on_lost_meshtastic_connection(...) to initiate reconnection.
+    - IMPORTANT: Do not use `getMyNodeInfo()` as the primary liveness probe here.
+      In current Meshtastic Python it reads cached local node data and does not
+      guarantee a fresh on-wire round trip.
 
     No return value; side effects are logging and scheduling/triggering reconnection when the device is unresponsive.
     """
@@ -3106,8 +3132,19 @@ async def check_connection() -> None:
         if meshtastic_client and not reconnecting:
             try:
                 loop = asyncio.get_running_loop()
+                # NOTE: Use a forced metadata probe for keepalive/liveness.
+                # `getMyNodeInfo()` is local cached state in Meshtastic Python,
+                # so it can succeed even when the transport is unhealthy.
                 await asyncio.wait_for(
-                    loop.run_in_executor(None, meshtastic_client.getMyNodeInfo),
+                    loop.run_in_executor(
+                        None,
+                        functools.partial(
+                            _get_device_metadata,
+                            meshtastic_client,
+                            force_refresh=True,
+                            raise_on_error=True,
+                        ),
+                    ),
                     timeout=DEFAULT_MESHTASTIC_OPERATION_TIMEOUT,
                 )
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1181,15 +1181,19 @@ def _get_device_metadata(
             r"(?i)\bfirmware[\s_/-]*version\b\s*[:=]\s*['\"]?\s*([^\s\r\n'\"]+)",
             console_output,
         )
-        if match:
-            parsed = match.group(1).strip()
-            if parsed:
-                result["firmware_version"] = parsed
-                result["success"] = True
+        parsed_output_firmware = (
+            _normalize_firmware_version(match.group(1)) if match else None
+        )
+        if parsed_output_firmware is not None:
+            result["firmware_version"] = parsed_output_firmware
+            result["success"] = True
         else:
             refreshed_firmware = _extract_firmware_version_from_client(client)
-            if refreshed_firmware is not None:
-                result["firmware_version"] = refreshed_firmware
+            normalized_refreshed_firmware = _normalize_firmware_version(
+                refreshed_firmware
+            )
+            if normalized_refreshed_firmware is not None:
+                result["firmware_version"] = normalized_refreshed_firmware
                 result["success"] = True
 
     except Exception as e:  # noqa: BLE001 - metadata failures must not block startup

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -999,12 +999,12 @@ def _extract_firmware_version_from_client(client: Any) -> str | None:
         str | None: Firmware version if present in any metadata location.
     """
     local_node = getattr(client, "localNode", None)
-    local_iface = getattr(local_node, "iface", None)
+    local_iface = getattr(local_node, "iface", None) if local_node else None
 
     candidates = (
         getattr(client, "metadata", None),
-        getattr(local_node, "metadata", None),
-        getattr(local_iface, "metadata", None),
+        local_node and getattr(local_node, "metadata", None),
+        local_iface and getattr(local_iface, "metadata", None),
     )
     for candidate in candidates:
         parsed = _extract_firmware_version_from_metadata(candidate)
@@ -1101,6 +1101,8 @@ def _get_device_metadata(
                 # A previous metadata request is still running; avoid piling up
                 # threads and leave the in-flight call to finish in its own time.
                 logger.debug("getMetadata() already running; skipping new request")
+                if raise_on_error:
+                    raise RuntimeError("getMetadata() probe already in progress")
                 return result
 
             try:
@@ -1112,6 +1114,8 @@ def _get_device_metadata(
                     "getMetadata() submission failed; skipping metadata retrieval",
                     exc_info=exc,
                 )
+                if raise_on_error:
+                    raise
                 return result
             _metadata_future = future
         timed_out = False
@@ -3148,15 +3152,17 @@ async def check_connection() -> None:
                     timeout=DEFAULT_MESHTASTIC_OPERATION_TIMEOUT,
                 )
 
-            except Exception as e:
+            except Exception as exc:
                 # Only trigger reconnection if we're not already reconnecting
                 if not reconnecting:
-                    logger.error(
-                        f"{connection_type.capitalize()} connection health check failed: {e}"
+                    logger.exception(
+                        "%s connection health check failed: %s",
+                        connection_type.capitalize(),
+                        exc,
                     )
                     on_lost_meshtastic_connection(
                         interface=meshtastic_client,
-                        detection_source=f"health check failed: {str(e)}",
+                        detection_source=f"health check failed: {exc!s}",
                     )
                 else:
                     logger.debug("Skipping reconnection trigger - already reconnecting")

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -940,11 +940,87 @@ def _get_name_or_none(
         return None
 
 
+def _normalize_firmware_version(value: Any) -> str | None:
+    """
+    Normalize a firmware version candidate into a non-empty string.
+
+    Parameters:
+        value (Any): Candidate firmware value from metadata sources.
+
+    Returns:
+        str | None: Trimmed firmware version string when valid, otherwise None.
+    """
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="ignore")
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized:
+            return normalized
+    return None
+
+
+def _extract_firmware_version_from_metadata(metadata_source: Any) -> str | None:
+    """
+    Extract firmware version from a metadata object or mapping.
+
+    Supports both snake_case and camelCase field names for compatibility with
+    different Meshtastic payload shapes.
+
+    Parameters:
+        metadata_source (Any): Metadata container (protobuf-like object or dict).
+
+    Returns:
+        str | None: Firmware version if available, else None.
+    """
+    if metadata_source is None:
+        return None
+
+    if isinstance(metadata_source, dict):
+        return _normalize_firmware_version(
+            metadata_source.get("firmware_version")
+            or metadata_source.get("firmwareVersion")
+        )
+
+    return _normalize_firmware_version(
+        getattr(metadata_source, "firmware_version", None)
+        or getattr(metadata_source, "firmwareVersion", None)
+    )
+
+
+def _extract_firmware_version_from_client(client: Any) -> str | None:
+    """
+    Read firmware version from known client metadata locations.
+
+    Parameters:
+        client (Any): Meshtastic client object.
+
+    Returns:
+        str | None: Firmware version if present in any metadata location.
+    """
+    local_node = getattr(client, "localNode", None)
+    local_iface = getattr(local_node, "iface", None)
+
+    candidates = (
+        getattr(client, "metadata", None),
+        getattr(local_node, "metadata", None),
+        getattr(local_iface, "metadata", None),
+    )
+    for candidate in candidates:
+        parsed = _extract_firmware_version_from_metadata(candidate)
+        if parsed is not None:
+            return parsed
+    return None
+
+
 def _get_device_metadata(client: Any) -> dict[str, Any]:
     """
     Retrieve firmware version and raw metadata output from a Meshtastic client.
 
-    Attempts to call client.localNode.getMetadata() (when present), captures any console output produced, and extracts a firmware version string if available.
+    Prefers structured metadata already present on the client/interface. If no
+    usable firmware version is cached, attempts to call
+    `client.localNode.getMetadata()`, captures console output produced by that
+    call, and extracts firmware version information from output and any updated
+    structured metadata.
 
     Parameters:
         client (Any): Meshtastic client object expected to expose localNode.getMetadata(); if absent, metadata retrieval is skipped.
@@ -960,6 +1036,12 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
     result = {"firmware_version": "unknown", "raw_output": "", "success": False}
 
     try:
+        cached_firmware = _extract_firmware_version_from_client(client)
+        if cached_firmware is not None:
+            result["firmware_version"] = cached_firmware
+            result["success"] = True
+            return result
+
         # Preflight: client may be a mock without localNode/getMetadata
         if not getattr(client, "localNode", None) or not hasattr(
             client.localNode, "getMetadata"
@@ -1081,6 +1163,11 @@ def _get_device_metadata(client: Any) -> dict[str, Any]:
             parsed = match.group(1).strip()
             if parsed:
                 result["firmware_version"] = parsed
+                result["success"] = True
+        else:
+            refreshed_firmware = _extract_firmware_version_from_client(client)
+            if refreshed_firmware is not None:
+                result["firmware_version"] = refreshed_firmware
                 result["success"] = True
 
     except Exception as e:  # noqa: BLE001 - metadata failures must not block startup
@@ -2981,8 +3068,8 @@ async def check_connection() -> None:
     - Controlled by config["meshtastic"]["health_check"]:
       - `enabled` (bool, default True) — enable or disable checks.
       - `heartbeat_interval` (int, seconds, default 60) — interval between checks. For backward compatibility, a top-level `heartbeat_interval` under `config["meshtastic"]` is supported.
-    - BLE connections are excluded from periodic checks because BLE libraries provide real-time disconnect detection.
-    - For non-BLE connections, attempts a metadata probe (via _get_device_metadata) and, if parsing fails, a fallback probe using `client.getMyNodeInfo()`. If both probes fail and no reconnection is already in progress, calls on_lost_meshtastic_connection(...) to initiate reconnection.
+    - BLE connections are excluded from periodic checks because BLE libraries provide real-time disconnect detection; this function returns early for BLE.
+    - For non-BLE connections, performs a liveness probe using `client.getMyNodeInfo()`. If the probe fails and no reconnection is already in progress, calls on_lost_meshtastic_connection(...) to initiate reconnection.
 
     No return value; side effects are logging and scheduling/triggering reconnection when the device is unresponsive.
     """
@@ -3009,60 +3096,33 @@ async def check_connection() -> None:
         logger.info("Connection health checks are disabled in configuration")
         return
 
-    ble_skip_logged = False
+    if connection_type == CONNECTION_TYPE_BLE:
+        logger.debug(
+            "BLE connection uses real-time disconnection detection; periodic health checks disabled"
+        )
+        return
 
     while not shutting_down:
         if meshtastic_client and not reconnecting:
-            # BLE has real-time disconnection detection in the library
-            # Skip periodic health checks to avoid duplicate reconnection attempts
-            if connection_type == CONNECTION_TYPE_BLE:
-                if not ble_skip_logged:
-                    logger.info(
-                        "BLE connection uses real-time disconnection detection - health checks disabled"
-                    )
-                    ble_skip_logged = True
-            else:
-                try:
-                    loop = asyncio.get_running_loop()
-                    # Use helper function to get device metadata, run in executor with timeout
-                    metadata = await asyncio.wait_for(
-                        loop.run_in_executor(
-                            None, _get_device_metadata, meshtastic_client
-                        ),
-                        timeout=DEFAULT_MESHTASTIC_OPERATION_TIMEOUT,
-                    )
-                    if not metadata["success"]:
-                        # Fallback probe: device responding at all?
-                        try:
-                            _ = await asyncio.wait_for(
-                                loop.run_in_executor(
-                                    None, meshtastic_client.getMyNodeInfo
-                                ),
-                                timeout=DEFAULT_MESHTASTIC_OPERATION_TIMEOUT,
-                            )
-                        except Exception as probe_err:
-                            raise Exception(
-                                "Metadata and nodeInfo probes failed"
-                            ) from probe_err
-                        else:
-                            logger.debug(
-                                "Metadata parse failed but device responded to getMyNodeInfo(); skipping reconnect this cycle"
-                            )
+            try:
+                loop = asyncio.get_running_loop()
+                await asyncio.wait_for(
+                    loop.run_in_executor(None, meshtastic_client.getMyNodeInfo),
+                    timeout=DEFAULT_MESHTASTIC_OPERATION_TIMEOUT,
+                )
 
-                except Exception as e:
-                    # Only trigger reconnection if we're not already reconnecting
-                    if not reconnecting:
-                        logger.error(
-                            f"{connection_type.capitalize()} connection health check failed: {e}"
-                        )
-                        on_lost_meshtastic_connection(
-                            interface=meshtastic_client,
-                            detection_source=f"health check failed: {str(e)}",
-                        )
-                    else:
-                        logger.debug(
-                            "Skipping reconnection trigger - already reconnecting"
-                        )
+            except Exception as e:
+                # Only trigger reconnection if we're not already reconnecting
+                if not reconnecting:
+                    logger.error(
+                        f"{connection_type.capitalize()} connection health check failed: {e}"
+                    )
+                    on_lost_meshtastic_connection(
+                        interface=meshtastic_client,
+                        detection_source=f"health check failed: {str(e)}",
+                    )
+                else:
+                    logger.debug("Skipping reconnection trigger - already reconnecting")
         elif reconnecting:
             logger.debug("Skipping connection check - reconnection in progress")
         elif not meshtastic_client:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -955,7 +955,7 @@ def _normalize_firmware_version(value: Any) -> str | None:
         value = value.decode("utf-8", errors="ignore")
     if isinstance(value, str):
         normalized = value.strip()
-        if normalized:
+        if normalized and normalized.lower() != "unknown":
             return normalized
     return None
 

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -261,6 +261,113 @@ class TestDbUtils(unittest.TestCase):
         self.assertEqual(get_shortname("!12345678"), "AS")
         self.assertEqual(get_shortname("!87654321"), "BJ")
 
+    def test_update_longnames_removes_stale_entries(self):
+        """
+        Test that update_longnames removes stale entries when nodes are removed from the device nodedb.
+
+        Simulates a device nodedb being cleared or nodes leaving the mesh by:
+        1. Adding multiple nodes to the database
+        2. Calling update_longnames with only a subset of nodes
+        3. Verifying that stale entries (nodes not in the new snapshot) are removed
+        """
+        initialize_database()
+
+        # Initial nodes - 3 nodes in the mesh
+        initial_nodes = {
+            "!11111111": {"user": {"id": "!11111111", "longName": "Alice"}},
+            "!22222222": {"user": {"id": "!22222222", "longName": "Bob"}},
+            "!33333333": {"user": {"id": "!33333333", "longName": "Charlie"}},
+        }
+        update_longnames(initial_nodes)
+
+        # Verify all 3 are stored
+        self.assertEqual(get_longname("!11111111"), "Alice")
+        self.assertEqual(get_longname("!22222222"), "Bob")
+        self.assertEqual(get_longname("!33333333"), "Charlie")
+
+        # Update with only 2 nodes (Charlie left the mesh)
+        updated_nodes = {
+            "!11111111": {"user": {"id": "!11111111", "longName": "Alice Updated"}},
+            "!22222222": {"user": {"id": "!22222222", "longName": "Bob"}},
+        }
+        update_longnames(updated_nodes)
+
+        # Verify Alice and Bob are still present (Alice updated)
+        self.assertEqual(get_longname("!11111111"), "Alice Updated")
+        self.assertEqual(get_longname("!22222222"), "Bob")
+        # Verify Charlie was removed as stale entry
+        self.assertIsNone(get_longname("!33333333"))
+
+    def test_update_shortnames_removes_stale_entries(self):
+        """
+        Test that update_shortnames removes stale entries when nodes are removed from the device nodedb.
+
+        Simulates a device nodedb being cleared or nodes leaving the mesh by:
+        1. Adding multiple nodes to the database
+        2. Calling update_shortnames with only a subset of nodes
+        3. Verifying that stale entries (nodes not in the new snapshot) are removed
+        """
+        initialize_database()
+
+        # Initial nodes - 3 nodes in the mesh
+        initial_nodes = {
+            "!11111111": {"user": {"id": "!11111111", "shortName": "ALI"}},
+            "!22222222": {"user": {"id": "!22222222", "shortName": "BOB"}},
+            "!33333333": {"user": {"id": "!33333333", "shortName": "CHA"}},
+        }
+        update_shortnames(initial_nodes)
+
+        # Verify all 3 are stored
+        self.assertEqual(get_shortname("!11111111"), "ALI")
+        self.assertEqual(get_shortname("!22222222"), "BOB")
+        self.assertEqual(get_shortname("!33333333"), "CHA")
+
+        # Update with only 2 nodes (Charlie left the mesh)
+        updated_nodes = {
+            "!11111111": {"user": {"id": "!11111111", "shortName": "ALX"}},
+            "!22222222": {"user": {"id": "!22222222", "shortName": "BOB"}},
+        }
+        update_shortnames(updated_nodes)
+
+        # Verify Alice and Bob are still present (Alice updated)
+        self.assertEqual(get_shortname("!11111111"), "ALX")
+        self.assertEqual(get_shortname("!22222222"), "BOB")
+        # Verify Charlie was removed as stale entry
+        self.assertIsNone(get_shortname("!33333333"))
+
+    def test_update_names_empty_nodes_preserves_existing(self):
+        """
+        Test that calling update_longnames/update_shortnames with empty dict does NOT wipe the database.
+
+        This is important because an empty dict could mean either:
+        - Device nodedb was actually cleared
+        - Transient failure/disconnect where we don't have node data
+
+        We choose to preserve existing data on empty input to avoid data loss.
+        """
+        initialize_database()
+
+        # Add initial nodes
+        initial_nodes = {
+            "!11111111": {
+                "user": {"id": "!11111111", "longName": "Alice", "shortName": "ALI"}
+            },
+        }
+        update_longnames(initial_nodes)
+        update_shortnames(initial_nodes)
+
+        # Verify stored
+        self.assertEqual(get_longname("!11111111"), "Alice")
+        self.assertEqual(get_shortname("!11111111"), "ALI")
+
+        # Call with empty dict (simulating transient issue)
+        update_longnames({})
+        update_shortnames({})
+
+        # Verify data is still present (not wiped)
+        self.assertEqual(get_longname("!11111111"), "Alice")
+        self.assertEqual(get_shortname("!11111111"), "ALI")
+
     def test_plugin_data_operations(self):
         """
         Test storing, retrieving, and deleting plugin data for specific nodes and plugins in the database.
@@ -315,6 +422,7 @@ class TestDbUtils(unittest.TestCase):
         # Retrieve by meshtastic_id
         result = get_message_map_by_meshtastic_id(meshtastic_id)
         self.assertIsNotNone(result)
+        assert result is not None  # Type narrowing for pyright
         self.assertEqual(result[0], matrix_event_id)
         self.assertEqual(result[1], matrix_room_id)
         self.assertEqual(result[2], meshtastic_text)
@@ -323,6 +431,7 @@ class TestDbUtils(unittest.TestCase):
         # Retrieve by matrix_event_id
         result = get_message_map_by_matrix_event_id(matrix_event_id)
         self.assertIsNotNone(result)
+        assert result is not None  # Type narrowing for pyright
         self.assertEqual(result[0], str(meshtastic_id))
         self.assertEqual(result[1], matrix_room_id)
         self.assertEqual(result[2], meshtastic_text)
@@ -441,6 +550,7 @@ class TestDbUtils(unittest.TestCase):
         self.assertIsNone(get_message_map_by_meshtastic_id("mesh1"))
         latest = get_message_map_by_meshtastic_id("mesh2")
         self.assertIsNotNone(latest)
+        assert latest is not None  # Type narrowing for pyright
         self.assertEqual(latest[0], "$event2:matrix.org")
 
     def test_database_manager_keyboard_interrupt(self):

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -261,6 +261,32 @@ class TestDbUtils(unittest.TestCase):
         self.assertEqual(get_shortname("!12345678"), "AS")
         self.assertEqual(get_shortname("!87654321"), "BJ")
 
+    def test_update_names_preserve_zero_id_for_stale_tracking(self):
+        """
+        Test that numeric zero IDs are treated as valid IDs, not skipped as missing.
+        """
+        initialize_database()
+
+        initial_nodes = {
+            "node_zero": {"user": {"id": 0, "longName": "Zero", "shortName": "ZRO"}},
+            "node_one": {"user": {"id": 1, "longName": "One", "shortName": "ONE"}},
+        }
+        update_longnames(initial_nodes)
+        update_shortnames(initial_nodes)
+
+        updated_nodes = {
+            "node_zero": {
+                "user": {"id": 0, "longName": "Zero Updated", "shortName": "Z0"}
+            }
+        }
+        update_longnames(updated_nodes)
+        update_shortnames(updated_nodes)
+
+        self.assertEqual(get_longname("0"), "Zero Updated")
+        self.assertEqual(get_shortname("0"), "Z0")
+        self.assertIsNone(get_longname("1"))
+        self.assertIsNone(get_shortname("1"))
+
     def test_update_longnames_removes_stale_entries(self):
         """
         Test that update_longnames removes stale entries when nodes are removed from the device nodedb.

--- a/tests/test_db_utils_async.py
+++ b/tests/test_db_utils_async.py
@@ -1104,6 +1104,19 @@ class TestLongnameShortnameErrors(unittest.TestCase):
             "Expected 'Database error saving shortname' in logs",
         )
 
+    def test_delete_stale_names_core_rejects_invalid_table_name(self):
+        """Reject invalid table names to prevent dynamic-SQL table injection."""
+        mock_cursor = MagicMock()
+
+        with self.assertRaisesRegex(ValueError, "Invalid table name"):
+            mmrelay.db_utils._delete_stale_names_core(
+                mock_cursor,
+                "longnames; DROP TABLE longnames; --",
+                {"!123"},
+            )
+
+        mock_cursor.execute.assert_not_called()
+
 
 class TestIntegrationWithRealDatabase(unittest.TestCase):
     """Integration tests with a real SQLite database."""

--- a/tests/test_db_utils_async.py
+++ b/tests/test_db_utils_async.py
@@ -1037,13 +1037,12 @@ class TestLongnameShortnameErrors(unittest.TestCase):
         # Both save_longname and delete_stale_longnames will fail with database errors
         self.assertTrue(mock_logger.exception.called)
         # Check that at least one call was for saving a longname
-        found_save_error = False
-        for call in mock_logger.exception.call_args_list:
-            if "Database error saving longname for" in call[0][0]:
-                found_save_error = True
-                break
         self.assertTrue(
-            found_save_error, "Expected 'Database error saving longname' in logs"
+            any(
+                "Database error saving longname for" in call[0][0]
+                for call in mock_logger.exception.call_args_list
+            ),
+            "Expected 'Database error saving longname' in logs",
         )
 
     @patch("mmrelay.db_utils._get_db_manager")
@@ -1097,13 +1096,12 @@ class TestLongnameShortnameErrors(unittest.TestCase):
         # Both save_shortname and delete_stale_shortnames will fail with database errors
         self.assertTrue(mock_logger.exception.called)
         # Check that at least one call was for saving a shortname
-        found_save_error = False
-        for call in mock_logger.exception.call_args_list:
-            if "Database error saving shortname for" in call[0][0]:
-                found_save_error = True
-                break
         self.assertTrue(
-            found_save_error, "Expected 'Database error saving shortname' in logs"
+            any(
+                "Database error saving shortname for" in call[0][0]
+                for call in mock_logger.exception.call_args_list
+            ),
+            "Expected 'Database error saving shortname' in logs",
         )
 
 

--- a/tests/test_db_utils_async.py
+++ b/tests/test_db_utils_async.py
@@ -1034,10 +1034,17 @@ class TestLongnameShortnameErrors(unittest.TestCase):
         nodes = {"1": {"num": 1, "user": {"id": "!testid", "longName": "Test1"}}}
         update_longnames(nodes)
 
-        mock_logger.exception.assert_called_once()
-        call_args = mock_logger.exception.call_args[0]
-        self.assertIn("Database error saving longname for", call_args[0])
-        self.assertEqual(call_args[1], "!testid")
+        # Both save_longname and delete_stale_longnames will fail with database errors
+        self.assertTrue(mock_logger.exception.called)
+        # Check that at least one call was for saving a longname
+        found_save_error = False
+        for call in mock_logger.exception.call_args_list:
+            if "Database error saving longname for" in call[0][0]:
+                found_save_error = True
+                break
+        self.assertTrue(
+            found_save_error, "Expected 'Database error saving longname' in logs"
+        )
 
     @patch("mmrelay.db_utils._get_db_manager")
     @patch("mmrelay.db_utils.logger")
@@ -1087,10 +1094,17 @@ class TestLongnameShortnameErrors(unittest.TestCase):
         nodes = {"1": {"num": 1, "user": {"id": "!testid", "shortName": "T1"}}}
         update_shortnames(nodes)
 
-        mock_logger.exception.assert_called_once()
-        call_args = mock_logger.exception.call_args[0]
-        self.assertIn("Database error saving shortname for", call_args[0])
-        self.assertEqual(call_args[1], "!testid")
+        # Both save_shortname and delete_stale_shortnames will fail with database errors
+        self.assertTrue(mock_logger.exception.called)
+        # Check that at least one call was for saving a shortname
+        found_save_error = False
+        for call in mock_logger.exception.call_args_list:
+            if "Database error saving shortname for" in call[0][0]:
+                found_save_error = True
+                break
+        self.assertTrue(
+            found_save_error, "Expected 'Database error saving shortname' in logs"
+        )
 
 
 class TestIntegrationWithRealDatabase(unittest.TestCase):
@@ -1252,6 +1266,7 @@ class TestIntegrationWithRealDatabase(unittest.TestCase):
         # Retrieve by meshtastic ID
         result = get_message_map_by_meshtastic_id(123)
         self.assertIsNotNone(result)
+        assert result is not None  # Type narrowing for pyright
         matrix_event_id, matrix_room_id, meshtastic_text, meshtastic_meshnet = result
         self.assertEqual(matrix_event_id, "$event123")
         self.assertEqual(matrix_room_id, "!room123")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2692,6 +2692,7 @@ class TestGetDeviceMetadata(unittest.TestCase):
         mock_client.localNode.iface.metadata = None
 
         def _populate_metadata() -> None:
+            """Simulate getMetadata() populating structured client metadata."""
             mock_client.localNode.iface.metadata = {
                 "firmwareVersion": "2.7.18",
             }

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2498,6 +2498,23 @@ class TestTextReplyFunctionality(unittest.TestCase):
 class TestGetDeviceMetadata(unittest.TestCase):
     """Test cases for _get_device_metadata helper function."""
 
+    def test_get_device_metadata_uses_structured_metadata_first(self):
+        """Use existing structured metadata without invoking getMetadata()."""
+        mock_client = MagicMock()
+        mock_client.localNode.getMetadata.side_effect = AssertionError(
+            "getMetadata() should not be called when metadata is already available"
+        )
+        mock_client.localNode.iface.metadata = SimpleNamespace(
+            firmware_version="2.7.18"
+        )
+
+        result = _get_device_metadata(mock_client)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["firmware_version"], "2.7.18")
+        self.assertEqual(result["raw_output"], "")
+        mock_client.localNode.getMetadata.assert_not_called()
+
     def test_get_device_metadata_success(self):
         """Test successful metadata retrieval and parsing."""
         # Create mock client with localNode.getMetadata()
@@ -2605,6 +2622,29 @@ class TestGetDeviceMetadata(unittest.TestCase):
             # Verify whitespace is handled correctly
             self.assertTrue(result["success"])
             self.assertEqual(result["firmware_version"], "2.3.15.abc123")
+
+    def test_get_device_metadata_structured_fallback_after_getmetadata(self):
+        """Fallback to structured metadata when stdout does not include firmware version."""
+        mock_client = MagicMock()
+        mock_client.localNode.iface.metadata = None
+
+        def _populate_metadata() -> None:
+            mock_client.localNode.iface.metadata = {
+                "firmwareVersion": "2.7.18",
+            }
+
+        mock_client.localNode.getMetadata.side_effect = _populate_metadata
+
+        with patch("mmrelay.meshtastic_utils.io.StringIO") as mock_stringio:
+            mock_output = MagicMock()
+            mock_output.getvalue.return_value = "hw_model: RAK4631"
+            mock_stringio.return_value = mock_output
+
+            result = _get_device_metadata(mock_client)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["firmware_version"], "2.7.18")
+        self.assertIn("hw_model: RAK4631", result["raw_output"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2515,6 +2515,25 @@ class TestGetDeviceMetadata(unittest.TestCase):
         self.assertEqual(result["raw_output"], "")
         mock_client.localNode.getMetadata.assert_not_called()
 
+    def test_get_device_metadata_force_refresh_ignores_cached_metadata(self):
+        """force_refresh=True should invoke getMetadata even with cached metadata."""
+        mock_client = MagicMock()
+        mock_client.localNode.iface.metadata = SimpleNamespace(
+            firmware_version="2.7.18"
+        )
+        mock_client.localNode.getMetadata = MagicMock()
+
+        with patch("mmrelay.meshtastic_utils.io.StringIO") as mock_stringio:
+            mock_output = MagicMock()
+            mock_output.getvalue.return_value = "firmware_version: 2.7.19"
+            mock_stringio.return_value = mock_output
+
+            result = _get_device_metadata(mock_client, force_refresh=True)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["firmware_version"], "2.7.19")
+        mock_client.localNode.getMetadata.assert_called_once()
+
     def test_get_device_metadata_success(self):
         """Test successful metadata retrieval and parsing."""
         # Create mock client with localNode.getMetadata()
@@ -2590,6 +2609,14 @@ class TestGetDeviceMetadata(unittest.TestCase):
             self.assertFalse(result["success"])
             self.assertEqual(result["firmware_version"], "unknown")
             mock_logger.debug.assert_called_once()
+
+    def test_get_device_metadata_raise_on_error_reraises(self):
+        """raise_on_error=True should propagate getMetadata probe failures."""
+        mock_client = MagicMock()
+        mock_client.localNode.getMetadata.side_effect = Exception("Device error")
+
+        with self.assertRaisesRegex(Exception, "Device error"):
+            _get_device_metadata(mock_client, raise_on_error=True)
 
     def test_get_device_metadata_quoted_version(self):
         """Test parsing firmware version with quotes."""

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2650,6 +2650,42 @@ class TestGetDeviceMetadata(unittest.TestCase):
             self.assertTrue(result["success"])
             self.assertEqual(result["firmware_version"], "2.3.15.abc123")
 
+    def test_get_device_metadata_ignores_unknown_regex_firmware(self):
+        """Regex-parsed 'unknown' firmware should not mark metadata retrieval successful."""
+        mock_client = MagicMock()
+        mock_client.localNode.getMetadata = MagicMock()
+
+        with patch("mmrelay.meshtastic_utils.io.StringIO") as mock_stringio:
+            mock_output = MagicMock()
+            mock_output.getvalue.return_value = "firmware_version: unknown"
+            mock_stringio.return_value = mock_output
+
+            result = _get_device_metadata(mock_client, force_refresh=True)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["firmware_version"], "unknown")
+
+    def test_get_device_metadata_normalizes_refreshed_firmware(self):
+        """Refreshed firmware fallback should normalize values before success assignment."""
+        mock_client = MagicMock()
+        mock_client.localNode.getMetadata = MagicMock()
+
+        with (
+            patch("mmrelay.meshtastic_utils.io.StringIO") as mock_stringio,
+            patch(
+                "mmrelay.meshtastic_utils._extract_firmware_version_from_client",
+                return_value="unknown",
+            ),
+        ):
+            mock_output = MagicMock()
+            mock_output.getvalue.return_value = "hw_model: HELTEC_V3"
+            mock_stringio.return_value = mock_output
+
+            result = _get_device_metadata(mock_client, force_refresh=True)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["firmware_version"], "unknown")
+
     def test_get_device_metadata_structured_fallback_after_getmetadata(self):
         """Fallback to structured metadata when stdout does not include firmware version."""
         mock_client = MagicMock()

--- a/tests/test_meshtastic_utils_health.py
+++ b/tests/test_meshtastic_utils_health.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -63,7 +63,8 @@ async def test_check_connection_ble_skips_health_checks(reset_meshtastic_globals
 
 
 @pytest.mark.asyncio
-async def test_check_connection_metadata_probe_succeeds(reset_meshtastic_globals):
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+async def test_check_connection_metadata_probe_succeeds():
     mu.config = _make_health_config(connection_type="tcp")
     mu.meshtastic_client = MagicMock()
 
@@ -112,8 +113,10 @@ async def test_check_connection_triggers_reconnect_on_probe_failure(
         await check_connection()
 
     mock_lost.assert_called_once()
-    mock_logger.error.assert_any_call(
-        "Tcp connection health check failed: probe failed"
+    mock_logger.exception.assert_any_call(
+        "%s connection health check failed: %s",
+        "Tcp",
+        ANY,
     )
 
 

--- a/tests/test_meshtastic_utils_health.py
+++ b/tests/test_meshtastic_utils_health.py
@@ -63,7 +63,7 @@ async def test_check_connection_ble_skips_health_checks(reset_meshtastic_globals
 
 
 @pytest.mark.asyncio
-async def test_check_connection_node_info_probe_succeeds(reset_meshtastic_globals):
+async def test_check_connection_metadata_probe_succeeds(reset_meshtastic_globals):
     mu.config = _make_health_config(connection_type="tcp")
     mu.meshtastic_client = MagicMock()
 
@@ -81,9 +81,11 @@ async def test_check_connection_node_info_probe_succeeds(reset_meshtastic_global
     ):
         await check_connection()
 
-    loop.run_in_executor.assert_called_once_with(
-        None, mu.meshtastic_client.getMyNodeInfo
-    )
+    loop.run_in_executor.assert_called_once()
+    _, probe = loop.run_in_executor.call_args.args
+    assert probe.func is mu._get_device_metadata
+    assert probe.args == (mu.meshtastic_client,)
+    assert probe.keywords == {"force_refresh": True, "raise_on_error": True}
     mock_logger.error.assert_not_called()
 
 

--- a/tests/test_meshtastic_utils_health.py
+++ b/tests/test_meshtastic_utils_health.py
@@ -54,28 +54,21 @@ async def test_check_connection_ble_skips_health_checks(reset_meshtastic_globals
     mu.config = _make_health_config(connection_type="ble")
     mu.meshtastic_client = MagicMock()
 
-    with (
-        patch(
-            "mmrelay.meshtastic_utils.asyncio.sleep",
-            new_callable=AsyncMock,
-            side_effect=_sleep_and_shutdown,
-        ),
-        patch("mmrelay.meshtastic_utils.logger") as mock_logger,
-    ):
+    with patch("mmrelay.meshtastic_utils.logger") as mock_logger:
         await check_connection()
 
-    mock_logger.info.assert_any_call(
-        "BLE connection uses real-time disconnection detection - health checks disabled"
+    mock_logger.debug.assert_any_call(
+        "BLE connection uses real-time disconnection detection; periodic health checks disabled"
     )
 
 
 @pytest.mark.asyncio
-async def test_check_connection_metadata_fallback_succeeds(reset_meshtastic_globals):
+async def test_check_connection_node_info_probe_succeeds(reset_meshtastic_globals):
     mu.config = _make_health_config(connection_type="tcp")
     mu.meshtastic_client = MagicMock()
 
     loop = MagicMock()
-    loop.run_in_executor = AsyncMock(side_effect=[{"success": False}, {}])
+    loop.run_in_executor = AsyncMock(return_value={})
 
     with (
         patch("mmrelay.meshtastic_utils.asyncio.get_running_loop", return_value=loop),
@@ -88,9 +81,10 @@ async def test_check_connection_metadata_fallback_succeeds(reset_meshtastic_glob
     ):
         await check_connection()
 
-    mock_logger.debug.assert_any_call(
-        "Metadata parse failed but device responded to getMyNodeInfo(); skipping reconnect this cycle"
+    loop.run_in_executor.assert_called_once_with(
+        None, mu.meshtastic_client.getMyNodeInfo
     )
+    mock_logger.error.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -101,9 +95,7 @@ async def test_check_connection_triggers_reconnect_on_probe_failure(
     mu.meshtastic_client = MagicMock()
 
     loop = MagicMock()
-    loop.run_in_executor = AsyncMock(
-        side_effect=[{"success": False}, Exception("probe failed")]
-    )
+    loop.run_in_executor = AsyncMock(side_effect=Exception("probe failed"))
 
     with (
         patch("mmrelay.meshtastic_utils.asyncio.get_running_loop", return_value=loop),
@@ -119,7 +111,7 @@ async def test_check_connection_triggers_reconnect_on_probe_failure(
 
     mock_lost.assert_called_once()
     mock_logger.error.assert_any_call(
-        "Tcp connection health check failed: Metadata and nodeInfo probes failed"
+        "Tcp connection health check failed: probe failed"
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR tightens firmware metadata handling, hardens health-check/liveness probing, and fixes node name cleanup in the database. It adds normalization and extraction helpers for firmware versions, changes health checks to perform on-wire metadata probes (with stricter error propagation), removes stale longname/shortname entries when nodes are updated, and introduces several null-checks and logging improvements to reduce crashes and improve diagnosability.

## Key changes

Features
- Firmware helpers
  - _normalize_firmware_version(value) -> str | None: trims/decodes values and treats "unknown" or empty strings as None.
  - _extract_firmware_version_from_metadata(metadata_source) -> str | None: reads firmwareVersion/firmware_version from dict-like or object metadata sources.
  - _extract_firmware_version_from_client(client) -> str | None: collects candidates from client.metadata, client.localNode.metadata, and iface.metadata.
- New metadata probe helper
  - _get_device_metadata(client, *, force_refresh: bool = False, raise_on_error: bool = False) -> dict[str, Any]
    - Can force an on-wire getMetadata() probe (force_refresh) and optionally propagate getMetadata() exceptions (raise_on_error).
    - Returns parsed firmware_version and raw_output when available; falls back to structured metadata when appropriate.

Fixes
- Health checks / liveness probing
  - Non-BLE periodic health checks now use a forced metadata probe (_get_device_metadata(force_refresh=True, raise_on_error=True)) instead of relying on getMyNodeInfo/cached reads.
  - Probe failures now propagate and trigger reconnection handling with clearer detection_source context.
  - BLE connections explicitly skip periodic health checks (early return) and log a debug message explaining BLE relies on real-time disconnect detection.
  - Connection-check logging changed to logger.exception in probe failure paths to include stack traces; tests updated accordingly.
- Nodes plugin and DB cleanup
  - When nodes are updated from the device nodedb, stale longname/shortname rows are removed.
  - update_longnames/update_shortnames delegate to new helpers that persist present names and prune entries not in the current nodedb snapshot.
  - Added early-return behavior so updating with an empty node dict does not wipe existing name data.
- Robustness and null-checks
  - Added null checks and improved error handling in metadata extraction and device metadata retrieval to avoid AttributeError/KeyError (including user id handling in node updates).
  - Normalization now represents values that would normalize to "unknown" as None instead of the literal "unknown".

Refactors / behavior changes
- Centralized health-check control flow around the new metadata helper (force_refresh/raise_on_error) rather than multi-step cached/fallback probes.
- Consolidated name-update logic in db_utils with _update_names_core and _delete_stale_names_core plus delete_stale_longnames/delete_stale_shortnames helpers.
- Minor import changes (functools) and logging/message wording adjustments to reflect the new probe flow.

Testing
- Unit tests added/updated to cover:
  - _get_device_metadata: structured metadata preference, force_refresh, raise_on_error propagation, normalization behavior, and fallback cases.
  - Health-check behavior: executor-driven forced probe invocation and exception logging expectations.
  - DB behavior: preservation of zero IDs, removal of stale longname/shortname records, and protecting against wiping data when given an empty node snapshot.
- Tests made less brittle around logged database errors (search for messages rather than exact single-call assertions).

Breaking changes / migration notes
- No public API signature changes; new helpers are private (underscore-prefixed).
- Behavioral change: non-BLE health checks now perform on-wire admin requests and may raise exceptions where cached reads previously succeeded silently. Code relying on silent cached metadata probes should expect stricter behavior when forced probes are used.
- DB cleanup change: update_longnames/update_shortnames now remove stale entries — this can delete previously retained name records if the device nodedb no longer lists them. If you need to retain names beyond device nodedb snapshots, handle that externally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->