### PR TITLE
Serialize Meshtastic connect attempts and harden shutdown callback cleanup

### DIFF
--- a/src/mmrelay/constants/network.py
+++ b/src/mmrelay/constants/network.py
@@ -160,8 +160,8 @@ MESHTASTIC_CHANNEL_MAX: Final[int] = 7
 # RxTime clock skew bootstrap windows
 RX_TIME_SKEW_BOOTSTRAP_WINDOW_SECS: Final[float] = 180.0
 RX_TIME_SKEW_BOOTSTRAP_MAX_SKEW_SECS: Final[float] = (
-    24 * 60 * 60
-)  # 24 hours - handles multi-hour host clock jumps
+    48 * 60 * 60
+)  # 48 hours - handles day-scale node/host clock jumps after reboot
 STARTUP_PACKET_DRAIN_SECS: Final[float] = 15.0
 RECONNECT_PRESTART_BOOTSTRAP_WINDOW_SECS: Final[float] = 5.0
 

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -1099,6 +1099,18 @@ async def main(config: dict[str, Any]) -> None:
             task_name="connection health task",
             timeout_seconds=5.0,
         )
+        reconnect_task_obj = meshtastic_utils.reconnect_task
+        if reconnect_task_obj:
+            reconnect_task_obj.cancel()
+            meshtastic_logger.info("Cancelled Meshtastic reconnect task.")
+            if isinstance(reconnect_task_obj, asyncio.Task):
+                await _await_background_task_shutdown(
+                    reconnect_task_obj,
+                    task_name="Meshtastic reconnect task",
+                    timeout_seconds=5.0,
+                )
+            meshtastic_utils.reconnect_task = None
+        meshtastic_utils.unsubscribe_meshtastic_callbacks()
         # Cleanup
         matrix_logger.info("Stopping plugins...")
         await _run_blocking_shutdown_step(
@@ -1120,11 +1132,6 @@ async def main(config: dict[str, Any]) -> None:
         if wipe_on_restart:
             logger.debug("wipe_on_restart enabled. Wiping message_map now (shutdown).")
             wipe_message_map()
-
-        # Cancel the reconnect task if it exists
-        if meshtastic_utils.reconnect_task:
-            meshtastic_utils.reconnect_task.cancel()
-            meshtastic_logger.info("Cancelled Meshtastic reconnect task.")
 
         matrix_logger.info("Shutdown complete.")
         if fatal_exception is not None and sys.exc_info()[1] is None:

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -632,6 +632,53 @@ async def main(config: dict[str, Any]) -> None:
             meshtastic_utils.meshtastic_client = None
             meshtastic_utils.meshtastic_iface = None
 
+    async def _cleanup_meshtastic_reconnect_state(*, context: str) -> None:
+        """Cancel reconnect work and unsubscribe Meshtastic callbacks."""
+
+        async def _cancel_future_with_timeout(
+            future_obj: asyncio.Future[Any] | None,
+            *,
+            task_name: str,
+        ) -> None:
+            if future_obj is None:
+                return
+            future_obj.cancel()
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(future_obj, return_exceptions=True),
+                    timeout=5.0,
+                )
+            except asyncio.TimeoutError:
+                meshtastic_logger.warning(
+                    "Timed out waiting for %s during %s",
+                    task_name,
+                    context,
+                )
+
+        reconnect_task_obj = meshtastic_utils.reconnect_task
+        if reconnect_task_obj is not None:
+            reconnect_task_obj.cancel()
+            meshtastic_logger.info("Cancelled Meshtastic reconnect task.")
+            if isinstance(reconnect_task_obj, asyncio.Future):
+                await _cancel_future_with_timeout(
+                    reconnect_task_obj,
+                    task_name="Meshtastic reconnect task",
+                )
+            meshtastic_utils.reconnect_task = None
+
+        reconnect_future_obj = meshtastic_utils.reconnect_task_future
+        if reconnect_future_obj is not None:
+            if isinstance(reconnect_future_obj, asyncio.Future):
+                await _cancel_future_with_timeout(
+                    reconnect_future_obj,
+                    task_name="Meshtastic reconnect worker future",
+                )
+            else:
+                reconnect_future_obj.cancel()
+            meshtastic_utils.reconnect_task_future = None
+
+        meshtastic_utils.unsubscribe_meshtastic_callbacks()
+
     try:
         # Load plugins early (run in executor to avoid blocking event loop with time.sleep)
         plugins_cleanup_needed = True
@@ -786,6 +833,7 @@ async def main(config: dict[str, Any]) -> None:
                 meshtastic_logger.warning(
                     "Timed out waiting for connection health task during startup rollback"
                 )
+        await _cleanup_meshtastic_reconnect_state(context="startup rollback")
         _remove_ready_file()
         if plugins_cleanup_needed:
             await _run_blocking_shutdown_step(
@@ -1099,27 +1147,7 @@ async def main(config: dict[str, Any]) -> None:
             task_name="connection health task",
             timeout_seconds=5.0,
         )
-        reconnect_future_obj = meshtastic_utils.reconnect_task_future
-        reconnect_task_obj = meshtastic_utils.reconnect_task
-        if reconnect_task_obj:
-            reconnect_task_obj.cancel()
-            meshtastic_logger.info("Cancelled Meshtastic reconnect task.")
-            if isinstance(reconnect_task_obj, asyncio.Future):
-                await _await_background_task_shutdown(
-                    reconnect_task_obj,
-                    task_name="Meshtastic reconnect task",
-                    timeout_seconds=5.0,
-                )
-            meshtastic_utils.reconnect_task = None
-        if reconnect_future_obj is not None:
-            reconnect_future_obj.cancel()
-            await _await_background_task_shutdown(
-                reconnect_future_obj,
-                task_name="Meshtastic reconnect worker future",
-                timeout_seconds=5.0,
-            )
-            meshtastic_utils.reconnect_task_future = None
-        meshtastic_utils.unsubscribe_meshtastic_callbacks()
+        await _cleanup_meshtastic_reconnect_state(context="shutdown")
         # Cleanup
         matrix_logger.info("Stopping plugins...")
         await _run_blocking_shutdown_step(

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -875,7 +875,7 @@ async def main(config: dict[str, Any]) -> None:
                 backoff_seconds = min(backoff_seconds * 2.0, max_backoff_seconds)
 
     async def _await_background_task_shutdown(
-        task: asyncio.Task[Any] | None,
+        task: asyncio.Future[Any] | None,
         *,
         task_name: str,
         timeout_seconds: float,
@@ -1099,17 +1099,26 @@ async def main(config: dict[str, Any]) -> None:
             task_name="connection health task",
             timeout_seconds=5.0,
         )
+        reconnect_future_obj = meshtastic_utils.reconnect_task_future
         reconnect_task_obj = meshtastic_utils.reconnect_task
         if reconnect_task_obj:
             reconnect_task_obj.cancel()
             meshtastic_logger.info("Cancelled Meshtastic reconnect task.")
-            if isinstance(reconnect_task_obj, asyncio.Task):
+            if isinstance(reconnect_task_obj, asyncio.Future):
                 await _await_background_task_shutdown(
                     reconnect_task_obj,
                     task_name="Meshtastic reconnect task",
                     timeout_seconds=5.0,
                 )
             meshtastic_utils.reconnect_task = None
+        if reconnect_future_obj is not None:
+            reconnect_future_obj.cancel()
+            await _await_background_task_shutdown(
+                reconnect_future_obj,
+                task_name="Meshtastic reconnect worker future",
+                timeout_seconds=5.0,
+            )
+            meshtastic_utils.reconnect_task_future = None
         meshtastic_utils.unsubscribe_meshtastic_callbacks()
         # Cleanup
         matrix_logger.info("Stopping plugins...")

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -2352,6 +2352,7 @@ def _wait_for_future_result_with_shutdown(
 
     deadline = time.monotonic() + float(timeout_seconds)
     poll_budget = max(0.05, float(poll_seconds))
+    immediate_timeout_count = 0
 
     while True:
         if shutting_down:
@@ -2361,9 +2362,21 @@ def _wait_for_future_result_with_shutdown(
         if remaining <= 0:
             raise FuturesTimeoutError()
 
+        wait_budget = min(remaining, poll_budget)
+        call_started = time.monotonic()
         try:
-            return result_future.result(timeout=min(remaining, poll_budget))
+            return result_future.result(timeout=wait_budget)
         except FuturesTimeoutError:
+            call_elapsed = time.monotonic() - call_started
+            # Some mocked futures raise timeout immediately instead of blocking for
+            # the timeout duration. Avoid a busy-loop that can run until the full
+            # deadline in that scenario.
+            if call_elapsed < min(0.01, wait_budget * 0.1):
+                immediate_timeout_count += 1
+                if immediate_timeout_count >= 3:
+                    raise
+            else:
+                immediate_timeout_count = 0
             continue
 
 
@@ -4670,7 +4683,6 @@ def on_lost_meshtastic_connection(
             and (
                 _callbacks_tearing_down
                 or subscribed_to_connection_lost
-                or reconnecting
                 or shutting_down
             )
         ):

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -24,6 +24,7 @@ import serial  # For serial port exceptions
 import serial.tools.list_ports  # Import serial tools for port listing
 from meshtastic.protobuf import admin_pb2, mesh_pb2, portnums_pb2
 from pubsub import pub
+from pubsub.core.topicexc import TopicNameError
 
 from mmrelay.config import get_meshtastic_config_value
 from mmrelay.constants.config import (
@@ -241,19 +242,39 @@ def unsubscribe_meshtastic_callbacks() -> None:
 
     with meshtastic_sub_lock:
         if subscribed_to_messages:
-            with contextlib.suppress(Exception):
+            try:
                 pub.unsubscribe(on_meshtastic_message, "meshtastic.receive")
-            subscribed_to_messages = False
-            logger.debug("Unsubscribed from meshtastic.receive")
+            except TopicNameError:
+                subscribed_to_messages = False
+                logger.debug(
+                    "meshtastic.receive topic missing during unsubscribe; treated as unsubscribed"
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to unsubscribe from meshtastic.receive; keeping subscribed_to_messages=True"
+                )
+            else:
+                subscribed_to_messages = False
+                logger.debug("Unsubscribed from meshtastic.receive")
 
         if subscribed_to_connection_lost:
-            with contextlib.suppress(Exception):
+            try:
                 pub.unsubscribe(
                     on_lost_meshtastic_connection,
                     "meshtastic.connection.lost",
                 )
-            subscribed_to_connection_lost = False
-            logger.debug("Unsubscribed from meshtastic.connection.lost")
+            except TopicNameError:
+                subscribed_to_connection_lost = False
+                logger.debug(
+                    "meshtastic.connection.lost topic missing during unsubscribe; treated as unsubscribed"
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to unsubscribe from meshtastic.connection.lost; keeping subscribed_to_connection_lost=True"
+                )
+            else:
+                subscribed_to_connection_lost = False
+                logger.debug("Unsubscribed from meshtastic.connection.lost")
 
 
 # Shared executor for getMetadata() to avoid leaking threads when metadata calls hang.
@@ -3569,9 +3590,9 @@ def connect_meshtastic(
             remaining_wait = wait_deadline - time.monotonic()
             if remaining_wait <= 0:
                 logger.debug(
-                    "Timed out waiting for active connect attempt; returning current client state"
+                    "Timed out waiting for active connect attempt; returning no client"
                 )
-                return meshtastic_client
+                return None
 
             logger.debug(
                 "connect_meshtastic() already in progress; waiting for active attempt to finish"
@@ -3588,9 +3609,9 @@ def connect_meshtastic(
                 return None
             if _connect_attempt_in_progress and time.monotonic() >= wait_deadline:
                 logger.debug(
-                    "Timed out waiting for active connect attempt; returning current client state"
+                    "Timed out waiting for active connect attempt; returning no client"
                 )
-                return meshtastic_client
+                return None
 
     try:
         return _connect_meshtastic_impl(
@@ -4330,6 +4351,20 @@ def _connect_meshtastic_impl(
 
                 node_info = client.getMyNodeInfo()
 
+                if shutting_down:
+                    logger.debug(
+                        "Shutdown started during connect setup (after getMyNodeInfo); rolling back client"
+                    )
+                    client_assigned_for_this_connect = _rollback_connect_attempt_state(
+                        client=client,
+                        client_assigned_for_this_connect=client_assigned_for_this_connect,
+                        startup_drain_armed_for_this_connect=startup_drain_armed_for_this_connect,
+                        startup_drain_applied_for_this_connect=startup_drain_applied_for_this_connect,
+                        reconnect_bootstrap_armed_for_this_connect=reconnect_bootstrap_armed_for_this_connect,
+                    )
+                    successful = False
+                    return None
+
                 # Safely access node info fields
                 user_info = node_info.get("user", {}) if node_info else {}
                 short_name = user_info.get("shortName", "unknown")
@@ -4338,6 +4373,20 @@ def _connect_meshtastic_impl(
                 # Get firmware version from device metadata
                 metadata = _get_device_metadata(client)
                 firmware_version = metadata["firmware_version"]
+
+                if shutting_down:
+                    logger.debug(
+                        "Shutdown started during connect setup (after metadata); rolling back client"
+                    )
+                    client_assigned_for_this_connect = _rollback_connect_attempt_state(
+                        client=client,
+                        client_assigned_for_this_connect=client_assigned_for_this_connect,
+                        startup_drain_armed_for_this_connect=startup_drain_armed_for_this_connect,
+                        startup_drain_applied_for_this_connect=startup_drain_applied_for_this_connect,
+                        reconnect_bootstrap_armed_for_this_connect=reconnect_bootstrap_armed_for_this_connect,
+                    )
+                    successful = False
+                    return None
 
                 if metadata.get("success"):
                     logger.info(
@@ -4365,6 +4414,20 @@ def _connect_meshtastic_impl(
                             "Armed startup drain window deadline=%s after setup completion",
                             _relay_startup_drain_deadline_monotonic_secs,
                         )
+
+                if shutting_down:
+                    logger.debug(
+                        "Shutdown started before callback subscription; rolling back client"
+                    )
+                    client_assigned_for_this_connect = _rollback_connect_attempt_state(
+                        client=client,
+                        client_assigned_for_this_connect=client_assigned_for_this_connect,
+                        startup_drain_armed_for_this_connect=startup_drain_armed_for_this_connect,
+                        startup_drain_applied_for_this_connect=startup_drain_applied_for_this_connect,
+                        reconnect_bootstrap_armed_for_this_connect=reconnect_bootstrap_armed_for_this_connect,
+                    )
+                    successful = False
+                    return None
 
                 # Subscribe to message and connection-lost events.
                 ensure_meshtastic_callbacks_subscribed()
@@ -4712,11 +4775,7 @@ async def reconnect() -> None:
                     None, connect_meshtastic, config, True
                 )
                 reconnect_task_future = connect_future
-                try:
-                    meshtastic_client = await connect_future
-                finally:
-                    if reconnect_task_future is connect_future:
-                        reconnect_task_future = None
+                meshtastic_client = await connect_future
                 if meshtastic_client:
                     logger.info("Reconnected successfully.")
                     break
@@ -4728,7 +4787,9 @@ async def reconnect() -> None:
     except asyncio.CancelledError:
         logger.info("Reconnection task was cancelled.")
     finally:
-        reconnect_task_future = None
+        if reconnect_task_future is not None:
+            if reconnect_task_future.done() and not reconnect_task_future.cancelled():
+                reconnect_task_future = None
         reconnecting = False
 
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -212,6 +212,42 @@ meshtastic_iface_lock = (
 subscribed_to_messages = False
 subscribed_to_connection_lost = False
 
+
+def ensure_meshtastic_callbacks_subscribed() -> None:
+    """Ensure Meshtastic pubsub callbacks are subscribed exactly once."""
+    global subscribed_to_messages, subscribed_to_connection_lost
+
+    if not subscribed_to_messages:
+        pub.subscribe(on_meshtastic_message, "meshtastic.receive")
+        subscribed_to_messages = True
+        logger.debug("Subscribed to meshtastic.receive")
+
+    if not subscribed_to_connection_lost:
+        pub.subscribe(on_lost_meshtastic_connection, "meshtastic.connection.lost")
+        subscribed_to_connection_lost = True
+        logger.debug("Subscribed to meshtastic.connection.lost")
+
+
+def unsubscribe_meshtastic_callbacks() -> None:
+    """Best-effort unsubscribe for Meshtastic pubsub callbacks."""
+    global subscribed_to_messages, subscribed_to_connection_lost
+
+    if subscribed_to_messages:
+        with contextlib.suppress(Exception):
+            pub.unsubscribe(on_meshtastic_message, "meshtastic.receive")
+        subscribed_to_messages = False
+        logger.debug("Unsubscribed from meshtastic.receive")
+
+    if subscribed_to_connection_lost:
+        with contextlib.suppress(Exception):
+            pub.unsubscribe(
+                on_lost_meshtastic_connection,
+                "meshtastic.connection.lost",
+            )
+        subscribed_to_connection_lost = False
+        logger.debug("Unsubscribed from meshtastic.connection.lost")
+
+
 # Shared executor for getMetadata() to avoid leaking threads when metadata calls hang.
 # A single worker is enough because getMetadata() is serialized by design.
 _metadata_executor: ThreadPoolExecutor | None = ThreadPoolExecutor(max_workers=1)
@@ -373,7 +409,8 @@ def _shutdown_shared_executors() -> None:
     global _ble_future_started_at, _ble_future_timeout_secs
     global _metadata_executor, _metadata_future, _metadata_future_started_at
     global _health_probe_request_deadlines
-    global _metadata_executor_orphaned_workers, _ble_executor_orphaned_workers_by_address
+    global _metadata_executor_orphaned_workers
+    global _ble_executor_orphaned_workers_by_address
     global _ble_executor_degraded_addresses, _metadata_executor_degraded
 
     # Cancel any pending BLE operation
@@ -462,7 +499,8 @@ def reset_executor_degraded_state(
         bool: True if any degraded state was reset, False otherwise.
     """
     global _ble_executor_degraded_addresses, _metadata_executor_degraded
-    global _metadata_executor_orphaned_workers, _ble_executor_orphaned_workers_by_address
+    global _metadata_executor_orphaned_workers
+    global _ble_executor_orphaned_workers_by_address
     global _ble_executor, _metadata_executor
 
     reset_any = False
@@ -4264,19 +4302,8 @@ def _connect_meshtastic_impl(
                             _relay_startup_drain_deadline_monotonic_secs,
                         )
 
-                # Subscribe to message and connection lost events (only once per application run)
-                global subscribed_to_messages, subscribed_to_connection_lost
-                if not subscribed_to_messages:
-                    pub.subscribe(on_meshtastic_message, "meshtastic.receive")
-                    subscribed_to_messages = True
-                    logger.debug("Subscribed to meshtastic.receive")
-
-                if not subscribed_to_connection_lost:
-                    pub.subscribe(
-                        on_lost_meshtastic_connection, "meshtastic.connection.lost"
-                    )
-                    subscribed_to_connection_lost = True
-                    logger.debug("Subscribed to meshtastic.connection.lost")
+                # Subscribe to message and connection-lost events.
+                ensure_meshtastic_callbacks_subscribed()
 
                 _schedule_connect_time_calibration_probe(
                     client,
@@ -4654,6 +4681,10 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
     # Validate packet structure
     if not packet or not isinstance(packet, dict):
         logger.error("Received malformed packet: packet is None or not a dict")
+        return
+
+    if shutting_down:
+        logger.debug("Shutdown in progress. Ignoring incoming messages.")
         return
 
     # Read-mostly guard values; avoid meshtastic_lock here because callbacks can

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -3519,6 +3519,7 @@ def _rollback_connect_attempt_state(
     startup_drain_armed_for_this_connect: bool,
     startup_drain_applied_for_this_connect: bool,
     reconnect_bootstrap_armed_for_this_connect: bool,
+    lock_held: bool = False,
 ) -> bool:
     """
     Centralize cleanup of partially-assigned clients and timing state when a connect attempt fails.
@@ -3529,10 +3530,11 @@ def _rollback_connect_attempt_state(
     global _relay_startup_drain_deadline_monotonic_secs, _startup_packet_drain_applied
     global _relay_reconnect_prestart_bootstrap_deadline_monotonic_secs
 
+    _lock_ctx = contextlib.nullcontext() if lock_held else meshtastic_lock
     if client is not None and (
         client_assigned_for_this_connect or client is meshtastic_iface
     ):
-        with meshtastic_lock:
+        with _lock_ctx:
             if meshtastic_client is client or client is meshtastic_iface:
                 try:
                     if client is meshtastic_iface:
@@ -4361,6 +4363,7 @@ def _connect_meshtastic_impl(
                         startup_drain_armed_for_this_connect=startup_drain_armed_for_this_connect,
                         startup_drain_applied_for_this_connect=startup_drain_applied_for_this_connect,
                         reconnect_bootstrap_armed_for_this_connect=reconnect_bootstrap_armed_for_this_connect,
+                        lock_held=True,
                     )
                     successful = False
                     return None
@@ -4384,6 +4387,7 @@ def _connect_meshtastic_impl(
                         startup_drain_armed_for_this_connect=startup_drain_armed_for_this_connect,
                         startup_drain_applied_for_this_connect=startup_drain_applied_for_this_connect,
                         reconnect_bootstrap_armed_for_this_connect=reconnect_bootstrap_armed_for_this_connect,
+                        lock_held=True,
                     )
                     successful = False
                     return None
@@ -4425,6 +4429,7 @@ def _connect_meshtastic_impl(
                         startup_drain_armed_for_this_connect=startup_drain_armed_for_this_connect,
                         startup_drain_applied_for_this_connect=startup_drain_applied_for_this_connect,
                         reconnect_bootstrap_armed_for_this_connect=reconnect_bootstrap_armed_for_this_connect,
+                        lock_held=True,
                     )
                     successful = False
                     return None
@@ -4724,7 +4729,7 @@ async def reconnect() -> None:
 
     Retries connect_meshtastic(force_connect=True) until a connection is obtained, the application begins shutting down, or the task is cancelled. Starts with DEFAULT_BACKOFF_TIME and doubles the wait after each failed attempt, capped at 300 seconds. Stops promptly on cancellation or when shutting_down is set, and ensures the module-level `reconnecting` flag is cleared before returning.
     """
-    global meshtastic_client, reconnecting, shutting_down, reconnect_task_future
+    global reconnecting, shutting_down, reconnect_task_future
     backoff_time = DEFAULT_BACKOFF_TIME
     try:
         while not shutting_down:
@@ -4775,8 +4780,8 @@ async def reconnect() -> None:
                     loop.run_in_executor(None, connect_meshtastic, config, True)
                 )
                 reconnect_task_future = connect_future
-                meshtastic_client = await connect_future
-                if meshtastic_client:
+                connected_client = await connect_future
+                if connected_client is not None:
                     logger.info("Reconnected successfully.")
                     break
             except Exception:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -196,6 +196,9 @@ event_loop = None  # Will be set from main.py
 meshtastic_lock = (
     threading.Lock()
 )  # To prevent race conditions on meshtastic_client access
+# Serialize full connect attempt lifecycles so concurrent callers do not
+# create overlapping clients/interfaces and race rollback cleanup.
+_connect_attempt_lock = threading.RLock()
 
 reconnecting = False
 shutting_down = False
@@ -3498,6 +3501,33 @@ def _rollback_connect_attempt_state(
 
 
 def connect_meshtastic(
+    passed_config: dict[str, Any] | None = None,
+    force_connect: bool = False,
+) -> Any:
+    """
+    Establish a Meshtastic connection while serializing full connect lifecycles.
+
+    This wrapper prevents overlapping `connect_meshtastic()` attempts across
+    threads. Callers that arrive while another connect is in progress wait for
+    that attempt to finish and then execute normally.
+    """
+    acquired_without_wait = _connect_attempt_lock.acquire(blocking=False)
+    if not acquired_without_wait:
+        logger.debug(
+            "connect_meshtastic() already in progress; waiting for active attempt to finish"
+        )
+        _connect_attempt_lock.acquire()
+
+    try:
+        return _connect_meshtastic_impl(
+            passed_config=passed_config,
+            force_connect=force_connect,
+        )
+    finally:
+        _connect_attempt_lock.release()
+
+
+def _connect_meshtastic_impl(
     passed_config: dict[str, Any] | None = None,
     force_connect: bool = False,
 ) -> Any:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -4729,7 +4729,7 @@ async def reconnect() -> None:
 
     Retries connect_meshtastic(force_connect=True) until a connection is obtained, the application begins shutting down, or the task is cancelled. Starts with DEFAULT_BACKOFF_TIME and doubles the wait after each failed attempt, capped at 300 seconds. Stops promptly on cancellation or when shutting_down is set, and ensures the module-level `reconnecting` flag is cleared before returning.
     """
-    global reconnecting, shutting_down, reconnect_task_future
+    global meshtastic_client, reconnecting, shutting_down, reconnect_task_future
     backoff_time = DEFAULT_BACKOFF_TIME
     try:
         while not shutting_down:
@@ -4782,6 +4782,7 @@ async def reconnect() -> None:
                 reconnect_task_future = connect_future
                 connected_client = await connect_future
                 if connected_client is not None:
+                    meshtastic_client = connected_client
                     logger.info("Reconnected successfully.")
                     break
             except Exception:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -4113,7 +4113,22 @@ def _connect_meshtastic_impl(
                                     raise TimeoutError(
                                         f"BLE connection attempt timed out for {ble_address}."
                                     ) from err
-                            except TimeoutError:
+                            except TimeoutError as err:
+                                if shutting_down or str(err) == "Shutdown in progress":
+                                    if future.cancel():
+                                        _clear_ble_future(future)
+                                    else:
+                                        _schedule_ble_future_cleanup(
+                                            future,
+                                            ble_address,
+                                            reason="interface creation shutdown cancellation",
+                                        )
+                                        _attach_late_ble_interface_disposer(
+                                            future,
+                                            ble_address,
+                                            reason="interface creation shutdown cancellation",
+                                        )
+                                    meshtastic_iface = None
                                 raise
                             except Exception:
                                 # Late BLE worker failures can surface during shutdown
@@ -4233,12 +4248,13 @@ def _connect_meshtastic_impl(
                             )
                             logger.info(f"BLE connection established to {ble_address}")
                             reset_executor_degraded_state(ble_address=ble_address)
-                        except TimeoutError as err:
+                        except (TimeoutError, FuturesTimeoutError) as err:
                             if shutting_down or str(err) == "Shutdown in progress":
                                 logger.debug(
                                     "BLE connect() interrupted by shutdown for %s",
                                     ble_address,
                                 )
+                                shutdown_iface = iface
                                 if connect_future.cancel():
                                     _clear_ble_future(connect_future)
                                 else:
@@ -4246,6 +4262,12 @@ def _connect_meshtastic_impl(
                                         connect_future,
                                         ble_address,
                                         reason="connect shutdown cancellation",
+                                    )
+                                    _attach_late_ble_interface_disposer(
+                                        connect_future,
+                                        ble_address,
+                                        reason="connect shutdown cancellation",
+                                        fallback_iface=shutdown_iface,
                                     )
                                 iface = None
                                 meshtastic_iface = None

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -199,11 +199,15 @@ meshtastic_lock = (
 # Serialize full connect attempt lifecycles so concurrent callers do not
 # create overlapping clients/interfaces and race rollback cleanup.
 _connect_attempt_lock = threading.RLock()
+_connect_attempt_condition = threading.Condition(_connect_attempt_lock)
+_connect_attempt_in_progress = False
+_CONNECT_ATTEMPT_WAIT_POLL_SECS = 1.0
 
 reconnecting = False
 shutting_down = False
 
 reconnect_task = None  # To keep track of the reconnect task
+reconnect_task_future: asyncio.Future[Any] | None = None
 meshtastic_iface_lock = (
     threading.Lock()
 )  # To prevent race conditions on BLE interface singleton creation
@@ -3543,18 +3547,28 @@ def connect_meshtastic(
     force_connect: bool = False,
 ) -> Any:
     """
-    Establish a Meshtastic connection while serializing full connect lifecycles.
+    Establish a Meshtastic connection while preventing overlapping attempts.
 
-    This wrapper prevents overlapping `connect_meshtastic()` attempts across
-    threads. Callers that arrive while another connect is in progress wait for
-    that attempt to finish and then execute normally.
+    This wrapper coordinates concurrent callers with an in-progress marker.
+    Callers that arrive while another connect is running wait for that attempt
+    to finish, then retry acquisition.
     """
-    acquired_without_wait = _connect_attempt_lock.acquire(blocking=False)
-    if not acquired_without_wait:
-        logger.debug(
-            "connect_meshtastic() already in progress; waiting for active attempt to finish"
-        )
-        _connect_attempt_lock.acquire()
+    global _connect_attempt_in_progress
+
+    while True:
+        with _connect_attempt_condition:
+            if not _connect_attempt_in_progress:
+                _connect_attempt_in_progress = True
+                break
+
+            logger.debug(
+                "connect_meshtastic() already in progress; waiting for active attempt to finish"
+            )
+            while _connect_attempt_in_progress and not shutting_down:
+                _connect_attempt_condition.wait(timeout=_CONNECT_ATTEMPT_WAIT_POLL_SECS)
+            if shutting_down:
+                logger.debug("Shutdown in progress. Not attempting to connect.")
+                return None
 
     try:
         return _connect_meshtastic_impl(
@@ -3562,7 +3576,9 @@ def connect_meshtastic(
             force_connect=force_connect,
         )
     finally:
-        _connect_attempt_lock.release()
+        with _connect_attempt_condition:
+            _connect_attempt_in_progress = False
+            _connect_attempt_condition.notify_all()
 
 
 def _connect_meshtastic_impl(
@@ -4597,7 +4613,7 @@ async def reconnect() -> None:
 
     Retries connect_meshtastic(force_connect=True) until a connection is obtained, the application begins shutting down, or the task is cancelled. Starts with DEFAULT_BACKOFF_TIME and doubles the wait after each failed attempt, capped at 300 seconds. Stops promptly on cancellation or when shutting_down is set, and ensures the module-level `reconnecting` flag is cleared before returning.
     """
-    global meshtastic_client, reconnecting, shutting_down
+    global meshtastic_client, reconnecting, shutting_down, reconnect_task_future
     backoff_time = DEFAULT_BACKOFF_TIME
     try:
         while not shutting_down:
@@ -4644,9 +4660,15 @@ async def reconnect() -> None:
                 loop = asyncio.get_running_loop()
                 # Pass the current config during reconnection to ensure matrix_rooms is populated
                 # Using None for passed_config would skip matrix_rooms initialization
-                meshtastic_client = await loop.run_in_executor(
+                connect_future = loop.run_in_executor(
                     None, connect_meshtastic, config, True
                 )
+                reconnect_task_future = connect_future
+                try:
+                    meshtastic_client = await connect_future
+                finally:
+                    if reconnect_task_future is connect_future:
+                        reconnect_task_future = None
                 if meshtastic_client:
                     logger.info("Reconnected successfully.")
                     break
@@ -4658,6 +4680,7 @@ async def reconnect() -> None:
     except asyncio.CancelledError:
         logger.info("Reconnection task was cancelled.")
     finally:
+        reconnect_task_future = None
         reconnecting = False
 
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -4771,8 +4771,8 @@ async def reconnect() -> None:
                 loop = asyncio.get_running_loop()
                 # Pass the current config during reconnection to ensure matrix_rooms is populated
                 # Using None for passed_config would skip matrix_rooms initialization
-                connect_future = loop.run_in_executor(
-                    None, connect_meshtastic, config, True
+                connect_future = asyncio.ensure_future(
+                    loop.run_in_executor(None, connect_meshtastic, config, True)
                 )
                 reconnect_task_future = connect_future
                 meshtastic_client = await connect_future

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -204,6 +204,9 @@ _connect_attempt_condition = threading.Condition(_connect_attempt_lock)
 _connect_attempt_in_progress = False
 _CONNECT_ATTEMPT_WAIT_POLL_SECS = 1.0
 _CONNECT_ATTEMPT_WAIT_MAX_SECS = 5.0
+_CONNECT_ATTEMPT_BLE_WAIT_MAX_SECS = (
+    BLE_INTERFACE_CREATE_TIMEOUT_FLOOR_SECS + BLE_CONNECT_TIMEOUT_SECS
+)
 
 reconnecting = False
 shutting_down = False
@@ -3398,7 +3401,7 @@ def _get_portnum_name(portnum: Any) -> str:
 
     if isinstance(portnum, int) and not isinstance(portnum, bool):
         try:
-            return portnums_pb2.PortNum.Name(portnum)  # type: ignore[no-any-return]
+            return portnums_pb2.PortNum.Name(portnum)  # type: ignore[arg-type]
         except ValueError:
             return f"UNKNOWN (portnum={portnum})"
 
@@ -3644,7 +3647,24 @@ def connect_meshtastic(
     to finish, then retry acquisition.
     """
     global _connect_attempt_in_progress
-    wait_deadline = time.monotonic() + _CONNECT_ATTEMPT_WAIT_MAX_SECS
+
+    wait_budget_secs = _CONNECT_ATTEMPT_WAIT_MAX_SECS
+    config_source = (
+        passed_config
+        if isinstance(passed_config, dict)
+        else config if isinstance(config, dict) else None
+    )
+    if isinstance(config_source, dict):
+        connection_type = config_source.get(CONFIG_SECTION_MESHTASTIC, {}).get(
+            CONFIG_KEY_CONNECTION_TYPE
+        )
+        if connection_type == CONNECTION_TYPE_BLE:
+            wait_budget_secs = max(
+                wait_budget_secs,
+                _CONNECT_ATTEMPT_BLE_WAIT_MAX_SECS,
+            )
+
+    wait_deadline = time.monotonic() + wait_budget_secs
 
     while True:
         with _connect_attempt_condition:
@@ -3844,6 +3864,7 @@ def _connect_meshtastic_impl(
         # Initialize before try block to avoid unbound variable errors
         ble_address: str | None = None
         supports_auto_reconnect = False
+        ble_connect_timeout_logged_for_attempt = False
         startup_drain_pending_for_this_connect = False
         startup_drain_armed_for_this_connect = False
         startup_drain_applied_for_this_connect = False
@@ -4231,6 +4252,7 @@ def _connect_meshtastic_impl(
                             else:
                                 # Use logger.exception so timeouts include stack context (TRY400),
                                 # but raise a short error and keep operator guidance in logs (TRY003).
+                                ble_connect_timeout_logged_for_attempt = True
                                 logger.exception(
                                     f"BLE connect() call timed out after {BLE_CONNECT_TIMEOUT_SECS} seconds for %s.",
                                     ble_address,
@@ -4565,6 +4587,20 @@ def _connect_meshtastic_impl(
             )
             if shutting_down:
                 break
+            if (
+                connection_type == CONNECTION_TYPE_BLE
+                and ble_address
+                and not ble_connect_timeout_logged_for_attempt
+                and str(e).startswith("BLE connect() timed out for ")
+            ):
+                logger.exception(
+                    f"BLE connect() call timed out after {BLE_CONNECT_TIMEOUT_SECS} seconds for %s.",
+                    ble_address,
+                )
+                logger.warning("This may indicate a BlueZ or adapter issue.")
+                logger.warning(
+                    f"BlueZ may be in a bad state. {BLE_TROUBLESHOOTING_GUIDANCE.format(ble_address=ble_address)}"
+                )
             attempts += 1
             if retry_limit == INFINITE_RETRIES:
                 timeout_attempts += 1

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -218,13 +218,17 @@ meshtastic_iface_lock = (
 meshtastic_sub_lock = threading.Lock()
 subscribed_to_messages = False
 subscribed_to_connection_lost = False
+# Guard for brief in-flight callback windows during explicit unsubscribe.
+_callbacks_tearing_down = False
 
 
 def ensure_meshtastic_callbacks_subscribed() -> None:
     """Ensure Meshtastic pubsub callbacks are subscribed exactly once."""
+    global _callbacks_tearing_down
     global subscribed_to_messages, subscribed_to_connection_lost
 
     with meshtastic_sub_lock:
+        _callbacks_tearing_down = False
         if not subscribed_to_messages:
             pub.subscribe(on_meshtastic_message, "meshtastic.receive")
             subscribed_to_messages = True
@@ -238,9 +242,11 @@ def ensure_meshtastic_callbacks_subscribed() -> None:
 
 def unsubscribe_meshtastic_callbacks() -> None:
     """Best-effort unsubscribe for Meshtastic pubsub callbacks."""
+    global _callbacks_tearing_down
     global subscribed_to_messages, subscribed_to_connection_lost
 
     with meshtastic_sub_lock:
+        _callbacks_tearing_down = True
         if subscribed_to_messages:
             try:
                 pub.unsubscribe(on_meshtastic_message, "meshtastic.receive")
@@ -4193,8 +4199,8 @@ def _connect_meshtastic_impl(
                             )
                             logger.info(f"BLE connection established to {ble_address}")
                             reset_executor_degraded_state(ble_address=ble_address)
-                        except TimeoutError:
-                            if shutting_down:
+                        except TimeoutError as err:
+                            if shutting_down or str(err) == "Shutdown in progress":
                                 logger.debug(
                                     "BLE connect() interrupted by shutdown for %s",
                                     ble_address,
@@ -4209,50 +4215,52 @@ def _connect_meshtastic_impl(
                                     )
                                 iface = None
                                 meshtastic_iface = None
-                            raise
-                        except FuturesTimeoutError as err:
-                            # Use logger.exception so timeouts include stack context (TRY400),
-                            # but raise a short error and keep operator guidance in logs (TRY003).
-                            logger.exception(
-                                f"BLE connect() call timed out after {BLE_CONNECT_TIMEOUT_SECS} seconds for %s.",
-                                ble_address,
-                            )
-                            logger.warning(
-                                "This may indicate a BlueZ or adapter issue."
-                            )
-                            logger.warning(
-                                f"BlueZ may be in a bad state. {BLE_TROUBLESHOOTING_GUIDANCE.format(ble_address=ble_address)}"
-                            )
-                            # Best-effort cancellation: a hung BLE connect blocks the worker
-                            # thread, so we cancel to allow retries only if it completes.
-                            if connect_future.cancel():
-                                _clear_ble_future(connect_future)
                             else:
-                                timed_out_iface = iface
-                                # Clear global/local references before attaching late
-                                # disposer so late completions cannot observe stale active
-                                # globals and skip cleanup.
+                                # Use logger.exception so timeouts include stack context (TRY400),
+                                # but raise a short error and keep operator guidance in logs (TRY003).
+                                logger.exception(
+                                    f"BLE connect() call timed out after {BLE_CONNECT_TIMEOUT_SECS} seconds for %s.",
+                                    ble_address,
+                                )
+                                logger.warning(
+                                    "This may indicate a BlueZ or adapter issue."
+                                )
+                                logger.warning(
+                                    f"BlueZ may be in a bad state. {BLE_TROUBLESHOOTING_GUIDANCE.format(ble_address=ble_address)}"
+                                )
+                                # Best-effort cancellation: a hung BLE connect blocks the worker
+                                # thread, so we cancel to allow retries only if it completes.
+                                if connect_future.cancel():
+                                    _clear_ble_future(connect_future)
+                                else:
+                                    timed_out_iface = iface
+                                    # Clear global/local references before attaching late
+                                    # disposer so late completions cannot observe stale active
+                                    # globals and skip cleanup.
+                                    iface = None
+                                    meshtastic_iface = None
+                                    _schedule_ble_future_cleanup(
+                                        connect_future,
+                                        ble_address,
+                                        reason="connect timeout",
+                                    )
+                                    _attach_late_ble_interface_disposer(
+                                        connect_future,
+                                        ble_address,
+                                        reason="connect timeout",
+                                        fallback_iface=timed_out_iface,
+                                    )
+                                    timeout_count = _record_ble_timeout(ble_address)
+                                    _maybe_reset_ble_executor(
+                                        ble_address, timeout_count
+                                    )
+                                # Don't use iface if connect() timed out - it may be in an inconsistent state
                                 iface = None
                                 meshtastic_iface = None
-                                _schedule_ble_future_cleanup(
-                                    connect_future,
-                                    ble_address,
-                                    reason="connect timeout",
-                                )
-                                _attach_late_ble_interface_disposer(
-                                    connect_future,
-                                    ble_address,
-                                    reason="connect timeout",
-                                    fallback_iface=timed_out_iface,
-                                )
-                                timeout_count = _record_ble_timeout(ble_address)
-                                _maybe_reset_ble_executor(ble_address, timeout_count)
-                            # Don't use iface if connect() timed out - it may be in an inconsistent state
-                            iface = None
-                            meshtastic_iface = None
-                            raise TimeoutError(
-                                f"BLE connect() timed out for {ble_address}."
-                            ) from err
+                                raise TimeoutError(
+                                    f"BLE connect() timed out for {ble_address}."
+                                ) from err
+                            raise
                     elif iface is not None and hasattr(iface, "connect"):
                         logger.debug(
                             "Skipping explicit BLE connect in compatibility mode; "
@@ -4659,7 +4667,12 @@ def on_lost_meshtastic_connection(
         if (
             interface is not None
             and active_client is None
-            and subscribed_to_connection_lost
+            and (
+                _callbacks_tearing_down
+                or subscribed_to_connection_lost
+                or reconnecting
+                or shutting_down
+            )
         ):
             logger.debug(
                 "Ignoring connection-lost event because no Meshtastic interface is currently active"
@@ -4796,7 +4809,7 @@ async def reconnect() -> None:
 
     Retries connect_meshtastic(force_connect=True) until a connection is obtained, the application begins shutting down, or the task is cancelled. Starts with DEFAULT_BACKOFF_TIME and doubles the wait after each failed attempt, capped at 300 seconds. Stops promptly on cancellation or when shutting_down is set, and ensures the module-level `reconnecting` flag is cleared before returning.
     """
-    global meshtastic_client, reconnecting, shutting_down, reconnect_task_future
+    global reconnecting, shutting_down, reconnect_task_future
     backoff_time = DEFAULT_BACKOFF_TIME
     try:
         while not shutting_down:
@@ -4849,7 +4862,6 @@ async def reconnect() -> None:
                 reconnect_task_future = connect_future
                 connected_client = await connect_future
                 if connected_client is not None:
-                    meshtastic_client = connected_client
                     logger.info("Reconnected successfully.")
                     break
             except Exception:
@@ -4907,7 +4919,12 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
         #
         # Keep direct unit-level handler invocation behavior unchanged when no
         # active session is being transitioned.
-        if subscribed_to_messages or reconnecting or shutting_down:
+        if (
+            _callbacks_tearing_down
+            or subscribed_to_messages
+            or reconnecting
+            or shutting_down
+        ):
             logger.debug(
                 "Ignoring packet because no Meshtastic interface is currently active"
             )

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -1059,6 +1059,7 @@ async def refresh_node_name_tables(
             interval = parsed
 
     previous_state: NodeNameState | None = None
+    client_unavailable_reason: str | None = None
     while not shutdown_event.is_set():
         try:
             nodes_snapshot, client_missing = await asyncio.to_thread(
@@ -1067,14 +1068,27 @@ async def refresh_node_name_tables(
 
             if nodes_snapshot is None:
                 if client_missing:
-                    logger.debug(
-                        "Skipping name-cache refresh from NodeDB because Meshtastic client is unavailable"
-                    )
+                    if reconnecting:
+                        next_reason = "reconnecting"
+                        if client_unavailable_reason != next_reason:
+                            logger.debug(
+                                "Skipping name-cache refresh from NodeDB while reconnection is in progress"
+                            )
+                        client_unavailable_reason = next_reason
+                    else:
+                        next_reason = "unavailable"
+                        if client_unavailable_reason != next_reason:
+                            logger.debug(
+                                "Skipping name-cache refresh from NodeDB because Meshtastic client is unavailable"
+                            )
+                        client_unavailable_reason = next_reason
                 else:
+                    client_unavailable_reason = None
                     logger.debug(
                         "Skipping name-cache refresh from NodeDB because client.nodes is unavailable"
                     )
             else:
+                client_unavailable_reason = None
                 previous_state = await asyncio.to_thread(
                     sync_name_tables_if_changed,
                     nodes_snapshot,
@@ -2315,6 +2329,36 @@ def _wait_for_result(
     finally:
         new_loop.close()
         asyncio.set_event_loop(None)
+
+
+def _wait_for_future_result_with_shutdown(
+    result_future: Future[Any],
+    *,
+    timeout_seconds: float,
+    poll_seconds: float = 1.0,
+) -> Any:
+    """Wait for a concurrent future while remaining responsive to shutdown.
+
+    Polls `result_future.result()` in short intervals so long BLE operations can
+    abort quickly when `shutting_down` is set, instead of waiting the full
+    timeout budget in one blocking call.
+    """
+
+    deadline = time.monotonic() + float(timeout_seconds)
+    poll_budget = max(0.05, float(poll_seconds))
+
+    while True:
+        if shutting_down:
+            raise TimeoutError("Shutdown in progress")
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise FuturesTimeoutError()
+
+        try:
+            return result_future.result(timeout=min(remaining, poll_budget))
+        except FuturesTimeoutError:
+            continue
 
 
 def _resolve_plugin_timeout(
@@ -3974,8 +4018,11 @@ def _connect_meshtastic_impl(
                                     _ble_future_timeout_secs = create_timeout_secs
                                 future.add_done_callback(_clear_ble_future)
                                 try:
-                                    meshtastic_iface = future.result(
-                                        timeout=create_timeout_secs
+                                    meshtastic_iface = (
+                                        _wait_for_future_result_with_shutdown(
+                                            future,
+                                            timeout_seconds=create_timeout_secs,
+                                        )
                                     )
                                     if meshtastic_iface is None:
                                         _clear_ble_future(future)
@@ -4140,9 +4187,29 @@ def _connect_meshtastic_impl(
                             _ble_future_timeout_secs = BLE_CONNECT_TIMEOUT_SECS
                         connect_future.add_done_callback(_clear_ble_future)
                         try:
-                            connect_future.result(timeout=BLE_CONNECT_TIMEOUT_SECS)
+                            _wait_for_future_result_with_shutdown(
+                                connect_future,
+                                timeout_seconds=BLE_CONNECT_TIMEOUT_SECS,
+                            )
                             logger.info(f"BLE connection established to {ble_address}")
                             reset_executor_degraded_state(ble_address=ble_address)
+                        except TimeoutError:
+                            if shutting_down:
+                                logger.debug(
+                                    "BLE connect() interrupted by shutdown for %s",
+                                    ble_address,
+                                )
+                                if connect_future.cancel():
+                                    _clear_ble_future(connect_future)
+                                else:
+                                    _schedule_ble_future_cleanup(
+                                        connect_future,
+                                        ble_address,
+                                        reason="connect shutdown cancellation",
+                                    )
+                                iface = None
+                                meshtastic_iface = None
+                            raise
                         except FuturesTimeoutError as err:
                             # Use logger.exception so timeouts include stack context (TRY400),
                             # but raise a short error and keep operator guidance in logs (TRY003).

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -3655,14 +3655,14 @@ def connect_meshtastic(
         else config if isinstance(config, dict) else None
     )
     if isinstance(config_source, dict):
-        connection_type = config_source.get(CONFIG_SECTION_MESHTASTIC, {}).get(
-            CONFIG_KEY_CONNECTION_TYPE
-        )
-        if connection_type == CONNECTION_TYPE_BLE:
-            wait_budget_secs = max(
-                wait_budget_secs,
-                _CONNECT_ATTEMPT_BLE_WAIT_MAX_SECS,
-            )
+        meshtastic_section = config_source.get(CONFIG_SECTION_MESHTASTIC)
+        if isinstance(meshtastic_section, dict):
+            connection_type = meshtastic_section.get(CONFIG_KEY_CONNECTION_TYPE)
+            if connection_type == CONNECTION_TYPE_BLE:
+                wait_budget_secs = max(
+                    wait_budget_secs,
+                    _CONNECT_ATTEMPT_BLE_WAIT_MAX_SECS,
+                )
 
     wait_deadline = time.monotonic() + wait_budget_secs
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -202,6 +202,7 @@ _connect_attempt_lock = threading.RLock()
 _connect_attempt_condition = threading.Condition(_connect_attempt_lock)
 _connect_attempt_in_progress = False
 _CONNECT_ATTEMPT_WAIT_POLL_SECS = 1.0
+_CONNECT_ATTEMPT_WAIT_MAX_SECS = 5.0
 
 reconnecting = False
 shutting_down = False
@@ -213,6 +214,7 @@ meshtastic_iface_lock = (
 )  # To prevent race conditions on BLE interface singleton creation
 
 # Subscription flags to prevent duplicate subscriptions
+meshtastic_sub_lock = threading.Lock()
 subscribed_to_messages = False
 subscribed_to_connection_lost = False
 
@@ -221,35 +223,37 @@ def ensure_meshtastic_callbacks_subscribed() -> None:
     """Ensure Meshtastic pubsub callbacks are subscribed exactly once."""
     global subscribed_to_messages, subscribed_to_connection_lost
 
-    if not subscribed_to_messages:
-        pub.subscribe(on_meshtastic_message, "meshtastic.receive")
-        subscribed_to_messages = True
-        logger.debug("Subscribed to meshtastic.receive")
+    with meshtastic_sub_lock:
+        if not subscribed_to_messages:
+            pub.subscribe(on_meshtastic_message, "meshtastic.receive")
+            subscribed_to_messages = True
+            logger.debug("Subscribed to meshtastic.receive")
 
-    if not subscribed_to_connection_lost:
-        pub.subscribe(on_lost_meshtastic_connection, "meshtastic.connection.lost")
-        subscribed_to_connection_lost = True
-        logger.debug("Subscribed to meshtastic.connection.lost")
+        if not subscribed_to_connection_lost:
+            pub.subscribe(on_lost_meshtastic_connection, "meshtastic.connection.lost")
+            subscribed_to_connection_lost = True
+            logger.debug("Subscribed to meshtastic.connection.lost")
 
 
 def unsubscribe_meshtastic_callbacks() -> None:
     """Best-effort unsubscribe for Meshtastic pubsub callbacks."""
     global subscribed_to_messages, subscribed_to_connection_lost
 
-    if subscribed_to_messages:
-        with contextlib.suppress(Exception):
-            pub.unsubscribe(on_meshtastic_message, "meshtastic.receive")
-        subscribed_to_messages = False
-        logger.debug("Unsubscribed from meshtastic.receive")
+    with meshtastic_sub_lock:
+        if subscribed_to_messages:
+            with contextlib.suppress(Exception):
+                pub.unsubscribe(on_meshtastic_message, "meshtastic.receive")
+            subscribed_to_messages = False
+            logger.debug("Unsubscribed from meshtastic.receive")
 
-    if subscribed_to_connection_lost:
-        with contextlib.suppress(Exception):
-            pub.unsubscribe(
-                on_lost_meshtastic_connection,
-                "meshtastic.connection.lost",
-            )
-        subscribed_to_connection_lost = False
-        logger.debug("Unsubscribed from meshtastic.connection.lost")
+        if subscribed_to_connection_lost:
+            with contextlib.suppress(Exception):
+                pub.unsubscribe(
+                    on_lost_meshtastic_connection,
+                    "meshtastic.connection.lost",
+                )
+            subscribed_to_connection_lost = False
+            logger.debug("Unsubscribed from meshtastic.connection.lost")
 
 
 # Shared executor for getMetadata() to avoid leaking threads when metadata calls hang.
@@ -3554,6 +3558,7 @@ def connect_meshtastic(
     to finish, then retry acquisition.
     """
     global _connect_attempt_in_progress
+    wait_deadline = time.monotonic() + _CONNECT_ATTEMPT_WAIT_MAX_SECS
 
     while True:
         with _connect_attempt_condition:
@@ -3561,14 +3566,31 @@ def connect_meshtastic(
                 _connect_attempt_in_progress = True
                 break
 
+            remaining_wait = wait_deadline - time.monotonic()
+            if remaining_wait <= 0:
+                logger.debug(
+                    "Timed out waiting for active connect attempt; returning current client state"
+                )
+                return meshtastic_client
+
             logger.debug(
                 "connect_meshtastic() already in progress; waiting for active attempt to finish"
             )
             while _connect_attempt_in_progress and not shutting_down:
-                _connect_attempt_condition.wait(timeout=_CONNECT_ATTEMPT_WAIT_POLL_SECS)
+                remaining_wait = wait_deadline - time.monotonic()
+                if remaining_wait <= 0:
+                    break
+                _connect_attempt_condition.wait(
+                    timeout=min(_CONNECT_ATTEMPT_WAIT_POLL_SECS, remaining_wait)
+                )
             if shutting_down:
                 logger.debug("Shutdown in progress. Not attempting to connect.")
                 return None
+            if _connect_attempt_in_progress and time.monotonic() >= wait_deadline:
+                logger.debug(
+                    "Timed out waiting for active connect attempt; returning current client state"
+                )
+                return meshtastic_client
 
     try:
         return _connect_meshtastic_impl(
@@ -4276,6 +4298,32 @@ def _connect_meshtastic_impl(
 
                 # Publish the active client only after per-connection timing state
                 # has been reset, so callbacks cannot observe stale skew windows.
+                if shutting_down:
+                    logger.debug(
+                        "Shutdown started during connect setup; closing new client before publish"
+                    )
+                    try:
+                        if client is meshtastic_iface:
+                            _disconnect_ble_interface(
+                                meshtastic_iface,
+                                reason="connect setup cancelled by shutdown",
+                            )
+                            meshtastic_iface = None
+                        else:
+                            client.close()
+                    except Exception as cleanup_error:  # noqa: BLE001 - best effort
+                        logger.warning(
+                            "Error closing Meshtastic client during shutdown race: %s",
+                            cleanup_error,
+                        )
+                    with _relay_rx_time_clock_skew_lock:
+                        if reconnect_bootstrap_armed_for_this_connect:
+                            _relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = (
+                                None
+                            )
+                    successful = False
+                    return None
+
                 meshtastic_client = client
                 _relay_active_client_id = id(client)
                 client_assigned_for_this_connect = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -960,6 +960,7 @@ def reset_meshtastic_globals():
         "subscribed_to_connection_lost": getattr(
             mu, "subscribed_to_connection_lost", False
         ),
+        "_callbacks_tearing_down": getattr(mu, "_callbacks_tearing_down", False),
         "_metadata_future": getattr(mu, "_metadata_future", None),
         "_metadata_future_started_at": getattr(mu, "_metadata_future_started_at", None),
         "_ble_future": getattr(mu, "_ble_future", None),
@@ -1024,6 +1025,7 @@ def reset_meshtastic_globals():
     mu.reconnect_task_future = None
     mu.subscribed_to_messages = False
     mu.subscribed_to_connection_lost = False
+    mu._callbacks_tearing_down = False
     mu._metadata_future = None
     mu._metadata_future_started_at = None
     cleanup_ble_future_state(mu)
@@ -1120,6 +1122,7 @@ def reset_meshtastic_globals():
                 )
         mu.subscribed_to_messages = False
         mu.subscribed_to_connection_lost = False
+        mu._callbacks_tearing_down = False
         cleanup_ble_future_state(mu)
         mu.shutdown_shared_executors()
         mu.meshtastic_iface = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1022,13 +1022,7 @@ def reset_meshtastic_globals():
     mu.shutting_down = False
     mu.reconnect_task = None
     mu.reconnect_task_future = None
-    connect_condition = getattr(mu, "_connect_attempt_condition", None)
-    if connect_condition is not None:
-        with connect_condition:
-            mu._connect_attempt_in_progress = False
-            connect_condition.notify_all()
-    else:
-        mu._connect_attempt_in_progress = False
+    mu._connect_attempt_in_progress = False
     mu.subscribed_to_messages = False
     mu.subscribed_to_connection_lost = False
     mu._metadata_future = None
@@ -1072,6 +1066,11 @@ def reset_meshtastic_globals():
     mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = None
     mu._startup_packet_drain_applied = False
     mu._health_probe_request_deadlines = {}
+    connect_condition = getattr(mu, "_connect_attempt_condition", None)
+    if connect_condition is not None:
+        with connect_condition:
+            mu._connect_attempt_in_progress = False
+            connect_condition.notify_all()
 
     yield
     try:
@@ -1110,13 +1109,7 @@ def reset_meshtastic_globals():
         )
         mu.reconnect_task = None
         mu.reconnect_task_future = None
-        connect_condition = getattr(mu, "_connect_attempt_condition", None)
-        if connect_condition is not None:
-            with connect_condition:
-                mu._connect_attempt_in_progress = False
-                connect_condition.notify_all()
-        else:
-            mu._connect_attempt_in_progress = False
+        mu._connect_attempt_in_progress = False
         mu._metadata_future = None
         mu._metadata_future_started_at = None
         if mu.subscribed_to_messages:
@@ -1133,6 +1126,11 @@ def reset_meshtastic_globals():
         mu.shutdown_shared_executors()
         mu.meshtastic_iface = None
         mu.meshtastic_client = None
+        connect_condition = getattr(mu, "_connect_attempt_condition", None)
+        if connect_condition is not None:
+            with connect_condition:
+                mu._connect_attempt_in_progress = False
+                connect_condition.notify_all()
     finally:
         for attr_name, original_value in original_values.items():
             setattr(mu, attr_name, original_value)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -951,6 +951,8 @@ def reset_meshtastic_globals():
         "shutting_down": getattr(mu, "shutting_down", False),
         "reconnect_task": getattr(mu, "reconnect_task", None),
         "reconnect_task_future": getattr(mu, "reconnect_task_future", None),
+        "_connect_attempt_lock": getattr(mu, "_connect_attempt_lock", None),
+        "_connect_attempt_condition": getattr(mu, "_connect_attempt_condition", None),
         "_connect_attempt_in_progress": getattr(
             mu, "_connect_attempt_in_progress", False
         ),
@@ -1020,7 +1022,13 @@ def reset_meshtastic_globals():
     mu.shutting_down = False
     mu.reconnect_task = None
     mu.reconnect_task_future = None
-    mu._connect_attempt_in_progress = False
+    connect_condition = getattr(mu, "_connect_attempt_condition", None)
+    if connect_condition is not None:
+        with connect_condition:
+            mu._connect_attempt_in_progress = False
+            connect_condition.notify_all()
+    else:
+        mu._connect_attempt_in_progress = False
     mu.subscribed_to_messages = False
     mu.subscribed_to_connection_lost = False
     mu._metadata_future = None
@@ -1102,7 +1110,13 @@ def reset_meshtastic_globals():
         )
         mu.reconnect_task = None
         mu.reconnect_task_future = None
-        mu._connect_attempt_in_progress = False
+        connect_condition = getattr(mu, "_connect_attempt_condition", None)
+        if connect_condition is not None:
+            with connect_condition:
+                mu._connect_attempt_in_progress = False
+                connect_condition.notify_all()
+        else:
+            mu._connect_attempt_in_progress = False
         mu._metadata_future = None
         mu._metadata_future_started_at = None
         if mu.subscribed_to_messages:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -950,6 +950,10 @@ def reset_meshtastic_globals():
         "reconnecting": getattr(mu, "reconnecting", False),
         "shutting_down": getattr(mu, "shutting_down", False),
         "reconnect_task": getattr(mu, "reconnect_task", None),
+        "reconnect_task_future": getattr(mu, "reconnect_task_future", None),
+        "_connect_attempt_in_progress": getattr(
+            mu, "_connect_attempt_in_progress", False
+        ),
         "subscribed_to_messages": getattr(mu, "subscribed_to_messages", False),
         "subscribed_to_connection_lost": getattr(
             mu, "subscribed_to_connection_lost", False
@@ -1015,6 +1019,8 @@ def reset_meshtastic_globals():
     mu.reconnecting = False
     mu.shutting_down = False
     mu.reconnect_task = None
+    mu.reconnect_task_future = None
+    mu._connect_attempt_in_progress = False
     mu.subscribed_to_messages = False
     mu.subscribed_to_connection_lost = False
     mu._metadata_future = None
@@ -1089,9 +1095,14 @@ def reset_meshtastic_globals():
 
         _cancel_and_drain_future_like(getattr(mu, "reconnect_task", None), timeout=0.2)
         _cancel_and_drain_future_like(
+            getattr(mu, "reconnect_task_future", None), timeout=0.2
+        )
+        _cancel_and_drain_future_like(
             getattr(mu, "_metadata_future", None), timeout=0.2
         )
         mu.reconnect_task = None
+        mu.reconnect_task_future = None
+        mu._connect_attempt_in_progress = False
         mu._metadata_future = None
         mu._metadata_future_started_at = None
         if mu.subscribed_to_messages:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1022,7 +1022,6 @@ def reset_meshtastic_globals():
     mu.shutting_down = False
     mu.reconnect_task = None
     mu.reconnect_task_future = None
-    mu._connect_attempt_in_progress = False
     mu.subscribed_to_messages = False
     mu.subscribed_to_connection_lost = False
     mu._metadata_future = None
@@ -1109,7 +1108,6 @@ def reset_meshtastic_globals():
         )
         mu.reconnect_task = None
         mu.reconnect_task_future = None
-        mu._connect_attempt_in_progress = False
         mu._metadata_future = None
         mu._metadata_future_started_at = None
         if mu.subscribed_to_messages:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -164,6 +164,14 @@ def reset_meshtastic_utils_globals(*, shutdown_executors: bool = False) -> None:
             with contextlib.suppress(Exception):
                 task.cancel()
         module.reconnect_task = None  # type: ignore[attr-defined]
+    if hasattr(module, "reconnect_task_future"):
+        future = module.reconnect_task_future  # type: ignore[attr-defined]
+        if future is not None and hasattr(future, "cancel"):
+            with contextlib.suppress(Exception):
+                future.cancel()
+        module.reconnect_task_future = None  # type: ignore[attr-defined]
+    if hasattr(module, "_connect_attempt_in_progress"):
+        module._connect_attempt_in_progress = False  # type: ignore[attr-defined]
     if hasattr(module, "subscribed_to_messages"):
         if module.subscribed_to_messages:  # type: ignore[attr-defined]
             with contextlib.suppress(Exception):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -170,7 +170,12 @@ def reset_meshtastic_utils_globals(*, shutdown_executors: bool = False) -> None:
             with contextlib.suppress(Exception):
                 future.cancel()
         module.reconnect_task_future = None  # type: ignore[attr-defined]
-    if hasattr(module, "_connect_attempt_in_progress"):
+    if hasattr(module, "_connect_attempt_condition"):
+        condition = module._connect_attempt_condition  # type: ignore[attr-defined]
+        with condition:
+            module._connect_attempt_in_progress = False  # type: ignore[attr-defined]
+            condition.notify_all()
+    elif hasattr(module, "_connect_attempt_in_progress"):
         module._connect_attempt_in_progress = False  # type: ignore[attr-defined]
     if hasattr(module, "subscribed_to_messages"):
         if module.subscribed_to_messages:  # type: ignore[attr-defined]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -917,6 +917,76 @@ class TestMain(unittest.TestCase):
 
         self.assertIsNone(mu.meshtastic_iface)
 
+    def test_main_shutdown_cancels_reconnect_before_ble_disconnect_and_unsubscribes(
+        self,
+    ):
+        """Shutdown should cancel reconnect before BLE disconnect and unsubscribe callbacks."""
+
+        import mmrelay.meshtastic_utils as mu
+
+        mock_iface = MagicMock()
+        reconnect_task = MagicMock()
+        mu.reconnect_task = reconnect_task
+
+        def _connect_meshtastic(*_args: Any, **_kwargs: Any) -> Any:
+            mu.meshtastic_iface = mock_iface
+            return mock_iface
+
+        mock_matrix_client = MagicMock()
+        mock_matrix_client.close = AsyncMock()
+
+        def _assert_disconnect_after_cancel(iface: Any, reason: str = "") -> None:
+            assert iface is mock_iface
+            assert reason == "shutdown"
+            assert reconnect_task.cancel.called
+
+        try:
+            with (
+                patch("mmrelay.main.initialize_database"),
+                patch("mmrelay.main.load_plugins"),
+                patch("mmrelay.main.start_message_queue"),
+                patch(
+                    "mmrelay.main.connect_meshtastic",
+                    side_effect=_connect_meshtastic,
+                ),
+                patch(
+                    "mmrelay.main.connect_matrix",
+                    side_effect=_make_async_return(mock_matrix_client),
+                ),
+                patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
+                patch("mmrelay.main.shutdown_plugins"),
+                patch("mmrelay.main.stop_message_queue"),
+                patch("mmrelay.main.get_message_queue") as mock_get_queue,
+                patch(
+                    "mmrelay.main.meshtastic_utils._disconnect_ble_interface",
+                    side_effect=_assert_disconnect_after_cancel,
+                ) as mock_disconnect_iface,
+                patch(
+                    "mmrelay.main.meshtastic_utils.unsubscribe_meshtastic_callbacks",
+                    create=True,
+                ) as mock_unsubscribe_callbacks,
+                patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
+                patch(
+                    "mmrelay.main.asyncio.get_running_loop",
+                    side_effect=_make_patched_get_running_loop(),
+                ),
+                patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+                patch(
+                    "mmrelay.main.meshtastic_utils.check_connection", new=_async_noop
+                ),
+            ):
+                mock_queue = MagicMock()
+                mock_queue.ensure_processor_started = MagicMock()
+                mock_get_queue.return_value = mock_queue
+
+                asyncio.run(main(self.mock_config))
+
+            reconnect_task.cancel.assert_called_once()
+            mock_disconnect_iface.assert_called_once_with(mock_iface, reason="shutdown")
+            mock_unsubscribe_callbacks.assert_called_once()
+        finally:
+            mu.reconnect_task = None
+
     @patch("mmrelay.main.initialize_database")
     @patch("mmrelay.main.load_plugins")
     @patch("mmrelay.main.start_message_queue")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -963,7 +963,6 @@ class TestMain(unittest.TestCase):
                 ) as mock_disconnect_iface,
                 patch(
                     "mmrelay.main.meshtastic_utils.unsubscribe_meshtastic_callbacks",
-                    create=True,
                 ) as mock_unsubscribe_callbacks,
                 patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
                 patch(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -924,6 +924,8 @@ class TestMain(unittest.TestCase):
 
         import mmrelay.meshtastic_utils as mu
 
+        _reset_all_mmrelay_globals()
+
         mock_iface = MagicMock()
         reconnect_task = MagicMock()
         mu.reconnect_task = reconnect_task
@@ -984,7 +986,7 @@ class TestMain(unittest.TestCase):
             mock_disconnect_iface.assert_called_once_with(mock_iface, reason="shutdown")
             mock_unsubscribe_callbacks.assert_called_once()
         finally:
-            mu.reconnect_task = None
+            _reset_all_mmrelay_globals()
 
     @patch("mmrelay.main.initialize_database")
     @patch("mmrelay.main.load_plugins")
@@ -2987,6 +2989,59 @@ class TestStartupRollback(unittest.TestCase):
                 asyncio.run(main(config))
 
             mock_stop_queue.assert_called_once()
+
+    @patch("mmrelay.main.initialize_database")
+    @patch("mmrelay.main.load_plugins")
+    @patch("mmrelay.main.start_message_queue")
+    @patch("mmrelay.main.connect_matrix")
+    @patch("mmrelay.main.connect_meshtastic")
+    @patch("mmrelay.main._remove_ready_file")
+    @patch("mmrelay.main.shutdown_plugins")
+    @patch("mmrelay.main.stop_message_queue")
+    def test_startup_rollback_cleans_reconnect_state_and_callbacks(
+        self,
+        mock_stop_queue,
+        mock_shutdown_plugins,
+        mock_remove_ready,
+        mock_connect_meshtastic,
+        mock_connect_matrix,
+        mock_start_queue,
+        mock_load_plugins,
+        mock_init_db,
+    ):
+        """Startup rollback should cancel reconnect work and unsubscribe callbacks."""
+
+        mock_connect_meshtastic.return_value = MagicMock()
+        mock_connect_matrix.side_effect = RuntimeError("After meshtastic client error")
+
+        import mmrelay.meshtastic_utils as mu
+
+        reconnect_task = MagicMock()
+        reconnect_future = MagicMock()
+        mu.reconnect_task = reconnect_task
+        mu.reconnect_task_future = reconnect_future
+
+        config = {"matrix_rooms": [{"id": "!room:matrix.org"}]}
+
+        with (
+            patch(
+                "mmrelay.main.asyncio.get_running_loop",
+                side_effect=_make_patched_get_running_loop(),
+            ),
+            patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+            patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
+            patch("mmrelay.main.meshtastic_utils.check_connection", new=_async_noop),
+            patch(
+                "mmrelay.main.meshtastic_utils.unsubscribe_meshtastic_callbacks"
+            ) as mock_unsubscribe,
+            patch("mmrelay.main.logger"),
+        ):
+            with self.assertRaises(RuntimeError):
+                asyncio.run(main(config))
+
+        reconnect_task.cancel.assert_called_once()
+        reconnect_future.cancel.assert_called_once()
+        mock_unsubscribe.assert_called_once()
 
     @patch("mmrelay.main.initialize_database")
     @patch("mmrelay.main.load_plugins")

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Test suite for uncovered code paths in main.py shutdown logic.
+
+Covers:
+- _await_background_task_shutdown error paths (lines 898-922)
+- Shutdown with reconnect_task_future set (lines 1115-1121)
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mmrelay.constants.network import CONNECTION_TYPE_SERIAL
+from mmrelay.main import main
+from tests.constants import (
+    TEST_BOT_USER_ID,
+    TEST_MATRIX_HOMESERVER,
+    TEST_ROOM_ID_1,
+    TEST_ROOM_ID_2,
+)
+from tests.helpers import (
+    inline_to_thread,
+    make_patched_get_running_loop,
+    reset_meshtastic_utils_globals,
+)
+
+_make_patched_get_running_loop = make_patched_get_running_loop
+
+
+def _make_async_return(value):
+    async def _async_return(*_args, **_kwargs):
+        return value
+
+    return _async_return
+
+
+async def _async_noop(*_args, **_kwargs) -> None:
+    return None
+
+
+class _ImmediateEvent:
+    def __init__(self) -> None:
+        self._set = True
+
+    def is_set(self) -> bool:
+        return self._set
+
+    def set(self) -> None:
+        self._set = True
+
+    async def wait(self) -> None:
+        return None
+
+
+def _reset_all_mmrelay_globals() -> None:
+    import contextlib
+    import sys
+
+    reset_meshtastic_utils_globals(shutdown_executors=True)
+
+    if "mmrelay.matrix_utils" in sys.modules:
+        module = sys.modules["mmrelay.matrix_utils"]
+        module.config = None
+        module.matrix_homeserver = None
+        module.matrix_rooms = None
+        module.matrix_access_token = None
+        module.bot_user_id = None
+        module.bot_user_name = None
+        module.matrix_client = None
+        import time
+
+        module.bot_start_time = int(time.time() * 1000)
+
+    if "mmrelay.main" in sys.modules:
+        module = sys.modules["mmrelay.main"]
+        module._banner_printed = False
+        module._ready_file_path = None
+        module._ready_heartbeat_seconds = 30
+
+    if "mmrelay.plugin_loader" in sys.modules:
+        module = sys.modules["mmrelay.plugin_loader"]
+        if hasattr(module, "_reset_caches_for_tests"):
+            module._reset_caches_for_tests()
+
+    if "mmrelay.message_queue" in sys.modules:
+        from mmrelay.message_queue import get_message_queue
+
+        with contextlib.suppress(AttributeError, RuntimeError):
+            queue = get_message_queue()
+            if hasattr(queue, "stop"):
+                queue.stop()
+
+
+class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
+    def setUp(self):
+        self.mock_config = {
+            "matrix": {
+                "homeserver": TEST_MATRIX_HOMESERVER,
+                "access_token": "test_token",
+                "bot_user_id": TEST_BOT_USER_ID,
+            },
+            "matrix_rooms": [
+                {"id": TEST_ROOM_ID_1, "meshtastic_channel": 0},
+                {"id": TEST_ROOM_ID_2, "meshtastic_channel": 1},
+            ],
+            "meshtastic": {
+                "connection_type": CONNECTION_TYPE_SERIAL,
+                "serial_port": "/dev/ttyUSB0",
+                "message_delay": 2.0,
+            },
+            "database": {"msg_map": {"wipe_on_restart": False}},
+        }
+
+    def tearDown(self):
+        _reset_all_mmrelay_globals()
+
+    def test_await_background_task_shutdown_logs_error_on_runtime_error(self):
+        import mmrelay.meshtastic_utils as mu
+
+        original_client = mu.meshtastic_client
+        original_iface = mu.meshtastic_iface
+        original_shutting_down = mu.shutting_down
+        original_reconnecting = mu.reconnecting
+        original_reconnect_task = mu.reconnect_task
+        original_reconnect_task_future = mu.reconnect_task_future
+        try:
+            mu.reconnect_task = None
+            mu.reconnect_task_future = None
+
+            runtime_error = RuntimeError("background task exploded")
+
+            async def _check_connection_that_raises_after_delay(*_args, **_kwargs):
+                await asyncio.sleep(0.5)
+                raise runtime_error
+
+            with (
+                patch("mmrelay.main.initialize_database"),
+                patch("mmrelay.main.load_plugins"),
+                patch("mmrelay.main.start_message_queue"),
+                patch("mmrelay.main.connect_meshtastic", return_value=MagicMock()),
+                patch(
+                    "mmrelay.main.connect_matrix",
+                    side_effect=_make_async_return(MagicMock(close=AsyncMock())),
+                ),
+                patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
+                patch("mmrelay.main.shutdown_plugins"),
+                patch("mmrelay.main.stop_message_queue"),
+                patch("mmrelay.main.get_message_queue") as mock_get_queue,
+                patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
+                patch(
+                    "mmrelay.main.asyncio.get_running_loop",
+                    side_effect=_make_patched_get_running_loop(),
+                ),
+                patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+                patch(
+                    "mmrelay.main.meshtastic_utils.check_connection",
+                    side_effect=_check_connection_that_raises_after_delay,
+                ),
+                patch("mmrelay.main.logger") as mock_logger,
+                patch("mmrelay.main.meshtastic_logger"),
+            ):
+                mock_queue = MagicMock()
+                mock_queue.ensure_processor_started = MagicMock()
+                mock_get_queue.return_value = mock_queue
+
+                asyncio.run(main(self.mock_config))
+
+            error_calls = [str(c) for c in mock_logger.error.call_args_list]
+            assert any(
+                "Error while waiting for" in e and "connection health task" in e
+                for e in error_calls
+            ), f"Expected error log for RuntimeError during shutdown wait, got: {error_calls}"
+        finally:
+            mu.meshtastic_client = original_client
+            mu.meshtastic_iface = original_iface
+            mu.shutting_down = original_shutting_down
+            mu.reconnecting = original_reconnecting
+            mu.reconnect_task = original_reconnect_task
+            mu.reconnect_task_future = original_reconnect_task_future
+
+    def test_await_background_task_shutdown_timeout_on_cancel_gather(self):
+        import mmrelay.meshtastic_utils as mu
+
+        original_client = mu.meshtastic_client
+        original_iface = mu.meshtastic_iface
+        original_shutting_down = mu.shutting_down
+        original_reconnecting = mu.reconnecting
+        original_reconnect_task = mu.reconnect_task
+        original_reconnect_task_future = mu.reconnect_task_future
+        try:
+            mu.reconnect_task = None
+            mu.reconnect_task_future = None
+
+            async def _check_connection_that_ignores_cancel(*_args, **_kwargs):
+                try:
+                    while True:
+                        try:
+                            await asyncio.sleep(10)
+                        except asyncio.CancelledError:
+                            pass
+                except asyncio.CancelledError:
+                    pass
+
+            with (
+                patch("mmrelay.main.initialize_database"),
+                patch("mmrelay.main.load_plugins"),
+                patch("mmrelay.main.start_message_queue"),
+                patch("mmrelay.main.connect_meshtastic", return_value=MagicMock()),
+                patch(
+                    "mmrelay.main.connect_matrix",
+                    side_effect=_make_async_return(MagicMock(close=AsyncMock())),
+                ),
+                patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
+                patch("mmrelay.main.shutdown_plugins"),
+                patch("mmrelay.main.stop_message_queue"),
+                patch("mmrelay.main.get_message_queue") as mock_get_queue,
+                patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
+                patch(
+                    "mmrelay.main.asyncio.get_running_loop",
+                    side_effect=_make_patched_get_running_loop(),
+                ),
+                patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+                patch(
+                    "mmrelay.main.meshtastic_utils.check_connection",
+                    side_effect=_check_connection_that_ignores_cancel,
+                ),
+                patch("mmrelay.main.logger") as mock_logger,
+                patch("mmrelay.main.meshtastic_logger"),
+            ):
+                mock_queue = MagicMock()
+                mock_queue.ensure_processor_started = MagicMock()
+                mock_get_queue.return_value = mock_queue
+
+                asyncio.run(main(self.mock_config))
+
+            warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+            assert any(
+                "Timed out cancelling" in w for w in warning_calls
+            ), f"Expected warning log for timeout during cancel gather, got: {warning_calls}"
+        finally:
+            mu.meshtastic_client = original_client
+            mu.meshtastic_iface = original_iface
+            mu.shutting_down = original_shutting_down
+            mu.reconnecting = original_reconnecting
+            mu.reconnect_task = original_reconnect_task
+            mu.reconnect_task_future = original_reconnect_task_future
+
+
+class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
+    def setUp(self):
+        self.mock_config = {
+            "matrix": {
+                "homeserver": TEST_MATRIX_HOMESERVER,
+                "access_token": "test_token",
+                "bot_user_id": TEST_BOT_USER_ID,
+            },
+            "matrix_rooms": [
+                {"id": TEST_ROOM_ID_1, "meshtastic_channel": 0},
+                {"id": TEST_ROOM_ID_2, "meshtastic_channel": 1},
+            ],
+            "meshtastic": {
+                "connection_type": CONNECTION_TYPE_SERIAL,
+                "serial_port": "/dev/ttyUSB0",
+                "message_delay": 2.0,
+            },
+            "database": {"msg_map": {"wipe_on_restart": False}},
+        }
+
+    def tearDown(self):
+        _reset_all_mmrelay_globals()
+
+    def test_shutdown_cancels_and_awaits_reconnect_task_future(self):
+        import mmrelay.meshtastic_utils as mu
+
+        original_client = mu.meshtastic_client
+        original_iface = mu.meshtastic_iface
+        original_shutting_down = mu.shutting_down
+        original_reconnecting = mu.reconnecting
+        original_reconnect_task = mu.reconnect_task
+        original_reconnect_task_future = mu.reconnect_task_future
+        try:
+            mu.reconnect_task = None
+
+            captured_future = None
+
+            def _capture_reconnect_future(*_args, **_kwargs):
+                nonlocal captured_future
+
+                async def _fake_reconnect():
+                    try:
+                        await asyncio.sleep(300)
+                    except asyncio.CancelledError:
+                        pass
+
+                loop = asyncio.get_running_loop()
+                captured_future = loop.create_task(_fake_reconnect())
+                mu.reconnect_task_future = captured_future
+                mu.reconnect_task = captured_future
+                return None
+
+            with (
+                patch("mmrelay.main.initialize_database"),
+                patch("mmrelay.main.load_plugins"),
+                patch("mmrelay.main.start_message_queue"),
+                patch("mmrelay.main.connect_meshtastic", return_value=MagicMock()),
+                patch(
+                    "mmrelay.main.connect_matrix",
+                    side_effect=_make_async_return(MagicMock(close=AsyncMock())),
+                ),
+                patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
+                patch("mmrelay.main.shutdown_plugins"),
+                patch("mmrelay.main.stop_message_queue"),
+                patch("mmrelay.main.get_message_queue") as mock_get_queue,
+                patch("mmrelay.main.asyncio.Event", return_value=_ImmediateEvent()),
+                patch(
+                    "mmrelay.main.asyncio.get_running_loop",
+                    side_effect=_make_patched_get_running_loop(),
+                ),
+                patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+                patch(
+                    "mmrelay.main.meshtastic_utils.check_connection",
+                    side_effect=_capture_reconnect_future,
+                ),
+                patch("mmrelay.main.logger"),
+                patch("mmrelay.main.meshtastic_logger"),
+            ):
+                mock_queue = MagicMock()
+                mock_queue.ensure_processor_started = MagicMock()
+                mock_get_queue.return_value = mock_queue
+
+                asyncio.run(main(self.mock_config))
+
+            assert captured_future is not None
+            assert captured_future.cancelled()
+            assert mu.reconnect_task_future is None
+        finally:
+            mu.meshtastic_client = original_client
+            mu.meshtastic_iface = original_iface
+            mu.shutting_down = original_shutting_down
+            mu.reconnecting = original_reconnecting
+            mu.reconnect_task = original_reconnect_task
+            mu.reconnect_task_future = original_reconnect_task_future

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -294,15 +294,18 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
             mu.reconnect_task = None
 
             captured_future = None
+            cancel_observed = False
 
             def _capture_reconnect_future(*_args, **_kwargs):
                 nonlocal captured_future
+                nonlocal cancel_observed
 
                 async def _fake_reconnect():
+                    nonlocal cancel_observed
                     try:
                         await asyncio.sleep(300)
                     except asyncio.CancelledError:
-                        pass
+                        cancel_observed = True
 
                 loop = asyncio.get_running_loop()
                 captured_future = loop.create_task(_fake_reconnect())
@@ -343,7 +346,8 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
                 asyncio.run(main(self.mock_config))
 
             assert captured_future is not None
-            assert captured_future.cancelled()
+            assert captured_future.cancelled() or cancel_observed
+            assert captured_future.done()
             assert mu.reconnect_task_future is None
         finally:
             mu.meshtastic_client = original_client

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -192,13 +192,20 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
             mu.reconnect_task = None
             mu.reconnect_task_future = None
 
+            original_wait_for = asyncio.wait_for
+            wait_for_call_count = 0
+
+            async def _wait_for_that_times_out_on_gather(coro, timeout):
+                nonlocal wait_for_call_count
+                wait_for_call_count += 1
+                if wait_for_call_count >= 2:
+                    raise asyncio.TimeoutError()
+                return await original_wait_for(coro, timeout)
+
             async def _check_connection_that_ignores_cancel(*_args, **_kwargs):
                 try:
                     while True:
-                        try:
-                            await asyncio.sleep(10)
-                        except asyncio.CancelledError:
-                            pass
+                        await asyncio.sleep(10)
                 except asyncio.CancelledError:
                     pass
 
@@ -221,6 +228,10 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
                     side_effect=_make_patched_get_running_loop(),
                 ),
                 patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+                patch(
+                    "mmrelay.main.asyncio.wait_for",
+                    side_effect=_wait_for_that_times_out_on_gather,
+                ),
                 patch(
                     "mmrelay.main.meshtastic_utils.check_connection",
                     side_effect=_check_connection_that_ignores_cancel,

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2444,6 +2444,32 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         assert not second_result
         assert mu._relay_rx_time_clock_skew_secs is None
 
+    def test_seed_connect_time_skew_accepts_day_scale_future_offset(self):
+        """Day-scale node clock offsets should still be calibratable."""
+        import mmrelay.meshtastic_utils as mu
+
+        now_wall = 200_000.0
+        now_mono = 1_005.0
+        rx_time = now_wall + 100_654.84
+
+        mu._relay_rx_time_clock_skew_secs = None
+        mu._relay_connection_started_monotonic_secs = 1_000.0
+        mu.RELAY_START_TIME = 190_000.0
+        mu._relay_startup_drain_deadline_monotonic_secs = None
+        mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = None
+
+        with (
+            patch("mmrelay.meshtastic_utils.time.time", return_value=now_wall),
+            patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now_mono),
+        ):
+            result = mu._seed_connect_time_skew(rx_time)
+
+        self.assertTrue(result)
+        skew = mu._relay_rx_time_clock_skew_secs
+        self.assertIsNotNone(skew)
+        assert skew is not None
+        self.assertLess(abs(skew + 100_654.84), 1e-6)
+
     def test_claim_health_probe_uses_localnode_fallback(self):
         """_claim_health_probe_response_and_maybe_calibrate should fall back to localNode when myInfo is absent."""
         import mmrelay.meshtastic_utils as mu

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -2464,11 +2464,10 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         ):
             result = mu._seed_connect_time_skew(rx_time)
 
-        self.assertTrue(result)
+        assert result
         skew = mu._relay_rx_time_clock_skew_secs
-        self.assertIsNotNone(skew)
         assert skew is not None
-        self.assertLess(abs(skew + 100_654.84), 1e-6)
+        assert abs(skew + 100_654.84) < 1e-6
 
     def test_claim_health_probe_uses_localnode_fallback(self):
         """_claim_health_probe_response_and_maybe_calibrate should fall back to localNode when myInfo is absent."""

--- a/tests/test_meshtastic_utils_async_helpers.py
+++ b/tests/test_meshtastic_utils_async_helpers.py
@@ -1,8 +1,17 @@
 import asyncio
 from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from unittest.mock import MagicMock, patch
 
-from mmrelay.meshtastic_utils import _get_name_safely, _make_awaitable, _wait_for_result
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+from mmrelay.meshtastic_utils import (
+    _get_name_safely,
+    _make_awaitable,
+    _wait_for_future_result_with_shutdown,
+    _wait_for_result,
+)
 
 
 class _DummyLoop:
@@ -192,3 +201,45 @@ def test_get_name_safely_returns_sender_on_exception():
         raise TypeError("boom")
 
     assert _get_name_safely(_bad_lookup, 123) == "123"
+
+
+def test_wait_for_future_result_with_shutdown_returns_result():
+    future = Future()
+    future.set_result("ok")
+
+    result = _wait_for_future_result_with_shutdown(
+        future,
+        timeout_seconds=0.1,
+        poll_seconds=0.01,
+    )
+
+    assert result == "ok"
+
+
+def test_wait_for_future_result_with_shutdown_aborts_when_shutting_down():
+    future = MagicMock()
+
+    with patch.object(mu, "shutting_down", True):
+        with pytest.raises(TimeoutError, match="Shutdown in progress"):
+            _wait_for_future_result_with_shutdown(
+                future,
+                timeout_seconds=0.5,
+                poll_seconds=0.01,
+            )
+
+    future.result.assert_not_called()
+
+
+def test_wait_for_future_result_with_shutdown_raises_futures_timeout():
+    future = MagicMock()
+    future.result.side_effect = FuturesTimeoutError
+
+    with patch.object(mu, "shutting_down", False):
+        with pytest.raises(FuturesTimeoutError):
+            _wait_for_future_result_with_shutdown(
+                future,
+                timeout_seconds=0.02,
+                poll_seconds=0.005,
+            )
+
+    assert future.result.call_count >= 1

--- a/tests/test_meshtastic_utils_callback_lifecycle.py
+++ b/tests/test_meshtastic_utils_callback_lifecycle.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import patch
 
 import pytest
@@ -144,9 +145,12 @@ class TestConnectMeshtasticShutdownGuard:
         mu._connect_attempt_in_progress = True
         mu.shutting_down = True
 
+        start = time.monotonic()
         result = connect_meshtastic(passed_config=None)
+        elapsed = time.monotonic() - start
 
         assert result is None
+        assert elapsed < 0.2
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")

--- a/tests/test_meshtastic_utils_callback_lifecycle.py
+++ b/tests/test_meshtastic_utils_callback_lifecycle.py
@@ -1,0 +1,187 @@
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+from mmrelay.meshtastic_utils import (
+    _connect_meshtastic_impl,
+    connect_meshtastic,
+    ensure_meshtastic_callbacks_subscribed,
+    unsubscribe_meshtastic_callbacks,
+)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestEnsureCallbacksSubscribed:
+    def test_subscribes_to_both_topics(self):
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = False
+
+        with patch("mmrelay.meshtastic_utils.pub.subscribe") as mock_subscribe:
+            ensure_meshtastic_callbacks_subscribed()
+
+        assert mock_subscribe.call_count == 2
+        mock_subscribe.assert_any_call(mu.on_meshtastic_message, "meshtastic.receive")
+        mock_subscribe.assert_any_call(
+            mu.on_lost_meshtastic_connection, "meshtastic.connection.lost"
+        )
+        assert mu.subscribed_to_messages is True
+        assert mu.subscribed_to_connection_lost is True
+
+    def test_idempotent_does_not_double_subscribe(self):
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = False
+
+        with patch("mmrelay.meshtastic_utils.pub.subscribe") as mock_subscribe:
+            ensure_meshtastic_callbacks_subscribed()
+            ensure_meshtastic_callbacks_subscribed()
+
+        assert mock_subscribe.call_count == 2
+
+    def test_skips_already_subscribed_topics(self):
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = True
+
+        with patch("mmrelay.meshtastic_utils.pub.subscribe") as mock_subscribe:
+            ensure_meshtastic_callbacks_subscribed()
+
+        mock_subscribe.assert_not_called()
+
+    def test_partial_subscription_only_subscribes_missing(self):
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = False
+
+        with patch("mmrelay.meshtastic_utils.pub.subscribe") as mock_subscribe:
+            ensure_meshtastic_callbacks_subscribed()
+
+        assert mock_subscribe.call_count == 1
+        mock_subscribe.assert_called_once_with(
+            mu.on_lost_meshtastic_connection, "meshtastic.connection.lost"
+        )
+        assert mu.subscribed_to_messages is True
+        assert mu.subscribed_to_connection_lost is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestUnsubscribeCallbacks:
+    def test_unsubscribes_from_both_topics_when_subscribed(self):
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = True
+
+        with patch("mmrelay.meshtastic_utils.pub.unsubscribe") as mock_unsubscribe:
+            unsubscribe_meshtastic_callbacks()
+
+        assert mock_unsubscribe.call_count == 2
+        mock_unsubscribe.assert_any_call(mu.on_meshtastic_message, "meshtastic.receive")
+        mock_unsubscribe.assert_any_call(
+            mu.on_lost_meshtastic_connection, "meshtastic.connection.lost"
+        )
+        assert mu.subscribed_to_messages is False
+        assert mu.subscribed_to_connection_lost is False
+
+    def test_suppresses_exception_from_unsubscribe_messages(self):
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = False
+
+        with patch(
+            "mmrelay.meshtastic_utils.pub.unsubscribe",
+            side_effect=RuntimeError("boom"),
+        ):
+            unsubscribe_meshtastic_callbacks()
+
+        assert mu.subscribed_to_messages is False
+
+    def test_suppresses_exception_from_unsubscribe_connection_lost(self):
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = True
+
+        with patch(
+            "mmrelay.meshtastic_utils.pub.unsubscribe",
+            side_effect=RuntimeError("boom"),
+        ):
+            unsubscribe_meshtastic_callbacks()
+
+        assert mu.subscribed_to_connection_lost is False
+
+    def test_suppresses_exception_from_both_unsubscribes(self):
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = True
+
+        with patch(
+            "mmrelay.meshtastic_utils.pub.unsubscribe",
+            side_effect=RuntimeError("boom"),
+        ):
+            unsubscribe_meshtastic_callbacks()
+
+        assert mu.subscribed_to_messages is False
+        assert mu.subscribed_to_connection_lost is False
+
+    def test_idempotent_when_already_unsubscribed(self):
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = False
+
+        with patch("mmrelay.meshtastic_utils.pub.unsubscribe") as mock_unsubscribe:
+            unsubscribe_meshtastic_callbacks()
+
+        mock_unsubscribe.assert_not_called()
+
+    def test_unsubscribes_only_subscribed_topics(self):
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = False
+
+        with patch("mmrelay.meshtastic_utils.pub.unsubscribe") as mock_unsubscribe:
+            unsubscribe_meshtastic_callbacks()
+
+        assert mock_unsubscribe.call_count == 1
+        mock_unsubscribe.assert_called_once_with(
+            mu.on_meshtastic_message, "meshtastic.receive"
+        )
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestConnectMeshtasticShutdownGuard:
+    def test_returns_none_when_shutting_down_while_waiting_for_connect(self):
+        mu._connect_attempt_in_progress = True
+        mu.shutting_down = True
+
+        result = connect_meshtastic(passed_config=None)
+
+        assert result is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestConnectMeshtasticImplGuards:
+    def test_returns_none_when_shutting_down(self):
+        mu.shutting_down = True
+
+        result = _connect_meshtastic_impl(passed_config=None, force_connect=False)
+
+        assert result is None
+
+    def test_returns_none_when_reconnecting_and_not_force_connect(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+
+        result = _connect_meshtastic_impl(passed_config=None, force_connect=False)
+
+        assert result is None
+
+    def test_proceeds_when_reconnecting_but_force_connect_is_true(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.meshtastic_client = None
+        mu.config = None
+
+        with patch("mmrelay.meshtastic_utils.logger") as mock_logger:
+            result = _connect_meshtastic_impl(passed_config=None, force_connect=True)
+
+        assert result is None
+        assert not any(
+            "Reconnection already in progress" in str(c.args)
+            for c in mock_logger.debug.call_args_list
+        )
+        assert any(
+            "No configuration available" in str(c.args)
+            for c in mock_logger.error.call_args_list
+        )

--- a/tests/test_meshtastic_utils_callback_lifecycle.py
+++ b/tests/test_meshtastic_utils_callback_lifecycle.py
@@ -17,6 +17,7 @@ class TestEnsureCallbacksSubscribed:
     def test_subscribes_to_both_topics(self):
         mu.subscribed_to_messages = False
         mu.subscribed_to_connection_lost = False
+        mu._callbacks_tearing_down = True
 
         with patch("mmrelay.meshtastic_utils.pub.subscribe") as mock_subscribe:
             ensure_meshtastic_callbacks_subscribed()
@@ -28,6 +29,7 @@ class TestEnsureCallbacksSubscribed:
         )
         assert mu.subscribed_to_messages is True
         assert mu.subscribed_to_connection_lost is True
+        assert mu._callbacks_tearing_down is False
 
     def test_idempotent_does_not_double_subscribe(self):
         mu.subscribed_to_messages = False
@@ -68,6 +70,7 @@ class TestUnsubscribeCallbacks:
     def test_unsubscribes_from_both_topics_when_subscribed(self):
         mu.subscribed_to_messages = True
         mu.subscribed_to_connection_lost = True
+        mu._callbacks_tearing_down = False
 
         with patch("mmrelay.meshtastic_utils.pub.unsubscribe") as mock_unsubscribe:
             unsubscribe_meshtastic_callbacks()
@@ -79,6 +82,7 @@ class TestUnsubscribeCallbacks:
         )
         assert mu.subscribed_to_messages is False
         assert mu.subscribed_to_connection_lost is False
+        assert mu._callbacks_tearing_down is True
 
     def test_suppresses_exception_from_unsubscribe_messages(self):
         mu.subscribed_to_messages = True

--- a/tests/test_meshtastic_utils_callback_lifecycle.py
+++ b/tests/test_meshtastic_utils_callback_lifecycle.py
@@ -90,7 +90,7 @@ class TestUnsubscribeCallbacks:
         ):
             unsubscribe_meshtastic_callbacks()
 
-        assert mu.subscribed_to_messages is False
+        assert mu.subscribed_to_messages is True
 
     def test_suppresses_exception_from_unsubscribe_connection_lost(self):
         mu.subscribed_to_messages = False
@@ -102,7 +102,7 @@ class TestUnsubscribeCallbacks:
         ):
             unsubscribe_meshtastic_callbacks()
 
-        assert mu.subscribed_to_connection_lost is False
+        assert mu.subscribed_to_connection_lost is True
 
     def test_suppresses_exception_from_both_unsubscribes(self):
         mu.subscribed_to_messages = True
@@ -114,8 +114,8 @@ class TestUnsubscribeCallbacks:
         ):
             unsubscribe_meshtastic_callbacks()
 
-        assert mu.subscribed_to_messages is False
-        assert mu.subscribed_to_connection_lost is False
+        assert mu.subscribed_to_messages is True
+        assert mu.subscribed_to_connection_lost is True
 
     def test_idempotent_when_already_unsubscribed(self):
         mu.subscribed_to_messages = False

--- a/tests/test_meshtastic_utils_callback_lifecycle.py
+++ b/tests/test_meshtastic_utils_callback_lifecycle.py
@@ -1,5 +1,4 @@
-import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -53,7 +53,8 @@ def test_connect_meshtastic_serializes_concurrent_connect_attempts(
 
     constructor_entered = threading.Event()
     allow_constructor_return = threading.Event()
-    worker_errors: list[BaseException] = []
+    second_ready_to_connect = threading.Event()
+    worker_errors: list[Exception] = []
     worker_results: list[Any | None] = [None, None]
 
     def _tcp_constructor(*_args: Any, **_kwargs: Any) -> Any:
@@ -63,8 +64,10 @@ def test_connect_meshtastic_serializes_concurrent_connect_attempts(
 
     def _run_connect(index: int) -> None:
         try:
+            if index == 1:
+                second_ready_to_connect.set()
             worker_results[index] = connect_meshtastic(passed_config=config)
-        except BaseException as exc:  # pragma: no cover - exercised only on failure
+        except Exception as exc:  # pragma: no cover - exercised only on failure
             worker_errors.append(exc)
 
     with (
@@ -82,8 +85,7 @@ def test_connect_meshtastic_serializes_concurrent_connect_attempts(
         first.start()
         assert constructor_entered.wait(timeout=1.0)
         second.start()
-        # Give the second thread time to block on connect serialization.
-        time.sleep(0.05)
+        assert second_ready_to_connect.wait(timeout=1.0)
         assert mock_tcp.call_count == 1
         allow_constructor_return.set()
         first.join(timeout=1.0)
@@ -108,6 +110,7 @@ def test_connect_meshtastic_waiter_times_out_when_attempt_stuck(
     with (
         patch.object(mu, "_CONNECT_ATTEMPT_WAIT_MAX_SECS", 0.02),
         patch.object(mu, "_CONNECT_ATTEMPT_WAIT_POLL_SECS", 0.005),
+        patch("mmrelay.meshtastic_utils._connect_meshtastic_impl") as mock_impl,
     ):
         result = connect_meshtastic()
     elapsed = time.monotonic() - start
@@ -117,6 +120,8 @@ def test_connect_meshtastic_waiter_times_out_when_attempt_stuck(
         mu._connect_attempt_condition.notify_all()
 
     assert result is None
+    assert elapsed >= 0.015
+    mock_impl.assert_not_called()
     assert elapsed < 0.2
 
 

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -97,6 +97,29 @@ def test_connect_meshtastic_serializes_concurrent_connect_attempts(
     assert mock_tcp.call_count == 1
 
 
+def test_connect_meshtastic_waiter_times_out_when_attempt_stuck(
+    reset_meshtastic_globals,
+):
+    """Waiting callers should return quickly when a connect attempt is stuck."""
+    with mu._connect_attempt_condition:
+        mu._connect_attempt_in_progress = True
+
+    start = time.monotonic()
+    with (
+        patch.object(mu, "_CONNECT_ATTEMPT_WAIT_MAX_SECS", 0.02),
+        patch.object(mu, "_CONNECT_ATTEMPT_WAIT_POLL_SECS", 0.005),
+    ):
+        result = connect_meshtastic()
+    elapsed = time.monotonic() - start
+
+    with mu._connect_attempt_condition:
+        mu._connect_attempt_in_progress = False
+        mu._connect_attempt_condition.notify_all()
+
+    assert result is None
+    assert elapsed < 0.2
+
+
 def test_connect_meshtastic_network_alias_warns_and_uses_tcp(reset_meshtastic_globals):
     mock_client = MagicMock()
     mock_client.getMyNodeInfo.return_value = {

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -40,9 +40,8 @@ def test_connect_meshtastic_returns_existing_client(reset_meshtastic_globals):
     mock_tcp.assert_not_called()
 
 
-def test_connect_meshtastic_serializes_concurrent_connect_attempts(
-    reset_meshtastic_globals,
-):
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_meshtastic_serializes_concurrent_connect_attempts():
     config = {
         "meshtastic": {"connection_type": CONNECTION_TYPE_TCP, "host": "127.0.0.1"}
     }
@@ -99,9 +98,8 @@ def test_connect_meshtastic_serializes_concurrent_connect_attempts(
     assert mock_tcp.call_count == 1
 
 
-def test_connect_meshtastic_waiter_times_out_when_attempt_stuck(
-    reset_meshtastic_globals,
-):
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_meshtastic_waiter_times_out_when_attempt_stuck():
     """Waiting callers should return quickly when a connect attempt is stuck."""
     with mu._connect_attempt_condition:
         mu._connect_attempt_in_progress = True

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from collections.abc import Callable
 from typing import Any
@@ -37,6 +38,63 @@ def test_connect_meshtastic_returns_existing_client(reset_meshtastic_globals):
 
     assert result is mock_client
     mock_tcp.assert_not_called()
+
+
+def test_connect_meshtastic_serializes_concurrent_connect_attempts(
+    reset_meshtastic_globals,
+):
+    config = {
+        "meshtastic": {"connection_type": CONNECTION_TYPE_TCP, "host": "127.0.0.1"}
+    }
+    created_client = MagicMock()
+    created_client.getMyNodeInfo.return_value = {
+        "user": {"shortName": "Node", "hwModel": "HW"}
+    }
+
+    constructor_entered = threading.Event()
+    allow_constructor_return = threading.Event()
+    worker_errors: list[BaseException] = []
+    worker_results: list[Any | None] = [None, None]
+
+    def _tcp_constructor(*_args: Any, **_kwargs: Any) -> Any:
+        constructor_entered.set()
+        assert allow_constructor_return.wait(timeout=1.0)
+        return created_client
+
+    def _run_connect(index: int) -> None:
+        try:
+            worker_results[index] = connect_meshtastic(passed_config=config)
+        except BaseException as exc:  # pragma: no cover - exercised only on failure
+            worker_errors.append(exc)
+
+    with (
+        patch(
+            "mmrelay.meshtastic_utils.meshtastic.tcp_interface.TCPInterface",
+            side_effect=_tcp_constructor,
+        ) as mock_tcp,
+        patch(
+            "mmrelay.meshtastic_utils._get_device_metadata",
+            return_value={"firmware_version": "unknown", "success": False},
+        ),
+    ):
+        first = threading.Thread(target=_run_connect, args=(0,))
+        second = threading.Thread(target=_run_connect, args=(1,))
+        first.start()
+        assert constructor_entered.wait(timeout=1.0)
+        second.start()
+        # Give the second thread time to block on connect serialization.
+        time.sleep(0.05)
+        assert mock_tcp.call_count == 1
+        allow_constructor_return.set()
+        first.join(timeout=1.0)
+        second.join(timeout=1.0)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert worker_errors == []
+    assert worker_results[0] is created_client
+    assert worker_results[1] is created_client
+    assert mock_tcp.call_count == 1
 
 
 def test_connect_meshtastic_network_alias_warns_and_uses_tcp(reset_meshtastic_globals):

--- a/tests/test_meshtastic_utils_event_guards_coverage.py
+++ b/tests/test_meshtastic_utils_event_guards_coverage.py
@@ -113,6 +113,10 @@ class TestOnMeshtasticMessageNoActiveClient:
 
         debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
         assert any(
+            "Shutdown in progress. Ignoring incoming messages." in c
+            for c in debug_calls
+        )
+        assert not any(
             "Ignoring packet because no Meshtastic interface is currently active" in c
             for c in debug_calls
         )

--- a/tests/test_meshtastic_utils_event_guards_coverage.py
+++ b/tests/test_meshtastic_utils_event_guards_coverage.py
@@ -29,6 +29,25 @@ class TestOnLostConnectionNoActiveClient:
             for c in debug_calls
         )
 
+    def test_ignores_when_no_active_client_and_callbacks_tearing_down(self):
+        mu.meshtastic_client = None
+        mu.subscribed_to_connection_lost = False
+        mu._callbacks_tearing_down = True
+        mu.shutting_down = False
+
+        mock_interface = MagicMock()
+
+        with patch("mmrelay.meshtastic_utils.logger") as mock_logger:
+            on_lost_meshtastic_connection(interface=mock_interface)
+
+        assert mu.reconnecting is False
+        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+        assert any(
+            "Ignoring connection-lost event because no Meshtastic interface is currently active"
+            in c
+            for c in debug_calls
+        )
+
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestOnLostConnectionStaleInterface:
@@ -88,6 +107,22 @@ class TestOnMeshtasticMessageNoActiveClient:
     def test_ignores_packet_when_reconnecting(self):
         mu.meshtastic_client = None
         mu.reconnecting = True
+
+        mock_interface = MagicMock()
+        packet = {"decoded": {"text": "hello"}, "fromId": "!abc", "to": 4294967295}
+
+        with patch("mmrelay.meshtastic_utils.logger") as mock_logger:
+            on_meshtastic_message(packet, mock_interface)
+
+        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+        assert any(
+            "Ignoring packet because no Meshtastic interface is currently active" in c
+            for c in debug_calls
+        )
+
+    def test_ignores_packet_when_callbacks_tearing_down(self):
+        mu.meshtastic_client = None
+        mu._callbacks_tearing_down = True
 
         mock_interface = MagicMock()
         packet = {"decoded": {"text": "hello"}, "fromId": "!abc", "to": 4294967295}

--- a/tests/test_meshtastic_utils_node_name_refresh.py
+++ b/tests/test_meshtastic_utils_node_name_refresh.py
@@ -123,6 +123,56 @@ def test_refresh_node_name_tables_handles_timeout_then_retries(
     assert mock_sync.call_args_list[1].args[1] is state_after_first_refresh
 
 
+def test_refresh_node_name_tables_logs_unavailable_only_once_per_state(
+    reset_meshtastic_globals,
+) -> None:
+    """Unavailable-client debug noise should be deduplicated across loop iterations."""
+    _ = reset_meshtastic_globals
+    event = _TimeoutThenSetEvent()
+    with (
+        patch.object(mu, "meshtastic_client", None),
+        patch.object(mu, "logger") as mock_logger,
+    ):
+        asyncio.run(
+            mu.refresh_node_name_tables(
+                event,  # type: ignore[arg-type]
+                refresh_interval_seconds=0.01,
+            )
+        )
+
+    unavailable_calls = [
+        c
+        for c in mock_logger.debug.call_args_list
+        if c.args
+        and c.args[0]
+        == "Skipping name-cache refresh from NodeDB because Meshtastic client is unavailable"
+    ]
+    assert len(unavailable_calls) == 1
+
+
+def test_refresh_node_name_tables_uses_reconnecting_unavailable_message(
+    reset_meshtastic_globals,
+) -> None:
+    """When reconnecting, refresh logs reconnect-specific unavailability reason."""
+    _ = reset_meshtastic_globals
+    event = _OnePassEvent()
+    with (
+        patch.object(mu, "meshtastic_client", None),
+        patch.object(mu, "reconnecting", True),
+        patch.object(mu, "logger") as mock_logger,
+    ):
+        asyncio.run(
+            mu.refresh_node_name_tables(
+                event,  # type: ignore[arg-type]
+                refresh_interval_seconds=0.01,
+            )
+        )
+
+    mock_logger.debug.assert_any_call(
+        "Skipping name-cache refresh from NodeDB while reconnection is in progress"
+    )
+
+
 def test_refresh_node_name_tables_non_positive_interval_exits_after_one_pass(
     reset_meshtastic_globals,
 ) -> None:

--- a/tests/test_meshtastic_utils_reconnect.py
+++ b/tests/test_meshtastic_utils_reconnect.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 import mmrelay.meshtastic_utils as mu
-from mmrelay.constants.network import DEFAULT_BACKOFF_TIME
 from mmrelay.meshtastic_utils import reconnect
 
 
@@ -20,7 +19,7 @@ class TestReconnectSuccess:
             await reconnect()
 
         with (
-            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
             patch(
                 "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
             ),
@@ -42,7 +41,7 @@ class TestReconnectSuccess:
             await reconnect()
 
         with (
-            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
             patch(
                 "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
             ),
@@ -62,24 +61,21 @@ class TestReconnectCancellation:
         mu.shutting_down = False
         mu.reconnect_task_future = None
 
-        async def _sleep_side_effect(_seconds):
-            mu.shutting_down = True
-            await asyncio.sleep(0)
+        reconnect_task = None
 
         async def _run_with_cancel():
+            nonlocal reconnect_task
             reconnect_task = asyncio.create_task(reconnect())
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(0.01)
             reconnect_task.cancel()
             try:
                 await reconnect_task
-            except (asyncio.CancelledError, RuntimeError):
+            except asyncio.CancelledError:
                 pass
 
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
-            patch(
-                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
-            ),
+            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
             patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
@@ -96,13 +92,40 @@ class TestReconnectShutdownAbort:
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
-        sleep_call_count = 0
 
-        async def _sleep_side_effect(_seconds):
-            nonlocal sleep_call_count
-            sleep_call_count += 1
-            mu.shutting_down = True
-            await asyncio.sleep(0)
+        async def _run():
+            await reconnect()
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
+            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
+            patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None),
+            patch("mmrelay.meshtastic_utils.logger") as mock_logger,
+        ):
+            asyncio.run(_run())
+
+        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+        assert any(
+            "Shutdown in progress. Aborting reconnection attempts." in c
+            for c in debug_calls
+        )
+        assert mu.reconnecting is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestReconnectFailureBackoff:
+    def test_connect_failure_logs_exception_and_clears_state(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+        attempt_count = 0
+
+        def _connect_side_effect(cfg, force):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count >= 2:
+                mu.shutting_down = True
+            raise ConnectionError("connection refused")
 
         async def _run():
             await reconnect()
@@ -110,109 +133,19 @@ class TestReconnectShutdownAbort:
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
             patch(
-                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
-            ),
-            patch("mmrelay.meshtastic_utils.logger") as mock_logger,
-        ):
-            asyncio.run(_run())
-
-        assert sleep_call_count == 1
-        assert any(
-            "Shutdown in progress. Aborting reconnection attempts." in str(c.args)
-            for c in mock_logger.debug.call_args_list
-        )
-        assert mu.reconnecting is False
-
-
-@pytest.mark.usefixtures("reset_meshtastic_globals")
-class TestReconnectFailureBackoff:
-    def test_connect_failure_logs_and_doubles_backoff(self):
-        mu.reconnecting = True
-        mu.shutting_down = False
-        mu.reconnect_task_future = None
-        attempt_count = 0
-
-        def _connect_side_effect(cfg, force):
-            nonlocal attempt_count
-            attempt_count += 1
-            if attempt_count >= 3:
-                mu.shutting_down = True
-            raise ConnectionError("connection refused")
-
-        class _NoOpProgress:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                pass
-
-            def update(self, *args, **kwargs):
-                pass
-
-        async def _sleep_side_effect(seconds):
-            await asyncio.sleep(0)
-
-        async def _run():
-            await reconnect()
-
-        with (
-            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
-            patch(
                 "mmrelay.meshtastic_utils.connect_meshtastic",
                 side_effect=_connect_side_effect,
             ),
-            patch(
-                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
-            ),
+            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
-            patch("mmrelay.meshtastic_utils.time.sleep"),
         ):
             asyncio.run(_run())
 
-        assert attempt_count == 3
+        assert attempt_count == 2
         assert any(
             "Reconnection attempt failed" in str(c.args)
             for c in mock_logger.exception.call_args_list
         )
-        assert mu.reconnecting is False
-        assert mu.reconnect_task_future is None
-
-    def test_backoff_caps_at_300_seconds(self):
-        mu.reconnecting = True
-        mu.shutting_down = False
-        mu.reconnect_task_future = None
-        attempt_count = 0
-        sleep_times = []
-
-        def _connect_side_effect(cfg, force):
-            nonlocal attempt_count
-            attempt_count += 1
-            if attempt_count >= 10:
-                mu.shutting_down = True
-            raise ConnectionError("connection refused")
-
-        async def _sleep_side_effect(seconds):
-            sleep_times.append(seconds)
-            await asyncio.sleep(0)
-
-        async def _run():
-            await reconnect()
-
-        with (
-            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
-            patch(
-                "mmrelay.meshtastic_utils.connect_meshtastic",
-                side_effect=_connect_side_effect,
-            ),
-            patch(
-                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
-            ),
-            patch("mmrelay.meshtastic_utils.logger"),
-            patch("mmrelay.meshtastic_utils.time.sleep"),
-        ):
-            asyncio.run(_run())
-
-        assert max(sleep_times) == 300
         assert mu.reconnecting is False
         assert mu.reconnect_task_future is None
 
@@ -229,23 +162,17 @@ class TestReconnectFailureBackoff:
                 mu.shutting_down = True
             raise RuntimeError("unexpected error")
 
-        async def _sleep_side_effect(seconds):
-            await asyncio.sleep(0)
-
         async def _run():
             await reconnect()
 
         with (
-            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
             patch(
                 "mmrelay.meshtastic_utils.connect_meshtastic",
                 side_effect=_connect_side_effect,
             ),
-            patch(
-                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
-            ),
+            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
             patch("mmrelay.meshtastic_utils.logger"),
-            patch("mmrelay.meshtastic_utils.time.sleep"),
         ):
             asyncio.run(_run())
 

--- a/tests/test_meshtastic_utils_reconnect.py
+++ b/tests/test_meshtastic_utils_reconnect.py
@@ -20,10 +20,15 @@ class TestReconnectSuccess:
         mu.shutting_down = False
         mu.reconnect_task_future = None
 
+        def _connect_side_effect(_cfg, _force):
+            mu.meshtastic_client = mock_client
+            return mock_client
+
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
             patch(
-                "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+                "mmrelay.meshtastic_utils.connect_meshtastic",
+                side_effect=_connect_side_effect,
             ),
             patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -33,11 +38,12 @@ class TestReconnectSuccess:
         assert mu.reconnecting is False
         assert mu.reconnect_task_future is None
 
-    async def test_reconnect_clears_future_after_success(self):
+    async def test_reconnect_success_does_not_republish_client_global(self):
         mock_client = MagicMock()
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
+        mu.meshtastic_client = None
 
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
@@ -50,7 +56,7 @@ class TestReconnectSuccess:
 
         assert mu.reconnect_task_future is None
         assert mu.reconnecting is False
-        assert mu.meshtastic_client is mock_client
+        assert mu.meshtastic_client is None
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")

--- a/tests/test_meshtastic_utils_reconnect.py
+++ b/tests/test_meshtastic_utils_reconnect.py
@@ -139,6 +139,16 @@ class TestReconnectFailureBackoff:
                 mu.shutting_down = True
             raise ConnectionError("connection refused")
 
+        class _NoOpProgress:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def update(self, *args, **kwargs):
+                pass
+
         async def _sleep_side_effect(seconds):
             await asyncio.sleep(0)
 
@@ -155,6 +165,7 @@ class TestReconnectFailureBackoff:
                 "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
             ),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
+            patch("mmrelay.meshtastic_utils.time.sleep"),
         ):
             asyncio.run(_run())
 
@@ -197,6 +208,7 @@ class TestReconnectFailureBackoff:
                 "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
             ),
             patch("mmrelay.meshtastic_utils.logger"),
+            patch("mmrelay.meshtastic_utils.time.sleep"),
         ):
             asyncio.run(_run())
 
@@ -233,6 +245,7 @@ class TestReconnectFailureBackoff:
                 "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
             ),
             patch("mmrelay.meshtastic_utils.logger"),
+            patch("mmrelay.meshtastic_utils.time.sleep"),
         ):
             asyncio.run(_run())
 

--- a/tests/test_meshtastic_utils_reconnect.py
+++ b/tests/test_meshtastic_utils_reconnect.py
@@ -1,0 +1,241 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+from mmrelay.constants.network import DEFAULT_BACKOFF_TIME
+from mmrelay.meshtastic_utils import reconnect
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestReconnectSuccess:
+    def test_reconnect_succeeds_and_clears_future_and_flag(self):
+        mock_client = MagicMock()
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+
+        async def _run():
+            await reconnect()
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch(
+                "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+            ),
+            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            asyncio.run(_run())
+
+        assert mu.meshtastic_client is mock_client
+        assert mu.reconnecting is False
+        assert mu.reconnect_task_future is None
+
+    def test_reconnect_clears_future_after_success(self):
+        mock_client = MagicMock()
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+
+        async def _run():
+            await reconnect()
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch(
+                "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+            ),
+            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            asyncio.run(_run())
+
+        assert mu.reconnect_task_future is None
+        assert mu.reconnecting is False
+        assert mu.meshtastic_client is mock_client
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestReconnectCancellation:
+    def test_reconnect_cancellation_logs_and_clears_state(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+
+        async def _run_with_cancel():
+            reconnect_task = asyncio.create_task(reconnect())
+            await asyncio.sleep(0.01)
+            reconnect_task.cancel()
+            await reconnect_task
+
+        async def _sleep_side_effect(_seconds):
+            await asyncio.sleep(0.001)
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
+            ),
+            patch("mmrelay.meshtastic_utils.logger") as mock_logger,
+        ):
+            try:
+                asyncio.run(_run_with_cancel())
+            except (asyncio.CancelledError, RuntimeError):
+                pass
+
+        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
+        assert any("Shutdown in progress" in c for c in debug_calls) or any(
+            "Reconnection task was cancelled" in str(c)
+            for c in mock_logger.info.call_args_list
+        )
+        assert mu.reconnecting is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestReconnectShutdownAbort:
+    def test_shutdown_during_backoff_aborts_reconnect(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+        sleep_call_count = 0
+
+        async def _sleep_side_effect(_seconds):
+            nonlocal sleep_call_count
+            sleep_call_count += 1
+            mu.shutting_down = True
+            await asyncio.sleep(0)
+
+        async def _run():
+            await reconnect()
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
+            ),
+            patch("mmrelay.meshtastic_utils.logger") as mock_logger,
+        ):
+            asyncio.run(_run())
+
+        assert sleep_call_count == 1
+        assert any(
+            "Shutdown in progress. Aborting reconnection attempts." in str(c.args)
+            for c in mock_logger.debug.call_args_list
+        )
+        assert mu.reconnecting is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestReconnectFailureBackoff:
+    def test_connect_failure_logs_and_doubles_backoff(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+        attempt_count = 0
+
+        def _connect_side_effect(cfg, force):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count >= 3:
+                mu.shutting_down = True
+            raise ConnectionError("connection refused")
+
+        async def _sleep_side_effect(seconds):
+            await asyncio.sleep(0)
+
+        async def _run():
+            await reconnect()
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch(
+                "mmrelay.meshtastic_utils.connect_meshtastic",
+                side_effect=_connect_side_effect,
+            ),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
+            ),
+            patch("mmrelay.meshtastic_utils.logger") as mock_logger,
+        ):
+            asyncio.run(_run())
+
+        assert attempt_count == 3
+        assert any(
+            "Reconnection attempt failed" in str(c.args)
+            for c in mock_logger.exception.call_args_list
+        )
+        assert mu.reconnecting is False
+        assert mu.reconnect_task_future is None
+
+    def test_backoff_caps_at_300_seconds(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+        attempt_count = 0
+        sleep_times = []
+
+        def _connect_side_effect(cfg, force):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count >= 10:
+                mu.shutting_down = True
+            raise ConnectionError("connection refused")
+
+        async def _sleep_side_effect(seconds):
+            sleep_times.append(seconds)
+            await asyncio.sleep(0)
+
+        async def _run():
+            await reconnect()
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch(
+                "mmrelay.meshtastic_utils.connect_meshtastic",
+                side_effect=_connect_side_effect,
+            ),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
+            ),
+            patch("mmrelay.meshtastic_utils.logger"),
+        ):
+            asyncio.run(_run())
+
+        assert max(sleep_times) == 300
+        assert mu.reconnecting is False
+        assert mu.reconnect_task_future is None
+
+    def test_reconnect_task_future_cleared_after_failure(self):
+        mu.reconnecting = True
+        mu.shutting_down = False
+        mu.reconnect_task_future = None
+        attempt_count = 0
+
+        def _connect_side_effect(cfg, force):
+            nonlocal attempt_count
+            attempt_count += 1
+            if attempt_count >= 2:
+                mu.shutting_down = True
+            raise RuntimeError("unexpected error")
+
+        async def _sleep_side_effect(seconds):
+            await asyncio.sleep(0)
+
+        async def _run():
+            await reconnect()
+
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch(
+                "mmrelay.meshtastic_utils.connect_meshtastic",
+                side_effect=_connect_side_effect,
+            ),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
+            ),
+            patch("mmrelay.meshtastic_utils.logger"),
+        ):
+            asyncio.run(_run())
+
+        assert mu.reconnect_task_future is None
+        assert mu.reconnecting is False

--- a/tests/test_meshtastic_utils_reconnect.py
+++ b/tests/test_meshtastic_utils_reconnect.py
@@ -7,16 +7,18 @@ import mmrelay.meshtastic_utils as mu
 from mmrelay.meshtastic_utils import reconnect
 
 
+def _sleep_and_mark_shutdown(_seconds: int) -> None:
+    mu.shutting_down = True
+
+
 @pytest.mark.usefixtures("reset_meshtastic_globals")
+@pytest.mark.asyncio
 class TestReconnectSuccess:
-    def test_reconnect_succeeds_and_clears_future_and_flag(self):
+    async def test_reconnect_succeeds_and_clears_future_and_flag(self):
         mock_client = MagicMock()
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
-
-        async def _run():
-            await reconnect()
 
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
@@ -25,20 +27,17 @@ class TestReconnectSuccess:
             ),
             patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
         ):
-            asyncio.run(_run())
+            await reconnect()
 
         assert mu.meshtastic_client is mock_client
         assert mu.reconnecting is False
         assert mu.reconnect_task_future is None
 
-    def test_reconnect_clears_future_after_success(self):
+    async def test_reconnect_clears_future_after_success(self):
         mock_client = MagicMock()
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
-
-        async def _run():
-            await reconnect()
 
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
@@ -47,7 +46,7 @@ class TestReconnectSuccess:
             ),
             patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
         ):
-            asyncio.run(_run())
+            await reconnect()
 
         assert mu.reconnect_task_future is None
         assert mu.reconnecting is False
@@ -55,80 +54,71 @@ class TestReconnectSuccess:
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
+@pytest.mark.asyncio
 class TestReconnectCancellation:
-    def test_reconnect_cancellation_logs_and_clears_state(self):
+    async def test_reconnect_cancellation_logs_and_clears_state(self):
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
 
-        reconnect_task = None
-
-        async def _run_with_cancel():
-            nonlocal reconnect_task
-            reconnect_task = asyncio.create_task(reconnect())
-            await asyncio.sleep(0.01)
-            reconnect_task.cancel()
-            try:
-                await reconnect_task
-            except asyncio.CancelledError:
-                pass
-
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
-            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
-            patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep",
+                new_callable=AsyncMock,
+                side_effect=asyncio.CancelledError,
+            ),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
-            asyncio.run(_run_with_cancel())
+            await reconnect()
 
-        info_calls = [str(c) for c in mock_logger.info.call_args_list]
-        assert any("Reconnection task was cancelled" in c for c in info_calls)
+        mock_logger.info.assert_any_call("Reconnection task was cancelled.")
         assert mu.reconnecting is False
+        assert mu.reconnect_task_future is None
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
+@pytest.mark.asyncio
 class TestReconnectShutdownAbort:
-    def test_shutdown_during_backoff_aborts_reconnect(self):
+    async def test_shutdown_during_backoff_aborts_reconnect(self):
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
 
-        async def _run():
-            await reconnect()
-
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
-            patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
-            patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep",
+                new_callable=AsyncMock,
+                side_effect=_sleep_and_mark_shutdown,
+            ),
+            patch("mmrelay.meshtastic_utils.connect_meshtastic") as mock_connect,
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
-            asyncio.run(_run())
+            await reconnect()
 
-        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
-        assert any(
-            "Shutdown in progress. Aborting reconnection attempts." in c
-            for c in debug_calls
+        mock_connect.assert_not_called()
+        mock_logger.debug.assert_any_call(
+            "Shutdown in progress. Aborting reconnection attempts."
         )
         assert mu.reconnecting is False
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
+@pytest.mark.asyncio
 class TestReconnectFailureBackoff:
-    def test_connect_failure_logs_exception_and_clears_state(self):
+    async def test_connect_failure_logs_exception_and_clears_state(self):
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
         attempt_count = 0
 
-        def _connect_side_effect(cfg, force):
+        def _connect_side_effect(_cfg, _force):
             nonlocal attempt_count
             attempt_count += 1
             if attempt_count >= 2:
                 mu.shutting_down = True
             raise ConnectionError("connection refused")
-
-        async def _run():
-            await reconnect()
 
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
@@ -139,7 +129,7 @@ class TestReconnectFailureBackoff:
             patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
-            asyncio.run(_run())
+            await reconnect()
 
         assert attempt_count == 2
         assert any(
@@ -149,21 +139,18 @@ class TestReconnectFailureBackoff:
         assert mu.reconnecting is False
         assert mu.reconnect_task_future is None
 
-    def test_reconnect_task_future_cleared_after_failure(self):
+    async def test_reconnect_task_future_cleared_after_failure(self):
         mu.reconnecting = True
         mu.shutting_down = False
         mu.reconnect_task_future = None
         attempt_count = 0
 
-        def _connect_side_effect(cfg, force):
+        def _connect_side_effect(_cfg, _force):
             nonlocal attempt_count
             attempt_count += 1
             if attempt_count >= 2:
                 mu.shutting_down = True
             raise RuntimeError("unexpected error")
-
-        async def _run():
-            await reconnect()
 
         with (
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
@@ -174,7 +161,8 @@ class TestReconnectFailureBackoff:
             patch("mmrelay.meshtastic_utils.asyncio.sleep", new_callable=AsyncMock),
             patch("mmrelay.meshtastic_utils.logger"),
         ):
-            asyncio.run(_run())
+            await reconnect()
 
+        assert attempt_count == 2
         assert mu.reconnect_task_future is None
         assert mu.reconnecting is False

--- a/tests/test_meshtastic_utils_reconnect.py
+++ b/tests/test_meshtastic_utils_reconnect.py
@@ -62,32 +62,31 @@ class TestReconnectCancellation:
         mu.shutting_down = False
         mu.reconnect_task_future = None
 
+        async def _sleep_side_effect(_seconds):
+            mu.shutting_down = True
+            await asyncio.sleep(0)
+
         async def _run_with_cancel():
             reconnect_task = asyncio.create_task(reconnect())
-            await asyncio.sleep(0.01)
+            await asyncio.sleep(0.05)
             reconnect_task.cancel()
-            await reconnect_task
-
-        async def _sleep_side_effect(_seconds):
-            await asyncio.sleep(0.001)
-
-        with (
-            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
-            patch(
-                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
-            ),
-            patch("mmrelay.meshtastic_utils.logger") as mock_logger,
-        ):
             try:
-                asyncio.run(_run_with_cancel())
+                await reconnect_task
             except (asyncio.CancelledError, RuntimeError):
                 pass
 
-        debug_calls = [str(c) for c in mock_logger.debug.call_args_list]
-        assert any("Shutdown in progress" in c for c in debug_calls) or any(
-            "Reconnection task was cancelled" in str(c)
-            for c in mock_logger.info.call_args_list
-        )
+        with (
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
+            patch(
+                "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
+            ),
+            patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None),
+            patch("mmrelay.meshtastic_utils.logger") as mock_logger,
+        ):
+            asyncio.run(_run_with_cancel())
+
+        info_calls = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("Reconnection task was cancelled" in c for c in info_calls)
         assert mu.reconnecting is False
 
 
@@ -109,7 +108,7 @@ class TestReconnectShutdownAbort:
             await reconnect()
 
         with (
-            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=False),
+            patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
             patch(
                 "mmrelay.meshtastic_utils.asyncio.sleep", side_effect=_sleep_side_effect
             ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR hardens Meshtastic connection lifecycle and shutdown handling. It serializes connection attempts to avoid concurrent setup races, adds bounded wait/polling and shutdown-aware waiting to prevent hangs, tracks and cleans up both asyncio tasks and executor futures used for reconnects, and makes pubsub callback subscribe/unsubscribe thread-safe and robust during teardown. Tests and test helpers were extended to cover these behaviours. The RX clock-skew bootstrap window was increased from 24 to 48 hours.

## Key changes

Features
- Serialize connect attempts
  - Add _connect_attempt_lock, _connect_attempt_condition, and _connect_attempt_in_progress so connect_meshtastic() serializes concurrent callers.
  - Split connection flow: connect_meshtastic(...) is a serialized wrapper; _connect_meshtastic_impl(...) contains the actual connection logic.
  - Bounded waiter behavior with _CONNECT_ATTEMPT_WAIT_MAX_SECS and _CONNECT_ATTEMPT_WAIT_POLL_SECS; waiters return None on shutdown or timeout.
- Reconnect-task and executor-future tracking
  - Expose reconnect_task_future (executor Future) in addition to reconnect_task (asyncio.Task).
  - Track and clear reconnect_task_future so shutdown/startup rollback can cancel and await both kinds of in-flight reconnect work.
- Thread-safe callback subscription
  - Add meshtastic_sub_lock and ensure_meshtastic_callbacks_subscribed()/unsubscribe_meshtastic_callbacks() for idempotent, locked pub.subscribe/pub.unsubscribe and subscription-flag bookkeeping.

Fixes
- Shutdown and startup-rollback hardening
  - Add _cleanup_meshtastic_reconnect_state(context) to cancel/await reconnect_task and reconnect_task_future with bounded waits, unsubscribe callbacks robustly, and clear reconnect state.
  - Invoke this cleanup during startup rollback and during shutdown (before BLE disconnect and plugin/queue teardown) to avoid lingering reconnect work or late callbacks.
  - Insert shutdown checks in _connect_meshtastic_impl at multiple stages; on shutdown it cleans up newly created client/interface and rolls back state.
- Robust unsubscribe behavior and teardown guards
  - unsubscribe_meshtastic_callbacks() is best-effort: suppresses TopicNameError and logs per-topic failures.
  - Introduce _callbacks_tearing_down guard so incoming events/messages are ignored during unsubscribe/teardown windows.
- Prevent hangs and busy-waiting
  - Add _wait_for_future_result_with_shutdown to poll futures while respecting the shutdown signal and to avoid busy loops when futures timeout immediately.
  - Apply BLE-specific per-attempt wait budgeting and per-attempt timeout logging.
- Deadlock avoidance in rollback
  - _rollback_connect_attempt_state gained lock_held parameter so callers that already hold the lock can avoid re-acquiring it.

Refactors
- Centralize pubsub subscribe/unsubscribe into helpers and use a lock to prevent duplicate subscriptions.
- Replace ad-hoc in-progress flag handling with a Condition cleared in a finally block plus notify_all(), so waiters are reliably awakened.
- Standardize reconnect task creation and adapt shutdown helpers to accept asyncio.Future[Any] | None where appropriate.

Constants
- Increase RX_TIME_SKEW_BOOTSTRAP_MAX_SKEW_SECS from 24 hours to 48 hours.

Tests and test helpers
- Added/updated tests to cover:
  - Concurrent connect_meshtastic() serialization and bounded-timeout waiter behavior.
  - reconnect coroutine scenarios (success, cancellation, shutdown during backoff, repeated failures) and clearing of reconnect_task_future.
  - Callback lifecycle (idempotent subscribe, best-effort unsubscribe, teardown guards).
  - Shutdown ordering (reconnect cancelled before BLE disconnect; callbacks unsubscribed).
  - Startup rollback cleaning reconnect state and callbacks.
  - _wait_for_future_result_with_shutdown behaviour and BLE-specific timeout budgeting.
  - Seed connect time-skew acceptance.
- Test fixtures/helpers (conftest.py, tests/helpers.py) now reset new globals: reconnect_task_future, _connect_attempt_lock/condition, _connect_attempt_in_progress, and _callbacks_tearing_down.

Behavior / migration notes
- No public API signature changes.
- connect_meshtastic(...) callers may block briefly while another caller performs a connect (bounded by _CONNECT_ATTEMPT_WAIT_MAX_SECS); this is intentional to avoid duplicate clients.
- Test fixtures and tooling that relied on previous global-reset behaviour should be aware that reconnect_task_future and the new connect-attempt synchronization primitives are now reset by fixtures/helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->