### PR TITLE
Matrix message retry idempotency & improve BLE duplicate-connect recovery

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -2,7 +2,7 @@
 language: en-US
 early_access: true
 reviews:
-  profile: chill
+  profile: assertive
   request_changes_workflow: false
   high_level_summary: true
   high_level_summary_instructions: "Create a simple/humble (no marketing language, we're not selling anything), yet detailed summary with: 1) An overview paragraph, 2) Bullet-point list of key changes grouped by category (features, fixes, refactors), 3) If necessary, a note on any breaking changes or migration steps needed."

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,12 +20,12 @@ lint:
   enabled:
     - shellcheck@0.11.0
     - shfmt@3.6.0
-    - mypy@1.19.1
+    - mypy@1.20.0
     - pyright@1.1.408
     - dotenv-linter@4.0.0
     - hadolint@2.14.0
     - taplo@0.10.0
-    - actionlint@1.7.11
+    - actionlint@1.7.12
     - bandit@1.9.4
     - black@26.3.1
     - checkov@3.2.513

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -2,4 +2,4 @@
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
 
-__version__: str = "1.3.2"
+__version__: str = "1.3.3"

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -3283,6 +3283,7 @@ async def _send_matrix_message_with_retry(
     max_retries: int = 3,
     base_delay: float = 1.0,
     max_delay: float = 30.0,
+    transaction_id: str | None = None,
 ) -> Any:
     """
     Send a message to a Matrix room, retrying on transient failures with exponential backoff.
@@ -3296,12 +3297,15 @@ async def _send_matrix_message_with_retry(
         max_retries: Maximum number of retry attempts (default 3).
         base_delay: Initial backoff delay in seconds (used to compute exponential backoff).
         max_delay: Maximum backoff delay in seconds.
+        transaction_id: Optional Matrix transaction ID to reuse across retries for idempotent send semantics.
 
     Returns:
         The response object returned by the client's send call on success, `None` if sending was blocked due to E2EE being disabled for an encrypted room or if all retries are exhausted.
     """
     # Use cryptographically secure random for jitter
     rng = secrets.SystemRandom()
+    # Reuse one transaction ID across retries so timed-out attempts are idempotent.
+    stable_transaction_id = transaction_id or f"mmrelay-{secrets.token_hex(16)}"
 
     for attempt in range(max_retries + 1):
         try:
@@ -3334,6 +3338,7 @@ async def _send_matrix_message_with_retry(
                     room_id=room_id,
                     message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,
                     content=content,
+                    tx_id=stable_transaction_id,
                     ignore_unverified_devices=True,
                 ),
                 timeout=MATRIX_ROOM_SEND_TIMEOUT,

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import atexit
 import contextlib
 import functools
+import importlib
 import importlib.util
 import inspect
 import io
@@ -132,6 +133,21 @@ matrix_rooms: list[dict[str, Any]] = []
 # Initialize logger for Meshtastic
 logger = get_logger(name="Meshtastic")
 
+# Detect optional BLE connection-gate reset support once at startup.
+# The legacy/official Meshtastic BLE implementation does not provide this.
+_ble_gate_reset_callable: Callable[[], None] | None = None
+_ble_gating_module: Any | None = None
+try:
+    _ble_gating_module = importlib.import_module("meshtastic.interfaces.ble.gating")
+except ModuleNotFoundError:
+    _ble_gating_module = None
+except Exception:
+    _ble_gating_module = None
+else:
+    clear_all_registries = getattr(_ble_gating_module, "_clear_all_registries", None)
+    if callable(clear_all_registries):
+        _ble_gate_reset_callable = cast(Callable[[], None], clear_all_registries)
+
 # Meshtastic text payloads are UTF-8 on the wire.
 MESHTASTIC_TEXT_ENCODING = "utf-8"
 
@@ -229,6 +245,50 @@ def _coerce_positive_int(value: Any, default: int) -> int:
         return parsed
     except (TypeError, ValueError, OverflowError):
         return default
+
+
+def _is_ble_duplicate_connect_suppressed_error(exc: BaseException) -> bool:
+    """
+    Return whether an exception message matches Meshtastic duplicate-connect suppression.
+
+    This targets forked meshtastic BLE gate errors such as:
+    "Connection suppressed: recently connected elsewhere".
+    """
+    message = str(exc).strip().lower()
+    if not message:
+        return False
+    return "recently connected elsewhere" in message or (
+        "connection suppressed" in message and "connected elsewhere" in message
+    )
+
+
+def _reset_ble_connection_gate_state(ble_address: str, *, reason: str) -> bool:
+    """
+    Best-effort reset of process-local BLE connection gate state.
+
+    This recovery hook is only active when the installed Meshtastic library
+    exposes a connection-gate reset API. Otherwise this function is a no-op.
+    """
+    if _ble_gate_reset_callable is None:
+        return False
+
+    try:
+        _ble_gate_reset_callable()
+    except Exception:
+        logger.debug(
+            "BLE connection-state reset failed for %s (%s)",
+            ble_address,
+            reason,
+            exc_info=True,
+        )
+        return False
+
+    logger.warning(
+        "Reset BLE connection state for %s (%s)",
+        ble_address,
+        reason,
+    )
+    return True
 
 
 def _normalize_room_channel(room: dict[str, Any]) -> int | None:
@@ -1532,6 +1592,10 @@ def _ensure_ble_worker_available(ble_address: str, *, operation: str) -> None:
             stale_address,
             stale_elapsed_secs,
             stale_timeout_secs,
+        )
+        _reset_ble_connection_gate_state(
+            stale_address,
+            reason=f"stale worker during {operation}",
         )
         timeout_count = _record_ble_timeout(stale_address)
         _maybe_reset_ble_executor(
@@ -3819,6 +3883,20 @@ def connect_meshtastic(
             if shutting_down:
                 logger.debug("Shutdown in progress. Aborting connection attempts.")
                 break
+            if (
+                connection_type == CONNECTION_TYPE_BLE
+                and ble_address
+                and _is_ble_duplicate_connect_suppressed_error(e)
+            ):
+                logger.warning(
+                    "Detected duplicate BLE connect suppression for %s; "
+                    "resetting local BLE connection state before retry.",
+                    ble_address,
+                )
+                _reset_ble_connection_gate_state(
+                    ble_address,
+                    reason="duplicate connect suppression",
+                )
             attempts += 1
             if (
                 connection_type == CONNECTION_TYPE_BLE

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -141,7 +141,7 @@ try:
     _ble_gating_module = importlib.import_module("meshtastic.interfaces.ble.gating")
 except ModuleNotFoundError:
     _ble_gating_module = None
-except Exception:
+except Exception:  # noqa: BLE001 - defensive import of optional fork-specific feature
     _ble_gating_module = None
 else:
     clear_all_registries = getattr(_ble_gating_module, "_clear_all_registries", None)

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -3889,14 +3889,17 @@ def connect_meshtastic(
                 and _is_ble_duplicate_connect_suppressed_error(e)
             ):
                 logger.warning(
-                    "Detected duplicate BLE connect suppression for %s; "
-                    "resetting local BLE connection state before retry.",
+                    "Detected duplicate BLE connect suppression for %s",
                     ble_address,
                 )
-                _reset_ble_connection_gate_state(
+                if not _reset_ble_connection_gate_state(
                     ble_address,
                     reason="duplicate connect suppression",
-                )
+                ):
+                    logger.debug(
+                        "BLE gate reset hook unavailable for %s; retrying without local reset",
+                        ble_address,
+                    )
             attempts += 1
             if (
                 connection_type == CONNECTION_TYPE_BLE

--- a/tests/test_matrix_utils.py
+++ b/tests/test_matrix_utils.py
@@ -34,6 +34,7 @@ from mmrelay.matrix_utils import (
     _is_room_alias,
     _iter_room_alias_entries,
     _normalize_bot_user_id,
+    _send_matrix_message_with_retry,
     _update_room_id_in_mapping,
     bot_command,
     connect_matrix,
@@ -2155,6 +2156,36 @@ async def test_matrix_relay_send_timeout_logs_and_returns(
     mock_logger.exception.assert_any_call(
         "Timeout sending message to Matrix room !room:matrix.org after 4 attempts"
     )
+
+
+@patch("mmrelay.matrix_utils.logger")
+async def test_send_matrix_message_with_retry_reuses_tx_id_across_retries(_mock_logger):
+    """Retry attempts must reuse one Matrix transaction ID to avoid duplicate sends."""
+    mock_client = MagicMock()
+    mock_client.rooms = {"!room:matrix.org": MagicMock(encrypted=False)}
+    success_response = MagicMock(event_id="$event123")
+    mock_client.room_send = AsyncMock(
+        side_effect=[asyncio.TimeoutError(), asyncio.TimeoutError(), success_response]
+    )
+
+    with patch("mmrelay.matrix_utils.asyncio.sleep", new_callable=AsyncMock):
+        response = await _send_matrix_message_with_retry(
+            matrix_client=mock_client,
+            room_id="!room:matrix.org",
+            content={"msgtype": "m.text", "body": "Hello Matrix"},
+            max_retries=3,
+            base_delay=0.01,
+            max_delay=0.1,
+        )
+
+    assert response is success_response
+    assert mock_client.room_send.await_count == 3
+    tx_ids = [
+        call.kwargs.get("tx_id") for call in mock_client.room_send.await_args_list
+    ]
+    assert len(set(tx_ids)) == 1
+    assert isinstance(tx_ids[0], str)
+    assert tx_ids[0].startswith("mmrelay-")
 
 
 @patch("mmrelay.matrix_utils.connect_matrix")

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -186,9 +186,8 @@ def test_connect_meshtastic_ble_recovers_from_stale_worker(
             new=_FakeBLEInterface,
         ),
         patch(
-            "mmrelay.meshtastic_utils._reset_ble_connection_gate_state",
-            return_value=True,
-        ) as mock_clear_gates,
+            "mmrelay.meshtastic_utils._ble_gate_reset_callable",
+        ) as mock_gate_callable,
         patch("mmrelay.meshtastic_utils._disconnect_ble_by_address"),
         patch(
             "mmrelay.meshtastic_utils._validate_ble_connection_address",
@@ -216,10 +215,16 @@ def test_connect_meshtastic_ble_recovers_from_stale_worker(
     ]
     assert stale_warning_calls, "Expected stale BLE worker recovery warning"
     assert stale_warning_calls[0].args[1] in {"interface creation", "connect"}
-    assert any(
-        call.args and call.args[0] == ble_address
-        for call in mock_clear_gates.call_args_list
-    )
+    # Verify gate seam was invoked through the real helper (observable via warning)
+    gate_reset_calls = [
+        call
+        for call in mock_logger.warning.call_args_list
+        if call.args
+        and "Reset BLE connection state for %s" in str(call.args[0])
+        and len(call.args) >= 2
+        and call.args[1] == ble_address
+    ]
+    assert gate_reset_calls, "Expected BLE connection state reset warning"
 
 
 def test_connect_meshtastic_duplicate_suppression_clears_fork_gates(
@@ -244,9 +249,8 @@ def test_connect_meshtastic_duplicate_suppression_clears_fork_gates(
             new=_SuppressedBLEInterface,
         ),
         patch(
-            "mmrelay.meshtastic_utils._reset_ble_connection_gate_state",
-            return_value=True,
-        ) as mock_clear_gates,
+            "mmrelay.meshtastic_utils._ble_gate_reset_callable",
+        ) as mock_gate_callable,
         patch("mmrelay.meshtastic_utils._disconnect_ble_by_address"),
         patch("mmrelay.meshtastic_utils.time.sleep"),
         patch("mmrelay.meshtastic_utils.logger") as mock_logger,
@@ -254,10 +258,16 @@ def test_connect_meshtastic_duplicate_suppression_clears_fork_gates(
         result = connect_meshtastic(passed_config=config)
 
     assert result is None
-    assert any(
-        call.args and call.args[0] == ble_address
-        for call in mock_clear_gates.call_args_list
-    )
+    # Verify gate seam was invoked through the real helper (observable via warning)
+    gate_reset_calls = [
+        call
+        for call in mock_logger.warning.call_args_list
+        if call.args
+        and "Reset BLE connection state for %s" in str(call.args[0])
+        and len(call.args) >= 2
+        and call.args[1] == ble_address
+    ]
+    assert gate_reset_calls, "Expected BLE connection state reset warning"
     assert any(
         call.args and "Detected duplicate BLE connect suppression" in str(call.args[0])
         for call in mock_logger.warning.call_args_list

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -185,6 +185,10 @@ def test_connect_meshtastic_ble_recovers_from_stale_worker(
             "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
             new=_FakeBLEInterface,
         ),
+        patch(
+            "mmrelay.meshtastic_utils._reset_ble_connection_gate_state",
+            return_value=True,
+        ) as mock_clear_gates,
         patch("mmrelay.meshtastic_utils._disconnect_ble_by_address"),
         patch(
             "mmrelay.meshtastic_utils._validate_ble_connection_address",
@@ -212,6 +216,52 @@ def test_connect_meshtastic_ble_recovers_from_stale_worker(
     ]
     assert stale_warning_calls, "Expected stale BLE worker recovery warning"
     assert stale_warning_calls[0].args[1] in {"interface creation", "connect"}
+    assert any(
+        call.args and call.args[0] == ble_address
+        for call in mock_clear_gates.call_args_list
+    )
+
+
+def test_connect_meshtastic_duplicate_suppression_clears_fork_gates(
+    reset_meshtastic_globals,
+):
+    ble_address = "AA:BB:CC:DD:EE:FF"
+    config = {
+        "meshtastic": {
+            "connection_type": CONNECTION_TYPE_BLE,
+            "ble_address": ble_address,
+            "retries": 1,
+        }
+    }
+
+    class _SuppressedBLEInterface:
+        def __init__(self, **_kwargs: object) -> None:
+            raise RuntimeError("Connection suppressed: recently connected elsewhere")
+
+    with (
+        patch(
+            "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
+            new=_SuppressedBLEInterface,
+        ),
+        patch(
+            "mmrelay.meshtastic_utils._reset_ble_connection_gate_state",
+            return_value=True,
+        ) as mock_clear_gates,
+        patch("mmrelay.meshtastic_utils._disconnect_ble_by_address"),
+        patch("mmrelay.meshtastic_utils.time.sleep"),
+        patch("mmrelay.meshtastic_utils.logger") as mock_logger,
+    ):
+        result = connect_meshtastic(passed_config=config)
+
+    assert result is None
+    assert any(
+        call.args and call.args[0] == ble_address
+        for call in mock_clear_gates.call_args_list
+    )
+    assert any(
+        call.args and "Detected duplicate BLE connect suppression" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
 
 
 def test_connect_meshtastic_tcp_missing_host_returns_none(

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -32,6 +32,7 @@ from mmrelay.constants.network import (
     DEFAULT_PLUGIN_TIMEOUT_SECS,
 )
 from mmrelay.meshtastic_utils import (
+    _is_ble_duplicate_connect_suppressed_error,
     connect_meshtastic,
     is_running_as_service,
     on_lost_meshtastic_connection,
@@ -1011,6 +1012,50 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             )
             # Matrix relay should NOT have been called
             mock_matrix_relay.assert_not_called()
+
+
+class TestBLEDuplicateConnectSuppressionDetector(unittest.TestCase):
+    """Test cases for BLE duplicate connect suppression error detection."""
+
+    def test_detects_full_suppression_message(self):
+        """Should detect the complete fork error message."""
+        exc = RuntimeError("Connection suppressed: recently connected elsewhere")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is True
+
+    def test_detects_partial_suppression_message(self):
+        """Should detect partial message with just 'recently connected elsewhere'."""
+        exc = RuntimeError("recently connected elsewhere")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is True
+
+    def test_detects_both_keywords_together(self):
+        """Should detect when both keywords appear separately."""
+        exc = RuntimeError("connection suppressed due to connected elsewhere issue")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is True
+
+    def test_rejects_other_ble_errors(self):
+        """Should not match unrelated BLE errors."""
+        exc = RuntimeError("BLE connection timeout")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is False
+
+    def test_rejects_empty_exception(self):
+        """Should handle empty exception messages."""
+        exc = RuntimeError("")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is False
+
+    def test_rejects_only_connection_suppressed(self):
+        """Should not match when only 'connection suppressed' appears without 'connected elsewhere'."""
+        exc = RuntimeError("Connection suppressed by gate")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is False
+
+    def test_handles_case_insensitivity(self):
+        """Should be case insensitive."""
+        exc = RuntimeError("CONNECTION SUPPRESSED: RECENTLY CONNECTED ELSEWHERE")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is True
+
+    def test_handles_whitespace(self):
+        """Should handle messages with extra whitespace."""
+        exc = RuntimeError("  Connection suppressed: recently connected elsewhere  ")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is True
 
 
 if __name__ == "__main__":

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -33,6 +33,7 @@ from mmrelay.constants.network import (
 )
 from mmrelay.meshtastic_utils import (
     _is_ble_duplicate_connect_suppressed_error,
+    _reset_ble_connection_gate_state,
     connect_meshtastic,
     is_running_as_service,
     on_lost_meshtastic_connection,
@@ -1056,6 +1057,258 @@ class TestBLEDuplicateConnectSuppressionDetector(unittest.TestCase):
         """Should handle messages with extra whitespace."""
         exc = RuntimeError("  Connection suppressed: recently connected elsewhere  ")
         assert _is_ble_duplicate_connect_suppressed_error(exc) is True
+
+
+class TestBLEGateResetCallable(unittest.TestCase):
+    """Test cases for BLE gate reset callable behavior."""
+
+    def test_reset_returns_false_when_no_callable(self):
+        """Should return False when _ble_gate_reset_callable is None."""
+        import mmrelay.meshtastic_utils as mu
+
+        # Save original state
+        original_callable = mu._ble_gate_reset_callable
+
+        try:
+            mu._ble_gate_reset_callable = None
+            result = _reset_ble_connection_gate_state(
+                "AA:BB:CC:DD:EE:FF", reason="test"
+            )
+            assert result is False
+        finally:
+            mu._ble_gate_reset_callable = original_callable
+
+    def test_reset_handles_callable_exception(self):
+        """Should handle exceptions from _ble_gate_reset_callable gracefully."""
+        import mmrelay.meshtastic_utils as mu
+
+        original_callable = mu._ble_gate_reset_callable
+
+        def _raising_callable():
+            raise RuntimeError("Gate reset failed")
+
+        try:
+            mu._ble_gate_reset_callable = _raising_callable
+            result = _reset_ble_connection_gate_state(
+                "AA:BB:CC:DD:EE:FF", reason="test exception handling"
+            )
+            assert result is False
+        finally:
+            mu._ble_gate_reset_callable = original_callable
+
+    def test_reset_returns_true_on_success(self):
+        """Should return True when callable succeeds."""
+        import mmrelay.meshtastic_utils as mu
+
+        original_callable = mu._ble_gate_reset_callable
+        call_count = [0]
+
+        def _successful_callable():
+            call_count[0] += 1
+
+        try:
+            mu._ble_gate_reset_callable = _successful_callable
+            result = _reset_ble_connection_gate_state(
+                "AA:BB:CC:DD:EE:FF", reason="test success"
+            )
+            assert result is True
+            assert call_count[0] == 1
+        finally:
+            mu._ble_gate_reset_callable = original_callable
+
+
+class TestBLEGateImportDetection(unittest.TestCase):
+    """Test cases for module-level BLE gate import detection."""
+
+    def test_module_imports_gracefully_when_gating_unavailable(self):
+        """Should have _ble_gate_reset_callable as None when gating module missing."""
+        import mmrelay.meshtastic_utils as mu
+
+        # In environments without the fork, this should be None
+        # We can't easily test the import side effects, but we can verify
+        # the module is importable and has the expected attributes
+        assert hasattr(mu, "_ble_gate_reset_callable")
+        assert hasattr(mu, "_ble_gating_module")
+        # The callable should be None or a callable
+        assert mu._ble_gate_reset_callable is None or callable(
+            mu._ble_gate_reset_callable
+        )
+
+    def test_helper_safe_when_no_gating_module(self):
+        """Should be safe to call _reset_ble_connection_gate_state even without gating."""
+        import mmrelay.meshtastic_utils as mu
+
+        original_callable = mu._ble_gate_reset_callable
+
+        try:
+            mu._ble_gate_reset_callable = None
+            # Should not raise even with no callable
+            result = _reset_ble_connection_gate_state(
+                "AA:BB:CC:DD:EE:FF", reason="no gating module"
+            )
+            assert result is False
+        finally:
+            mu._ble_gate_reset_callable = original_callable
+
+
+class TestDuplicateSuppressionRetryLogic(unittest.TestCase):
+    """Test cases for duplicate suppression retry logic in connect_meshtastic."""
+
+    @patch("mmrelay.meshtastic_utils.logger")
+    @patch("mmrelay.meshtastic_utils.time.sleep")
+    @patch("mmrelay.meshtastic_utils._ble_gate_reset_callable")
+    def test_logs_warning_on_duplicate_suppression(
+        self, mock_gate_callable, mock_sleep, mock_logger
+    ):
+        """Should log warning when duplicate suppression detected."""
+        from mmrelay.meshtastic_utils import CONNECTION_TYPE_BLE
+
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        config = {
+            "meshtastic": {
+                "connection_type": CONNECTION_TYPE_BLE,
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+
+        class _SuppressedBLEInterface:
+            def __init__(self, **_kwargs):
+                raise RuntimeError(
+                    "Connection suppressed: recently connected elsewhere"
+                )
+
+        with patch(
+            "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
+            new=_SuppressedBLEInterface,
+        ):
+            result = connect_meshtastic(passed_config=config)
+
+        # Should return None after retries exhausted
+        assert result is None
+
+        # Should have logged the suppression detection warning
+        suppression_calls = [
+            call
+            for call in mock_logger.warning.call_args_list
+            if call.args
+            and "Detected duplicate BLE connect suppression" in str(call.args[0])
+        ]
+        assert len(suppression_calls) > 0, "Expected suppression detection warning"
+
+    @patch("mmrelay.meshtastic_utils.logger")
+    @patch("mmrelay.meshtastic_utils.time.sleep")
+    def test_logs_debug_when_gate_reset_unavailable(self, mock_sleep, mock_logger):
+        """Should log debug when gate reset hook is unavailable."""
+        import mmrelay.meshtastic_utils as mu
+        from mmrelay.meshtastic_utils import CONNECTION_TYPE_BLE
+
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        config = {
+            "meshtastic": {
+                "connection_type": CONNECTION_TYPE_BLE,
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+
+        class _SuppressedBLEInterface:
+            def __init__(self, **_kwargs):
+                raise RuntimeError(
+                    "Connection suppressed: recently connected elsewhere"
+                )
+
+        original_callable = mu._ble_gate_reset_callable
+        try:
+            # Simulate no gate reset available
+            mu._ble_gate_reset_callable = None
+
+            with patch(
+                "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
+                new=_SuppressedBLEInterface,
+            ):
+                result = connect_meshtastic(passed_config=config)
+
+            # Should return None after retries exhausted
+            assert result is None
+
+            # Should have logged the suppression detection warning
+            suppression_calls = [
+                call
+                for call in mock_logger.warning.call_args_list
+                if call.args
+                and "Detected duplicate BLE connect suppression" in str(call.args[0])
+            ]
+            assert len(suppression_calls) > 0, "Expected suppression detection warning"
+
+            # Should have logged debug about unavailable hook
+            debug_calls = [
+                call
+                for call in mock_logger.debug.call_args_list
+                if call.args and "BLE gate reset hook unavailable" in str(call.args[0])
+            ]
+            assert len(debug_calls) > 0, "Expected debug about unavailable hook"
+        finally:
+            mu._ble_gate_reset_callable = original_callable
+
+    @patch("mmrelay.meshtastic_utils.logger")
+    @patch("mmrelay.meshtastic_utils.time.sleep")
+    def test_no_debug_log_when_gate_reset_succeeds(self, mock_sleep, mock_logger):
+        """Should not log debug when gate reset succeeds."""
+        import mmrelay.meshtastic_utils as mu
+        from mmrelay.meshtastic_utils import CONNECTION_TYPE_BLE
+
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        config = {
+            "meshtastic": {
+                "connection_type": CONNECTION_TYPE_BLE,
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+
+        class _SuppressedBLEInterface:
+            def __init__(self, **_kwargs):
+                raise RuntimeError(
+                    "Connection suppressed: recently connected elsewhere"
+                )
+
+        original_callable = mu._ble_gate_reset_callable
+
+        def _successful_reset():
+            pass
+
+        try:
+            # Set up a working gate reset callable
+            mu._ble_gate_reset_callable = _successful_reset
+
+            with patch(
+                "mmrelay.meshtastic_utils.meshtastic.ble_interface.BLEInterface",
+                new=_SuppressedBLEInterface,
+            ):
+                result = connect_meshtastic(passed_config=config)
+
+            # Should return None after retries exhausted
+            assert result is None
+
+            # Should have logged the suppression detection warning
+            suppression_calls = [
+                call
+                for call in mock_logger.warning.call_args_list
+                if call.args
+                and "Detected duplicate BLE connect suppression" in str(call.args[0])
+            ]
+            assert len(suppression_calls) > 0, "Expected suppression detection warning"
+
+            # Should NOT have logged debug about unavailable hook when reset succeeds
+            debug_calls = [
+                call
+                for call in mock_logger.debug.call_args_list
+                if call.args and "BLE gate reset hook unavailable" in str(call.args[0])
+            ]
+            assert len(debug_calls) == 0, "Should not log debug when reset succeeds"
+        finally:
+            mu._ble_gate_reset_callable = original_callable
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves BLE connection resilience by adding detection and recovery for Meshtastic BLE "duplicate connect suppression" cases and provides gated BLE reset behavior; it also makes Matrix message send retries idempotent by reusing a stable transaction id across retry attempts. Tests were updated to cover these behaviors and CI linter pins were bumped.

## Key Changes

Features
- BLE gate reset integration
  - Detects optional Meshtastic BLE gating support at startup and caches a reset callable when available.
  - Adds _reset_ble_connection_gate_state(ble_address, reason) to invoke the cached reset callable (best-effort) and log results.
  - Wires gate reset calls into BLE connect and worker-recovery paths to help clear fork/gate state before retrying.
- Duplicate connection suppression detection
  - Adds _is_ble_duplicate_connect_suppressed_error(exc) to classify exceptions whose messages indicate "Connection suppressed" and "connected elsewhere" (robust to partial matches, case, and whitespace).
  - On detecting such errors during connect, the code calls the BLE gate reset helper before continuing retry/backoff.
- Idempotent Matrix retries
  - Extends _send_matrix_message_with_retry(...) with an optional transaction_id parameter and computes a single stable_transaction_id per send call (generated if not provided).
  - Reuses stable transaction id (tx_id) across all retry attempts so transient failures do not cause duplicate sends.

Tests
- Added test_send_matrix_message_with_retry_reuses_tx_id_across_retries to assert a single mmrelay-* tx_id is passed across retries.
- Updated BLE-related tests to patch the new _ble_gate_reset_callable and assert warning logs indicating gate resets:
  - test_connect_meshtastic_ble_recovers_from_stale_worker now asserts gate reset warning is emitted.
  - Added test_connect_meshtastic_duplicate_suppression_clears_fork_gates to verify reset is invoked and duplicate-suppression is detected.
- Added unit tests for _is_ble_duplicate_connect_suppressed_error covering positive and negative message cases.

Refactors / Maintenance
- Tests refactored to patch _ble_gate_reset_callable rather than the internal _reset_ble_connection_gate_state.
- Bumped package version constant to 1.3.3.
- CI/tooling: bumped mypy (1.19.1 → 1.20.0) and actionlint (1.7.11 → 1.7.12) in .trunk/trunk.yaml.

Breaking Changes / Migration Notes

- None. The transaction_id parameter added to _send_matrix_message_with_retry() is optional (default None) and preserves previous behavior when omitted. Gate-reset behavior is best-effort and only invoked when the optional Meshtastic gating API is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->