### PR TITLE
Harden startup readiness sequencing and drain completion signaling; refine ping plugin behavior

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -35,7 +35,7 @@ lint:
     - osv-scanner@2.3.5
     - prettier@3.8.1
     - ruff@0.15.9
-    - trufflehog@3.94.2
+    - trufflehog@3.94.3
     - yamllint@1.38.0
   definitions:
     - name: bandit

--- a/scripts/ci/run-mmrelay-meshtasticd-integration.sh
+++ b/scripts/ci/run-mmrelay-meshtasticd-integration.sh
@@ -337,8 +337,12 @@ print_logs_if_needed() {
 	LOGS_PRINTED=true
 	echo "===== MMRelay A log ====="
 	[[ -f ${MMRELAY_LOG_PATH_A} ]] && cat "${MMRELAY_LOG_PATH_A}" || true
+	echo "===== MMRelay A file log ====="
+	[[ -f ${MMRELAY_FILE_LOG_PATH_A} ]] && cat "${MMRELAY_FILE_LOG_PATH_A}" || true
 	echo "===== MMRelay B log ====="
 	[[ -f ${MMRELAY_LOG_PATH_B} ]] && cat "${MMRELAY_LOG_PATH_B}" || true
+	echo "===== MMRelay B file log ====="
+	[[ -f ${MMRELAY_FILE_LOG_PATH_B} ]] && cat "${MMRELAY_FILE_LOG_PATH_B}" || true
 	echo "===== meshtasticd A log ====="
 	[[ -f ${MESHTASTICD_LOG_PATH_A} ]] && cat "${MESHTASTICD_LOG_PATH_A}" || true
 	echo "===== meshtasticd B log ====="

--- a/scripts/ci/run-mmrelay-meshtasticd-integration.sh
+++ b/scripts/ci/run-mmrelay-meshtasticd-integration.sh
@@ -571,7 +571,9 @@ write_observability_report() {
 		echo
 		echo "### Artifacts"
 		echo "- MMRelay A log: \`${MMRELAY_LOG_PATH_A}\`"
+		echo "- MMRelay A file log: \`${MMRELAY_FILE_LOG_PATH_A}\`"
 		echo "- MMRelay B log: \`${MMRELAY_LOG_PATH_B}\`"
+		echo "- MMRelay B file log: \`${MMRELAY_FILE_LOG_PATH_B}\`"
 		echo "- meshtasticd A live log snapshot: \`${mesh_log_a_live}\`"
 		echo "- meshtasticd B live log snapshot: \`${mesh_log_b_live}\`"
 		echo "- meshtasticd A final log: \`${MESHTASTICD_LOG_PATH_A}\`"

--- a/scripts/ci/run-mmrelay-meshtasticd-integration.sh
+++ b/scripts/ci/run-mmrelay-meshtasticd-integration.sh
@@ -2486,6 +2486,7 @@ database:
     wipe_on_restart: false
 logging:
   level: debug
+  log_to_file: true
 EOF_CONFIG
 
 # MMRelay B - Connects to Mesh B
@@ -2526,6 +2527,7 @@ database:
     wipe_on_restart: false
 logging:
   level: debug
+  log_to_file: true
 EOF_CONFIG
 
 # =============================================================================

--- a/scripts/ci/run-mmrelay-meshtasticd-integration.sh
+++ b/scripts/ci/run-mmrelay-meshtasticd-integration.sh
@@ -196,6 +196,8 @@ MMRELAY_CONFIG_PATH_A="${INSTANCE_A_DIR}/config.yaml"
 MMRELAY_CONFIG_PATH_B="${INSTANCE_B_DIR}/config.yaml"
 MMRELAY_HOME_DIR_A="${INSTANCE_A_DATA_DIR}/mmrelay-home"
 MMRELAY_HOME_DIR_B="${INSTANCE_B_DATA_DIR}/mmrelay-home"
+MMRELAY_FILE_LOG_PATH_A="${MMRELAY_HOME_DIR_A}/logs/mmrelay.log"
+MMRELAY_FILE_LOG_PATH_B="${MMRELAY_HOME_DIR_B}/logs/mmrelay.log"
 MMRELAY_DB_PATH_A="${MMRELAY_HOME_DIR_A}/database/meshtastic.sqlite"
 MMRELAY_DB_PATH_B="${MMRELAY_HOME_DIR_B}/database/meshtastic.sqlite"
 MATRIX_RUNTIME_JSON="${SHARED_DIR}/matrix-runtime.json"
@@ -2550,7 +2552,7 @@ MMRELAY_PID_A=$!
 startup_offset_a=0
 wait_for_log_pattern_since \
 	"${MMRELAY_LOG_PATH_A}" \
-	"Listening for inbound Matrix messages..." \
+	"Relay startup complete" \
 	"${startup_offset_a}" \
 	$((10#${MMRELAY_READY_TIMEOUT_SECONDS}))
 echo "MMRelay A is ready (PID ${MMRELAY_PID_A})"
@@ -2566,7 +2568,7 @@ MMRELAY_PID_B=$!
 startup_offset_b=0
 wait_for_log_pattern_since \
 	"${MMRELAY_LOG_PATH_B}" \
-	"Listening for inbound Matrix messages..." \
+	"Relay startup complete" \
 	"${startup_offset_b}" \
 	$((10#${MMRELAY_READY_TIMEOUT_SECONDS}))
 echo "MMRelay B is ready (PID ${MMRELAY_PID_B})"
@@ -2863,13 +2865,13 @@ start_test "Test 7" "Test 7: dm-rcv-basic plugin initialization..."
 
 run_or_fail "dm-rcv-basic did not initialize in relay A" \
 	wait_for_log_pattern_since \
-	"${MMRELAY_LOG_PATH_A}" \
+	"${MMRELAY_FILE_LOG_PATH_A}" \
 	"initialized - forwarding DMs to room: ${ROOM_ID_DM_A}" \
 	0 \
 	45
 run_or_fail "dm-rcv-basic did not initialize in relay B" \
 	wait_for_log_pattern_since \
-	"${MMRELAY_LOG_PATH_B}" \
+	"${MMRELAY_FILE_LOG_PATH_B}" \
 	"initialized - forwarding DMs to room: ${ROOM_ID_DM_B}" \
 	0 \
 	45

--- a/src/mmrelay/constants/plugins.py
+++ b/src/mmrelay/constants/plugins.py
@@ -230,7 +230,7 @@ LOW_BATTERY_THRESHOLD_PERCENT: Final[int] = 10
 
 # Regex patterns
 PING_EXPLICIT_COMMAND_REGEX: Final[re.Pattern[str]] = re.compile(
-    r"(?<!\w)!(ping)(?!\w)", re.IGNORECASE
+    r"!(ping)", re.IGNORECASE
 )
 PING_COMMAND_REGEX: Final[re.Pattern[str]] = re.compile(
     r"(?<!\w)([!?]*)(ping)([!?]*)(?!\w)", re.IGNORECASE

--- a/src/mmrelay/constants/plugins.py
+++ b/src/mmrelay/constants/plugins.py
@@ -229,6 +229,9 @@ TELEMETRY_MAX_DATA_ROWS: Final[int] = 50
 LOW_BATTERY_THRESHOLD_PERCENT: Final[int] = 10
 
 # Regex patterns
+PING_EXPLICIT_COMMAND_REGEX: Final[re.Pattern[str]] = re.compile(
+    r"(?<!\w)!(ping)(?!\w)", re.IGNORECASE
+)
 PING_COMMAND_REGEX: Final[re.Pattern[str]] = re.compile(
     r"(?<!\w)([!?]*)(ping)([!?]*)(?!\w)", re.IGNORECASE
 )

--- a/src/mmrelay/constants/plugins.py
+++ b/src/mmrelay/constants/plugins.py
@@ -230,7 +230,7 @@ LOW_BATTERY_THRESHOLD_PERCENT: Final[int] = 10
 
 # Regex patterns
 PING_EXPLICIT_COMMAND_REGEX: Final[re.Pattern[str]] = re.compile(
-    r"!(ping)", re.IGNORECASE
+    r"(?<!\w)!(ping)(?!\w)", re.IGNORECASE
 )
 PING_COMMAND_REGEX: Final[re.Pattern[str]] = re.compile(
     r"(?<!\w)([!?]*)(ping)([!?]*)(?!\w)", re.IGNORECASE

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -1081,12 +1081,27 @@ async def main(config: dict[str, Any]) -> None:
                         pass
                     else:
                         await asyncio.to_thread(_write_ready_file)
-                        logger.info("Relay startup complete")
-                        startup_ready_published = True
-                        if _ready_heartbeat_seconds > 0 and ready_task is None:
-                            ready_task = asyncio.create_task(
-                                _ready_heartbeat(shutdown_event)
-                            )
+                        if shutdown_event.is_set():
+                            # Avoid publishing stale readiness if shutdown raced
+                            # with ready-file creation.
+                            await asyncio.to_thread(_remove_ready_file)
+                            if not startup_ready_skipped_logged:
+                                matrix_logger.warning(
+                                    "Skipping readiness publication because shutdown was requested during startup"
+                                )
+                                startup_ready_skipped_logged = True
+                        elif sync_task.done():
+                            # Sync failed while ready-file write was in flight.
+                            # Remove stale readiness marker and let failure
+                            # handling below process the sync outcome.
+                            await asyncio.to_thread(_remove_ready_file)
+                        else:
+                            logger.info("Relay startup complete")
+                            startup_ready_published = True
+                            if _ready_heartbeat_seconds > 0 and ready_task is None:
+                                ready_task = asyncio.create_task(
+                                    _ready_heartbeat(shutdown_event)
+                                )
 
                 shutdown_task = asyncio.create_task(shutdown_event.wait())
 

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -222,7 +222,10 @@ async def _ready_heartbeat(shutdown_event: asyncio.Event) -> None:
             continue
 
 
-async def _wait_for_startup_drain_completion(shutdown_event: asyncio.Event) -> None:
+async def _wait_for_startup_drain_completion(
+    shutdown_event: asyncio.Event,
+    sync_task: asyncio.Task[Any] | None = None,
+) -> None:
     """
     Wait for Meshtastic startup drain completion or shutdown.
 
@@ -237,6 +240,8 @@ async def _wait_for_startup_drain_completion(shutdown_event: asyncio.Event) -> N
     if not isinstance(drain_complete_event, threading.Event):
         return
     while not drain_complete_event.is_set() and not shutdown_event.is_set():
+        if sync_task is not None and sync_task.done():
+            return
         try:
             await asyncio.wait_for(
                 shutdown_event.wait(),
@@ -1064,13 +1069,20 @@ async def main(config: dict[str, Any]) -> None:
                 )
 
                 if not startup_ready_published:
-                    await _wait_for_startup_drain_completion(shutdown_event)
+                    await _wait_for_startup_drain_completion(
+                        shutdown_event,
+                        sync_task=sync_task,
+                    )
                     if shutdown_event.is_set():
                         if not startup_ready_skipped_logged:
                             matrix_logger.warning(
                                 "Skipping readiness publication because shutdown was requested during startup"
                             )
                             startup_ready_skipped_logged = True
+                    elif sync_task.done():
+                        # Do not publish readiness after an early sync failure.
+                        # The sync outcome is handled by the standard loop below.
+                        pass
                     else:
                         _write_ready_file()
                         logger.info("Relay startup complete")
@@ -1099,7 +1111,7 @@ async def main(config: dict[str, Any]) -> None:
                     )
 
                 if shutdown_event.is_set():
-                    matrix_logger.info("Shutdown event detected. Stopping sync loop...")
+                    matrix_logger.info("Shutdown event detected. Stopping sync loop")
                     break
 
                 # Check if sync_task completed with an exception

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -97,6 +97,7 @@ _ready_heartbeat_seconds_raw = os.environ.get(
 )
 _PLUGIN_SHUTDOWN_TIMEOUT_SECONDS = PLUGIN_SHUTDOWN_TIMEOUT_SECONDS
 _MESSAGE_QUEUE_SHUTDOWN_TIMEOUT_SECONDS = MESSAGE_QUEUE_SHUTDOWN_TIMEOUT_SECONDS
+_STARTUP_DRAIN_WAIT_POLL_SECS = 0.1
 try:
     _ready_heartbeat_seconds = int(_ready_heartbeat_seconds_raw)
 except (TypeError, ValueError):
@@ -216,6 +217,30 @@ async def _ready_heartbeat(shutdown_event: asyncio.Event) -> None:
             await asyncio.wait_for(
                 shutdown_event.wait(),
                 timeout=_ready_heartbeat_seconds,
+            )
+        except asyncio.TimeoutError:
+            continue
+
+
+async def _wait_for_startup_drain_completion(shutdown_event: asyncio.Event) -> None:
+    """
+    Wait for Meshtastic startup drain completion or shutdown.
+
+    Uses bounded waits so async tests remain deterministic under inline loop
+    executor patches.
+    """
+    drain_complete_event = getattr(
+        meshtastic_utils,
+        "_relay_startup_drain_complete_event",
+        None,
+    )
+    if not isinstance(drain_complete_event, threading.Event):
+        return
+    while not drain_complete_event.is_set() and not shutdown_event.is_set():
+        try:
+            await asyncio.wait_for(
+                shutdown_event.wait(),
+                timeout=_STARTUP_DRAIN_WAIT_POLL_SECS,
             )
         except asyncio.TimeoutError:
             continue
@@ -728,7 +753,7 @@ async def main(config: dict[str, Any]) -> None:
             await join_matrix_room(matrix_client, room["id"])
 
         # Register the message callback for Matrix
-        matrix_logger.info("Listening for inbound Matrix messages...")
+        matrix_logger.info("Listening for inbound Matrix messages")
         matrix_client.add_event_callback(
             cast(Any, on_room_message),
             cast(
@@ -1005,10 +1030,13 @@ async def main(config: dict[str, Any]) -> None:
         nodedb_refresh_interval_seconds = (
             meshtastic_utils.get_nodedb_refresh_interval_seconds(config)
         )
+        startup_ready_published = False
+        startup_ready_skipped_logged = False
         if shutdown_event.is_set():
             matrix_logger.warning(
                 "Skipping readiness publication because shutdown was requested during startup"
             )
+            startup_ready_skipped_logged = True
         else:
             node_name_refresh_task = asyncio.create_task(
                 _node_name_refresh_supervisor(
@@ -1018,19 +1046,11 @@ async def main(config: dict[str, Any]) -> None:
 
             # Ensure message queue processor is started now that event loop is running.
             get_message_queue().ensure_processor_started()
-
-            # Publish readiness only after startup wiring in this section is complete.
-            _write_ready_file()
-            logger.info("Relay startup complete")
-
-            # Start heartbeat AFTER readiness is confirmed
-            if _ready_heartbeat_seconds > 0:
-                ready_task = asyncio.create_task(_ready_heartbeat(shutdown_event))
         while not shutdown_event.is_set():
             sync_task: asyncio.Task[Any] | None = None
             shutdown_task: asyncio.Task[Any] | None = None
             try:
-                matrix_logger.info("Starting Matrix sync loop...")
+                matrix_logger.info("Starting Matrix sync loop")
                 sync_filter = getattr(matrix_client, "mmrelay_sync_filter", None)
                 first_sync_filter = getattr(
                     matrix_client, "mmrelay_first_sync_filter", None
@@ -1042,6 +1062,23 @@ async def main(config: dict[str, Any]) -> None:
                         first_sync_filter=first_sync_filter,
                     )
                 )
+
+                if not startup_ready_published:
+                    await _wait_for_startup_drain_completion(shutdown_event)
+                    if shutdown_event.is_set():
+                        if not startup_ready_skipped_logged:
+                            matrix_logger.warning(
+                                "Skipping readiness publication because shutdown was requested during startup"
+                            )
+                            startup_ready_skipped_logged = True
+                    else:
+                        _write_ready_file()
+                        logger.info("Relay startup complete")
+                        startup_ready_published = True
+                        if _ready_heartbeat_seconds > 0 and ready_task is None:
+                            ready_task = asyncio.create_task(
+                                _ready_heartbeat(shutdown_event)
+                            )
 
                 shutdown_task = asyncio.create_task(shutdown_event.wait())
 

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -1080,7 +1080,7 @@ async def main(config: dict[str, Any]) -> None:
                         # The sync outcome is handled by the standard loop below.
                         pass
                     else:
-                        _write_ready_file()
+                        await asyncio.to_thread(_write_ready_file)
                         logger.info("Relay startup complete")
                         startup_ready_published = True
                         if _ready_heartbeat_seconds > 0 and ready_task is None:

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -232,12 +232,8 @@ async def _wait_for_startup_drain_completion(
     Uses bounded waits so async tests remain deterministic under inline loop
     executor patches.
     """
-    drain_complete_event = getattr(
-        meshtastic_utils,
-        "_relay_startup_drain_complete_event",
-        None,
-    )
-    if not isinstance(drain_complete_event, threading.Event):
+    drain_complete_event = meshtastic_utils.get_startup_drain_complete_event()
+    if drain_complete_event is None:
         return
     while not drain_complete_event.is_set() and not shutdown_event.is_set():
         if sync_task is not None and sync_task.done():

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -221,6 +221,7 @@ def _rollback_connect_attempt_state(
                 startup_drain_timer_to_cancel = facade._relay_startup_drain_expiry_timer
                 facade._relay_startup_drain_expiry_timer = None
                 facade._relay_startup_drain_deadline_monotonic_secs = None
+                facade._relay_startup_drain_complete_event.set()
                 if startup_drain_applied_for_this_connect:
                     facade._startup_packet_drain_applied = False
             if reconnect_bootstrap_armed_for_this_connect:
@@ -1100,6 +1101,7 @@ def _connect_meshtastic_impl(
                                 facade._relay_connection_started_monotonic_secs
                                 + facade.RECONNECT_PRESTART_BOOTSTRAP_WINDOW_SECS
                             )
+                            facade._relay_startup_drain_complete_event.set()
                             reconnect_bootstrap_armed_for_this_connect = True
                             timing_mode = "reconnect"
                         facade.logger.debug(
@@ -1210,6 +1212,7 @@ def _connect_meshtastic_impl(
                             facade._startup_packet_drain_applied = True
                             startup_drain_applied_for_this_connect = True
                             startup_drain_armed_for_this_connect = True
+                            facade._relay_startup_drain_complete_event.clear()
                     if (
                         startup_drain_armed_for_this_connect
                         and startup_drain_deadline is not None

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -189,6 +189,7 @@ def _rollback_connect_attempt_state(
     """
     _lock_ctx = contextlib.nullcontext() if lock_held else facade.meshtastic_lock
     startup_drain_timer_to_cancel: Any = None
+    mark_startup_drain_complete = False
     if client is not None and (
         client_assigned_for_this_connect or client is facade.meshtastic_iface
     ):
@@ -221,13 +222,16 @@ def _rollback_connect_attempt_state(
                 startup_drain_timer_to_cancel = facade._relay_startup_drain_expiry_timer
                 facade._relay_startup_drain_expiry_timer = None
                 facade._relay_startup_drain_deadline_monotonic_secs = None
-                facade._relay_startup_drain_complete_event.set()
+                mark_startup_drain_complete = True
                 if startup_drain_applied_for_this_connect:
                     facade._startup_packet_drain_applied = False
             if reconnect_bootstrap_armed_for_this_connect:
                 facade._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = (
                     None
                 )
+    if mark_startup_drain_complete:
+        # Keep lock scope focused on state mutation; event signaling is non-blocking.
+        facade._relay_startup_drain_complete_event.set()
     if startup_drain_timer_to_cancel is not None:
         with contextlib.suppress(AttributeError, RuntimeError, TypeError):
             startup_drain_timer_to_cancel.cancel()
@@ -479,6 +483,7 @@ def _connect_meshtastic_impl(
         startup_drain_armed_for_this_connect = False
         startup_drain_applied_for_this_connect = False
         reconnect_bootstrap_armed_for_this_connect = False
+        signal_startup_drain_complete_for_this_connect = False
         client_assigned_for_this_connect = False
 
         client = None
@@ -1101,7 +1106,7 @@ def _connect_meshtastic_impl(
                                 facade._relay_connection_started_monotonic_secs
                                 + facade.RECONNECT_PRESTART_BOOTSTRAP_WINDOW_SECS
                             )
-                            facade._relay_startup_drain_complete_event.set()
+                            signal_startup_drain_complete_for_this_connect = True
                             reconnect_bootstrap_armed_for_this_connect = True
                             timing_mode = "reconnect"
                         facade.logger.debug(
@@ -1112,6 +1117,9 @@ def _connect_meshtastic_impl(
                             facade._relay_startup_drain_deadline_monotonic_secs,
                             facade._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs,
                         )
+                if signal_startup_drain_complete_for_this_connect:
+                    # Signal completion after clock-skew state updates are committed.
+                    facade._relay_startup_drain_complete_event.set()
 
                 # Publish the active client only after per-connection timing state
                 # has been reset, so callbacks cannot observe stale skew windows.

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1213,6 +1213,7 @@ def _connect_meshtastic_impl(
                 # Arm startup drain only once setup completes, so the full drain
                 # interval is available when receive handling becomes active.
                 startup_drain_deadline: float | None = None
+                clear_startup_drain_complete_event = False
                 if startup_drain_pending_for_this_connect:
                     with facade._relay_rx_time_clock_skew_lock:
                         if not facade._startup_packet_drain_applied:
@@ -1226,11 +1227,14 @@ def _connect_meshtastic_impl(
                             facade._startup_packet_drain_applied = True
                             startup_drain_applied_for_this_connect = True
                             startup_drain_armed_for_this_connect = True
-                            startup_drain_complete_event = (
-                                facade.get_startup_drain_complete_event()
-                            )
-                            if startup_drain_complete_event is not None:
-                                startup_drain_complete_event.clear()
+                            clear_startup_drain_complete_event = True
+                    if clear_startup_drain_complete_event:
+                        # Keep lock scope focused on shared timing state updates.
+                        startup_drain_complete_event = (
+                            facade.get_startup_drain_complete_event()
+                        )
+                        if startup_drain_complete_event is not None:
+                            startup_drain_complete_event.clear()
                     if (
                         startup_drain_armed_for_this_connect
                         and startup_drain_deadline is not None

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -231,7 +231,9 @@ def _rollback_connect_attempt_state(
                 )
     if mark_startup_drain_complete:
         # Keep lock scope focused on state mutation; event signaling is non-blocking.
-        facade._relay_startup_drain_complete_event.set()
+        startup_drain_complete_event = facade.get_startup_drain_complete_event()
+        if startup_drain_complete_event is not None:
+            startup_drain_complete_event.set()
     if startup_drain_timer_to_cancel is not None:
         with contextlib.suppress(AttributeError, RuntimeError, TypeError):
             startup_drain_timer_to_cancel.cancel()
@@ -1119,7 +1121,11 @@ def _connect_meshtastic_impl(
                         )
                 if signal_startup_drain_complete_for_this_connect:
                     # Signal completion after clock-skew state updates are committed.
-                    facade._relay_startup_drain_complete_event.set()
+                    startup_drain_complete_event = (
+                        facade.get_startup_drain_complete_event()
+                    )
+                    if startup_drain_complete_event is not None:
+                        startup_drain_complete_event.set()
 
                 # Publish the active client only after per-connection timing state
                 # has been reset, so callbacks cannot observe stale skew windows.
@@ -1220,7 +1226,11 @@ def _connect_meshtastic_impl(
                             facade._startup_packet_drain_applied = True
                             startup_drain_applied_for_this_connect = True
                             startup_drain_armed_for_this_connect = True
-                            facade._relay_startup_drain_complete_event.clear()
+                            startup_drain_complete_event = (
+                                facade.get_startup_drain_complete_event()
+                            )
+                            if startup_drain_complete_event is not None:
+                                startup_drain_complete_event.clear()
                     if (
                         startup_drain_armed_for_this_connect
                         and startup_drain_deadline is not None

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1103,14 +1103,30 @@ def _connect_meshtastic_impl(
                             startup_drain_pending_for_this_connect = True
                             timing_mode = "startup_pending"
                         else:
-                            facade._relay_startup_drain_deadline_monotonic_secs = None
-                            facade._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = (
-                                facade._relay_connection_started_monotonic_secs
-                                + facade.RECONNECT_PRESTART_BOOTSTRAP_WINDOW_SECS
+                            existing_deadline = (
+                                facade._relay_startup_drain_deadline_monotonic_secs
                             )
-                            signal_startup_drain_complete_for_this_connect = True
-                            reconnect_bootstrap_armed_for_this_connect = True
-                            timing_mode = "reconnect"
+                            active_startup_drain = (
+                                existing_deadline is not None
+                                and existing_deadline > facade.time.monotonic()
+                            )
+                            if active_startup_drain:
+                                facade._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = (
+                                    facade._relay_connection_started_monotonic_secs
+                                    + facade.RECONNECT_PRESTART_BOOTSTRAP_WINDOW_SECS
+                                )
+                                timing_mode = "startup_pending_reconnect"
+                            else:
+                                facade._relay_startup_drain_deadline_monotonic_secs = (
+                                    None
+                                )
+                                facade._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = (
+                                    facade._relay_connection_started_monotonic_secs
+                                    + facade.RECONNECT_PRESTART_BOOTSTRAP_WINDOW_SECS
+                                )
+                                signal_startup_drain_complete_for_this_connect = True
+                                reconnect_bootstrap_armed_for_this_connect = True
+                                timing_mode = "reconnect"
                         facade.logger.debug(
                             "Initialized connection timing state mode=%s start=%.3f monotonic_start=%.3f startup_drain_deadline=%s reconnect_bootstrap_deadline=%s",
                             timing_mode,

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1115,6 +1115,7 @@ def _connect_meshtastic_impl(
                                     facade._relay_connection_started_monotonic_secs
                                     + facade.RECONNECT_PRESTART_BOOTSTRAP_WINDOW_SECS
                                 )
+                                reconnect_bootstrap_armed_for_this_connect = True
                                 timing_mode = "startup_pending_reconnect"
                             else:
                                 facade._relay_startup_drain_deadline_monotonic_secs = (

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -206,7 +206,8 @@ def _schedule_startup_drain_deadline_cleanup(startup_drain_deadline: float) -> N
             _schedule_startup_drain_deadline_cleanup(reschedule_deadline)
             return
         if should_log_drain_end:
-            facade.logger.debug("Startup drain window has ended — accepting packets")
+            facade._relay_startup_drain_complete_event.set()
+            facade.logger.debug("Startup drain window has ended - accepting packets")
 
     delay_secs = max(0.0, startup_drain_deadline - facade.time.monotonic())
     timer = threading.Timer(delay_secs, _cleanup)
@@ -223,6 +224,7 @@ def _schedule_startup_drain_deadline_cleanup(startup_drain_deadline: float) -> N
         with facade._relay_rx_time_clock_skew_lock:
             if facade._relay_startup_drain_expiry_timer is timer:
                 facade._relay_startup_drain_expiry_timer = None
+        facade._relay_startup_drain_complete_event.set()
         facade.logger.debug(
             "Failed to schedule startup drain expiry cleanup timer",
             exc_info=exc,
@@ -508,7 +510,8 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
                 facade._relay_startup_drain_deadline_monotonic_secs = None
                 should_log_drain_end = True
         if should_log_drain_end:
-            facade.logger.debug("Startup drain window has ended — accepting packets")
+            facade._relay_startup_drain_complete_event.set()
+            facade.logger.debug("Startup drain window has ended - accepting packets")
 
     # Seed clock skew from the first non-health-probe packet with a valid
     # rxTime so that the cutoff works even when health checks are disabled.

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -41,6 +41,12 @@ def _get_iterable_matrix_rooms() -> Iterable[Any]:
     )
 
 
+def _signal_startup_drain_complete() -> None:
+    startup_drain_complete_event = facade.get_startup_drain_complete_event()
+    if startup_drain_complete_event is not None:
+        startup_drain_complete_event.set()
+
+
 def _derive_disconnect_detection_source(
     interface: Any, detection_source: str, topic: Any
 ) -> str:
@@ -206,7 +212,7 @@ def _schedule_startup_drain_deadline_cleanup(startup_drain_deadline: float) -> N
             _schedule_startup_drain_deadline_cleanup(reschedule_deadline)
             return
         if should_log_drain_end:
-            facade._relay_startup_drain_complete_event.set()
+            _signal_startup_drain_complete()
             facade.logger.debug("Startup drain window has ended - accepting packets")
 
     delay_secs = max(0.0, startup_drain_deadline - facade.time.monotonic())
@@ -224,7 +230,7 @@ def _schedule_startup_drain_deadline_cleanup(startup_drain_deadline: float) -> N
         with facade._relay_rx_time_clock_skew_lock:
             if facade._relay_startup_drain_expiry_timer is timer:
                 facade._relay_startup_drain_expiry_timer = None
-        facade._relay_startup_drain_complete_event.set()
+        _signal_startup_drain_complete()
         facade.logger.debug(
             "Failed to schedule startup drain expiry cleanup timer",
             exc_info=exc,
@@ -510,7 +516,7 @@ def on_meshtastic_message(packet: dict[str, Any], interface: Any) -> None:
                 facade._relay_startup_drain_deadline_monotonic_secs = None
                 should_log_drain_end = True
         if should_log_drain_end:
-            facade._relay_startup_drain_complete_event.set()
+            _signal_startup_drain_complete()
             facade.logger.debug("Startup drain window has ended - accepting packets")
 
     # Seed clock skew from the first non-health-probe packet with a valid

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -227,15 +227,18 @@ def _schedule_startup_drain_deadline_cleanup(startup_drain_deadline: float) -> N
     try:
         timer.start()
     except Exception as exc:  # noqa: BLE001 - best-effort timer setup
+        should_signal_startup_drain_complete = False
         with facade._relay_rx_time_clock_skew_lock:
             if facade._relay_startup_drain_expiry_timer is timer:
                 facade._relay_startup_drain_expiry_timer = None
-            if (
-                facade._relay_startup_drain_deadline_monotonic_secs
-                == startup_drain_deadline
-            ):
-                facade._relay_startup_drain_deadline_monotonic_secs = None
-        _signal_startup_drain_complete()
+                if (
+                    facade._relay_startup_drain_deadline_monotonic_secs
+                    == startup_drain_deadline
+                ):
+                    facade._relay_startup_drain_deadline_monotonic_secs = None
+                    should_signal_startup_drain_complete = True
+        if should_signal_startup_drain_complete:
+            _signal_startup_drain_complete()
         facade.logger.debug(
             "Failed to schedule startup drain expiry cleanup timer",
             exc_info=exc,

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -230,6 +230,11 @@ def _schedule_startup_drain_deadline_cleanup(startup_drain_deadline: float) -> N
         with facade._relay_rx_time_clock_skew_lock:
             if facade._relay_startup_drain_expiry_timer is timer:
                 facade._relay_startup_drain_expiry_timer = None
+            if (
+                facade._relay_startup_drain_deadline_monotonic_secs
+                == startup_drain_deadline
+            ):
+                facade._relay_startup_drain_deadline_monotonic_secs = None
         _signal_startup_drain_complete()
         facade.logger.debug(
             "Failed to schedule startup drain expiry cleanup timer",

--- a/src/mmrelay/meshtastic/packet_routing.py
+++ b/src/mmrelay/meshtastic/packet_routing.py
@@ -300,12 +300,6 @@ def classify_packet(
         if detection_sensor_enabled:
             return PacketAction.RELAY
 
-        logger.debug(
-            "Packet %s classified as %s; skipping Matrix chat relay because "
-            "meshtastic.detection_sensor is disabled.",
-            portnum_name,
-            PacketAction.PLUGIN_ONLY,
-        )
         return PacketAction.PLUGIN_ONLY
 
     if is_text_message:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -194,6 +194,9 @@ _relay_rx_time_clock_skew_lock = threading.Lock()
 _relay_startup_drain_deadline_monotonic_secs: float | None = None
 # Timer used to decouple startup-drain expiry from packet arrival.
 _relay_startup_drain_expiry_timer: threading.Timer | None = None
+# Signals whether startup drain has completed for readiness publication.
+_relay_startup_drain_complete_event = threading.Event()
+_relay_startup_drain_complete_event.set()
 # Only apply startup drain on the first successful process-lifetime connect.
 _startup_packet_drain_applied = False
 # On reconnects, allow exactly one bounded pre-start skew bootstrap packet

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -204,6 +204,12 @@ _startup_packet_drain_applied = False
 _relay_reconnect_prestart_bootstrap_deadline_monotonic_secs: float | None = None
 
 
+def get_startup_drain_complete_event() -> threading.Event | None:
+    """Return the startup-drain completion event used by readiness coordination."""
+    event = _relay_startup_drain_complete_event
+    return event if isinstance(event, threading.Event) else None
+
+
 # Global variables for the Meshtastic connection and event loop management
 meshtastic_client = None
 # Session guard to reject callbacks emitted by stale interfaces after reconnect.

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -206,6 +206,8 @@ _relay_reconnect_prestart_bootstrap_deadline_monotonic_secs: float | None = None
 
 def get_startup_drain_complete_event() -> threading.Event | None:
     """Return the startup-drain completion event used by readiness coordination."""
+    # Defensive guard: tests intentionally monkeypatch facade globals and may
+    # temporarily replace this attribute with non-Event sentinels.
     event = _relay_startup_drain_complete_event
     return event if isinstance(event, threading.Event) else None
 

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -137,7 +137,10 @@ class Plugin(BasePlugin):
             return False
 
         self.logger.info(
-            f"Processing message from {longname} on channel {channel} with plugin '{self.plugin_name}'"
+            "Processing message from %s on channel %s with plugin '%s'",
+            longname,
+            channel,
+            self.plugin_name,
         )
 
         total_punc_length = len(pre_punc) + len(post_punc)
@@ -155,6 +158,9 @@ class Plugin(BasePlugin):
         from_id = packet.get("fromId")
 
         if is_direct_message:
+            if not from_id:
+                self.logger.warning("Direct message missing fromId; cannot reply")
+                return True
             await asyncio.to_thread(
                 meshtastic_client.sendText,
                 text=reply_message,

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -59,6 +59,7 @@ def match_case(source: str, target: str) -> str:
 class Plugin(BasePlugin):
     plugin_name = "ping"
     is_core_plugin = True
+    _invalid_mimic_mode_warned: bool = False
 
     @property
     def description(self) -> str:
@@ -70,7 +71,7 @@ class Plugin(BasePlugin):
             return mimic_mode
 
         # Keep invalid config warnings low-noise while still surfacing operator errors.
-        if not getattr(self, "_invalid_mimic_mode_warned", False):
+        if not self._invalid_mimic_mode_warned:
             self.logger.warning(
                 "Invalid ping.mimic_mode value %r; expected boolean. Defaulting to false.",
                 mimic_mode,

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -1,8 +1,6 @@
 import asyncio
 from typing import Any
 
-from meshtastic.mesh_interface import BROADCAST_NUM
-
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
 from nio import (
     MatrixRoom,
@@ -68,7 +66,17 @@ class Plugin(BasePlugin):
 
     def get_mimic_mode(self) -> bool:
         mimic_mode = self.config.get("mimic_mode", False)
-        return isinstance(mimic_mode, bool) and mimic_mode
+        if isinstance(mimic_mode, bool):
+            return mimic_mode
+
+        # Keep invalid config warnings low-noise while still surfacing operator errors.
+        if not getattr(self, "_invalid_mimic_mode_warned", False):
+            self.logger.warning(
+                "Invalid ping.mimic_mode value %r; expected boolean. Defaulting to false.",
+                mimic_mode,
+            )
+            self._invalid_mimic_mode_warned = True
+        return False
 
     async def handle_meshtastic_message(
         self,
@@ -122,12 +130,7 @@ class Plugin(BasePlugin):
 
         my_id = meshtastic_client.myInfo.my_node_num
 
-        if to_id == my_id:
-            is_direct_message = True
-        elif to_id == BROADCAST_NUM:
-            is_direct_message = False
-        else:
-            is_direct_message = False
+        is_direct_message = to_id == my_id
 
         if not self.is_channel_enabled(channel, is_direct_message=is_direct_message):
             return False

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -148,13 +148,13 @@ class Plugin(BasePlugin):
 
         await asyncio.sleep(self.get_response_delay())
 
-        fromId = packet.get("fromId")
+        from_id = packet.get("fromId")
 
         if is_direct_message:
             await asyncio.to_thread(
                 meshtastic_client.sendText,
                 text=reply_message,
-                destinationId=fromId,
+                destinationId=from_id,
             )
         else:
             await asyncio.to_thread(

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -64,10 +64,11 @@ class Plugin(BasePlugin):
 
     @property
     def description(self) -> str:
-        return "Check connectivity with the relay or respond to pings over the mesh"
+        return "Check connectivity with the relay; optional mimic mode responds to mesh pings"
 
     def get_mimic_mode(self) -> bool:
-        return bool(self.config.get("mimic_mode", False))
+        mimic_mode = self.config.get("mimic_mode", False)
+        return isinstance(mimic_mode, bool) and mimic_mode
 
     async def handle_meshtastic_message(
         self,
@@ -100,7 +101,7 @@ class Plugin(BasePlugin):
             matched_text = match.group(2)
             post_punc = match.group(3)
         else:
-            explicit_match = PING_EXPLICIT_COMMAND_REGEX.search(message)
+            explicit_match = PING_EXPLICIT_COMMAND_REGEX.fullmatch(message)
             if not explicit_match:
                 return False
             matched_text = explicit_match.group(1)

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -99,7 +99,8 @@ class Plugin(BasePlugin):
             return False
 
         message = packet["decoded"]["text"].strip()
-        channel = packet.get("channel", DEFAULT_CHANNEL)
+        raw_channel = packet.get("channel")
+        channel = DEFAULT_CHANNEL if raw_channel is None else raw_channel
 
         mimic_mode = self.get_mimic_mode()
 

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -112,7 +112,7 @@ class Plugin(BasePlugin):
 
         meshtastic_client = await asyncio.to_thread(connect_meshtastic)
 
-        toId = packet.get("to")
+        to_id = packet.get("to")
         if not meshtastic_client:
             self.logger.warning("Meshtastic client unavailable; skipping ping")
             return True
@@ -122,9 +122,9 @@ class Plugin(BasePlugin):
 
         my_id = meshtastic_client.myInfo.my_node_num
 
-        if toId == my_id:
+        if to_id == my_id:
             is_direct_message = True
-        elif toId == BROADCAST_NUM:
+        elif to_id == BROADCAST_NUM:
             is_direct_message = False
         else:
             is_direct_message = False

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -18,7 +18,11 @@ from mmrelay.constants.messages import (
     PING_MATRIX_RESPONSE,
     PORTNUM_TEXT_MESSAGE_APP,
 )
-from mmrelay.constants.plugins import MAX_PUNCTUATION_LENGTH, PING_COMMAND_REGEX
+from mmrelay.constants.plugins import (
+    MAX_PUNCTUATION_LENGTH,
+    PING_COMMAND_REGEX,
+    PING_EXPLICIT_COMMAND_REGEX,
+)
 from mmrelay.plugins.base_plugin import BasePlugin
 
 
@@ -60,13 +64,10 @@ class Plugin(BasePlugin):
 
     @property
     def description(self) -> str:
-        """
-        Short human-readable description of the plugin's purpose.
-
-        Returns:
-            A single-line string describing the plugin: "Check connectivity with the relay or respond to pings over the mesh"
-        """
         return "Check connectivity with the relay or respond to pings over the mesh"
+
+    def get_mimic_mode(self) -> bool:
+        return bool(self.config.get("mimic_mode", False))
 
     async def handle_meshtastic_message(
         self,
@@ -75,21 +76,6 @@ class Plugin(BasePlugin):
         longname: str,
         meshnet_name: str,
     ) -> bool:
-        """
-        Responds to an incoming Meshtastic "ping" message with a case-matched "pong" when permitted by addressing and channel rules.
-
-        Matches "ping" with optional surrounding punctuation (case-insensitive) in packet["decoded"]["text"]; if matched and the channel is enabled, sends a reply that preserves the punctuation and letter case pattern of the trigger, or "Pong..." when surrounding punctuation is excessively long. If the Meshtastic client or its `myInfo` is unavailable the function logs a warning and returns `True` to suppress further handling.
-
-        Parameters:
-            packet (dict[str, Any]): Incoming Meshtastic packet. Expected to contain `decoded["text"]`; may include `decoded["portnum"]`, `channel`, `to`, and `fromId`.
-            formatted_message (str): Preformatted representation of the message (kept for compatibility; not used).
-            longname (str): Human-readable sender identifier used for logging.
-            meshnet_name (str): Name of the mesh network where the message originated (kept for compatibility; not used).
-
-        Returns:
-            bool: `True` if the handler processed the packet or intentionally suppressed processing (e.g., client/myInfo unavailable); `False` if the packet was not handled (no match, disallowed port, or channel disabled).
-        """
-        # Keep parameter names for compatibility with keyword calls in tests.
         _ = formatted_message, meshnet_name
         if "decoded" not in packet or "text" not in packet["decoded"]:
             return False
@@ -102,15 +88,24 @@ class Plugin(BasePlugin):
             return False
 
         message = packet["decoded"]["text"].strip()
-        channel = packet.get(
-            "channel", DEFAULT_CHANNEL
-        )  # Default to channel 0 if not provided
+        channel = packet.get("channel", DEFAULT_CHANNEL)
 
-        # Updated regex to match optional punctuation before and after "ping"
-        match = PING_COMMAND_REGEX.search(message)
+        mimic_mode = self.get_mimic_mode()
 
-        if not match:
-            return False
+        if mimic_mode:
+            match = PING_COMMAND_REGEX.search(message)
+            if not match:
+                return False
+            pre_punc = match.group(1)
+            matched_text = match.group(2)
+            post_punc = match.group(3)
+        else:
+            explicit_match = PING_EXPLICIT_COMMAND_REGEX.search(message)
+            if not explicit_match:
+                return False
+            matched_text = explicit_match.group(1)
+            pre_punc = ""
+            post_punc = ""
 
         from mmrelay.meshtastic_utils import connect_meshtastic
 
@@ -124,56 +119,43 @@ class Plugin(BasePlugin):
             self.logger.warning("Meshtastic client myInfo unavailable; skipping ping")
             return True
 
-        myId = meshtastic_client.myInfo.my_node_num  # Get relay's own node number
+        myId = meshtastic_client.myInfo.my_node_num
 
         if toId == myId:
-            # Direct message to us
             is_direct_message = True
         elif toId == BROADCAST_NUM:
             is_direct_message = False
         else:
-            # Some radios omit/zero-fill destination; treat as broadcast to avoid dropping valid pings
             is_direct_message = False
 
         if not self.is_channel_enabled(channel, is_direct_message=is_direct_message):
             return False
 
-        # Log that the plugin is processing the message
         self.logger.info(
             f"Processing message from {longname} on channel {channel} with plugin '{self.plugin_name}'"
         )
 
-        # Extract matched text and punctuation
-        pre_punc = match.group(1)
-        matched_text = match.group(2)
-        post_punc = match.group(3)
-
         total_punc_length = len(pre_punc) + len(post_punc)
 
-        # Define base response
         base_response = match_case(matched_text, "pong")
 
-        # Construct reply message
         reply_message = (
             PING_FALLBACK_RESPONSE
             if total_punc_length > MAX_PUNCTUATION_LENGTH
             else pre_punc + base_response + post_punc
         )
 
-        # Wait for the response delay
         await asyncio.sleep(self.get_response_delay())
 
         fromId = packet.get("fromId")
 
         if is_direct_message:
-            # Send reply as DM
             await asyncio.to_thread(
                 meshtastic_client.sendText,
                 text=reply_message,
                 destinationId=fromId,
             )
         else:
-            # Send reply back to the same channel
             await asyncio.to_thread(
                 meshtastic_client.sendText,
                 text=reply_message,

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -94,7 +94,7 @@ class Plugin(BasePlugin):
         mimic_mode = self.get_mimic_mode()
 
         if mimic_mode:
-            match = PING_COMMAND_REGEX.search(message)
+            match = PING_COMMAND_REGEX.fullmatch(message)
             if not match:
                 return False
             pre_punc = match.group(1)
@@ -120,9 +120,9 @@ class Plugin(BasePlugin):
             self.logger.warning("Meshtastic client myInfo unavailable; skipping ping")
             return True
 
-        myId = meshtastic_client.myInfo.my_node_num
+        my_id = meshtastic_client.myInfo.my_node_num
 
-        if toId == myId:
+        if toId == my_id:
             is_direct_message = True
         elif toId == BROADCAST_NUM:
             is_direct_message = False

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
+from meshtastic.mesh_interface import BROADCAST_NUM
 from nio import (
     MatrixRoom,
     ReactionEvent,
@@ -131,7 +132,17 @@ class Plugin(BasePlugin):
 
         my_id = meshtastic_client.myInfo.my_node_num
 
-        is_direct_message = to_id == my_id
+        if to_id == my_id:
+            is_direct_message = True
+        elif to_id is None or to_id == BROADCAST_NUM:
+            is_direct_message = False
+        else:
+            return False
+
+        from_id = packet.get("fromId")
+        if is_direct_message and not from_id:
+            self.logger.warning("Direct message missing fromId; cannot reply")
+            return True
 
         if not self.is_channel_enabled(channel, is_direct_message=is_direct_message):
             return False
@@ -155,12 +166,7 @@ class Plugin(BasePlugin):
 
         await asyncio.sleep(self.get_response_delay())
 
-        from_id = packet.get("fromId")
-
         if is_direct_message:
-            if not from_id:
-                self.logger.warning("Direct message missing fromId; cannot reply")
-                return True
             await asyncio.to_thread(
                 meshtastic_client.sendText,
                 text=reply_message,

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -136,8 +136,9 @@ plugins:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only
     #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
-    #mimic_mode: false  # Optional; default false responds only to explicit !ping
-    #                   Set true to enable bare ping-style mesh-side "ping" -> "pong"
+    # When false (default), responds only to explicit !ping.
+    # Set true to enable bare ping-style mesh-side "ping" -> "pong".
+    #mimic_mode: false
   weather:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -137,7 +137,7 @@ plugins:
     #require_bot_mention: true  # Override global setting for this plugin only
     #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
     #mimic_mode: false  # Optional; default false responds only to explicit !ping
-    #                   Set true to enable conversational mesh-side "ping" -> "pong"
+    #                   Set true to enable bare ping-style mesh-side "ping" -> "pong"
   weather:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -136,6 +136,9 @@ plugins:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only
     #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
+    #mimic_mode: false  # When true, the plugin responds to bare "ping" in mesh messages
+                        # (e.g., "how far does the ping go?" → "pong"), not just explicit !ping.
+                        # Default is false; only !ping triggers a response.
   weather:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -136,8 +136,8 @@ plugins:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only
     #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
-    #mimic_mode: false  # Optional: true enables conversational mesh-side "ping" -> "pong"
-                        # Default false responds only to explicit !ping
+    #mimic_mode: false  # Optional; default false responds only to explicit !ping
+    #                   Set true to enable conversational mesh-side "ping" -> "pong"
   weather:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -136,9 +136,8 @@ plugins:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only
     #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
-    #mimic_mode: false  # When true, the plugin responds to bare "ping" in mesh messages
-                        # (e.g., "how far does the ping go?" → "pong"), not just explicit !ping.
-                        # Default is false; only !ping triggers a response.
+    #mimic_mode: false  # Optional: true enables conversational mesh-side "ping" -> "pong"
+                        # Default false responds only to explicit !ping
   weather:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -136,8 +136,8 @@ plugins:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only
     #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
-    # When false (default), responds only to explicit !ping.
-    # Set to true to enable bare ping-style mesh-side "ping" -> "pong".
+    # When false (default): responds only to explicit !ping.
+    # When true: responds to bare mesh-side "ping" messages with "pong".
     #mimic_mode: false
   weather:
     active: true

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -137,7 +137,7 @@ plugins:
     #require_bot_mention: true  # Override global setting for this plugin only
     #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
     # When false (default), responds only to explicit !ping.
-    # Set true to enable bare ping-style mesh-side "ping" -> "pong".
+    # Set to true to enable bare ping-style mesh-side "ping" -> "pong".
     #mimic_mode: false
   weather:
     active: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1040,6 +1040,9 @@ def reset_meshtastic_globals():
         "_relay_startup_drain_expiry_timer": getattr(
             mu, "_relay_startup_drain_expiry_timer", None
         ),
+        "_relay_startup_drain_complete_event": getattr(
+            mu, "_relay_startup_drain_complete_event", None
+        ),
         "_relay_reconnect_prestart_bootstrap_deadline_monotonic_secs": getattr(
             mu, "_relay_reconnect_prestart_bootstrap_deadline_monotonic_secs", None
         ),
@@ -1108,6 +1111,8 @@ def reset_meshtastic_globals():
     startup_drain_timer = getattr(mu, "_relay_startup_drain_expiry_timer", None)
     _cancel_and_join_timer_like(startup_drain_timer, timeout=0.2)
     mu._relay_startup_drain_expiry_timer = None
+    mu._relay_startup_drain_complete_event = threading.Event()
+    mu._relay_startup_drain_complete_event.set()
     mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = None
     mu._startup_packet_drain_applied = False
     mu._health_probe_request_deadlines = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1111,8 +1111,15 @@ def reset_meshtastic_globals():
     startup_drain_timer = getattr(mu, "_relay_startup_drain_expiry_timer", None)
     _cancel_and_join_timer_like(startup_drain_timer, timeout=0.2)
     mu._relay_startup_drain_expiry_timer = None
-    mu._relay_startup_drain_complete_event = threading.Event()
-    mu._relay_startup_drain_complete_event.set()
+    startup_drain_complete_event = getattr(
+        mu, "_relay_startup_drain_complete_event", None
+    )
+    if isinstance(startup_drain_complete_event, threading.Event):
+        startup_drain_complete_event.set()
+    else:
+        startup_drain_complete_event = threading.Event()
+        startup_drain_complete_event.set()
+        mu._relay_startup_drain_complete_event = startup_drain_complete_event
     mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = None
     mu._startup_packet_drain_applied = False
     mu._health_probe_request_deadlines = {}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,6 +8,7 @@ and improve maintainability of the test suite.
 import asyncio
 import contextlib
 import sys
+import threading
 from typing import Any, Callable, TypeVar, cast
 
 from pubsub import pub
@@ -221,6 +222,9 @@ def reset_meshtastic_utils_globals(*, shutdown_executors: bool = False) -> None:
         module._metadata_executor_degraded = False  # type: ignore[attr-defined]
     if hasattr(module, "_health_probe_request_deadlines"):
         module._health_probe_request_deadlines = {}  # type: ignore[attr-defined]
+    if hasattr(module, "_relay_startup_drain_complete_event"):
+        module._relay_startup_drain_complete_event = threading.Event()  # type: ignore[attr-defined]
+        module._relay_startup_drain_complete_event.set()  # type: ignore[attr-defined]
     if hasattr(module, "_ble_future_watchdog_secs"):
         module._ble_future_watchdog_secs = getattr(  # type: ignore[attr-defined]
             module, "BLE_FUTURE_WATCHDOG_SECS", module._ble_future_watchdog_secs

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -224,11 +224,11 @@ def reset_meshtastic_utils_globals(*, shutdown_executors: bool = False) -> None:
         module._health_probe_request_deadlines = {}  # type: ignore[attr-defined]
     if hasattr(module, "_relay_startup_drain_complete_event"):
         old_event = module._relay_startup_drain_complete_event  # type: ignore[attr-defined]
-        if hasattr(old_event, "set"):
-            with contextlib.suppress(Exception):
-                old_event.set()
-        module._relay_startup_drain_complete_event = threading.Event()  # type: ignore[attr-defined]
-        module._relay_startup_drain_complete_event.set()  # type: ignore[attr-defined]
+        if isinstance(old_event, threading.Event):
+            old_event.set()
+        else:
+            module._relay_startup_drain_complete_event = threading.Event()  # type: ignore[attr-defined]
+            module._relay_startup_drain_complete_event.set()  # type: ignore[attr-defined]
     if hasattr(module, "_ble_future_watchdog_secs"):
         module._ble_future_watchdog_secs = getattr(  # type: ignore[attr-defined]
             module, "BLE_FUTURE_WATCHDOG_SECS", module._ble_future_watchdog_secs

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -223,6 +223,10 @@ def reset_meshtastic_utils_globals(*, shutdown_executors: bool = False) -> None:
     if hasattr(module, "_health_probe_request_deadlines"):
         module._health_probe_request_deadlines = {}  # type: ignore[attr-defined]
     if hasattr(module, "_relay_startup_drain_complete_event"):
+        old_event = module._relay_startup_drain_complete_event  # type: ignore[attr-defined]
+        if hasattr(old_event, "set"):
+            with contextlib.suppress(Exception):
+                old_event.set()
         module._relay_startup_drain_complete_event = threading.Event()  # type: ignore[attr-defined]
         module._relay_startup_drain_complete_event.set()  # type: ignore[attr-defined]
     if hasattr(module, "_ble_future_watchdog_secs"):

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1401,6 +1401,169 @@ class TestBasePlugin(unittest.TestCase):
             "test_plugin", subdir="subdir", plugin_type="core"
         )
 
+    def test_is_core_plugin_inferred_from_type_error(self):
+        """Test is_core_plugin inference when inspect.getfile raises TypeError."""
+
+        class DynamicPlugin(BasePlugin):
+            plugin_name = "dynamic"
+            is_core_plugin = None
+
+            async def handle_meshtastic_message(
+                self, packet, formatted_message, longname, meshnet_name
+            ) -> bool:
+                return False
+
+            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+                return False
+
+        with (
+            patch("mmrelay.plugins.base_plugin.config", {"plugins": {}}),
+            patch("mmrelay.plugins.base_plugin.inspect.getfile", side_effect=TypeError),
+        ):
+            plugin = DynamicPlugin()
+            self.assertFalse(plugin.is_core_plugin)
+
+    def test_config_plugin_none_treated_as_empty(self):
+        """Plugin config that is None should be treated as empty dict."""
+        config = {"plugins": {"test_plugin": None}}
+
+        with patch("mmrelay.plugins.base_plugin.config", config):
+            plugin = MockPlugin()
+            self.assertEqual(plugin.config, {})
+
+    def test_config_plugin_non_dict_logs_warning(self):
+        """Plugin config that is non-dict should log warning and use empty dict."""
+
+        class NonDictPlugin(BasePlugin):
+            plugin_name = "test_plugin"
+            is_core_plugin = True
+
+            async def handle_meshtastic_message(
+                self, packet, formatted_message, longname, meshnet_name
+            ) -> bool:
+                return False
+
+            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+                return False
+
+        config = {"plugins": {"test_plugin": "invalid"}}
+        with patch("mmrelay.plugins.base_plugin.config", config):
+            plugin = NonDictPlugin()
+            self.assertIsInstance(plugin.config, dict)
+
+    def test_channels_not_list_wrapped(self):
+        """channels config as non-list should be wrapped in a list."""
+        config = {
+            "plugins": {"test_plugin": {"active": True, "channels": 0}},
+            "matrix": {"rooms": [{"id": "!r:matrix.org", "meshtastic_channel": 0}]},
+        }
+
+        with patch("mmrelay.plugins.base_plugin.config", config):
+            plugin = CoreMockPlugin()
+            self.assertEqual(plugin.channels, [0])
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_send_matrix_message_none_client(self, mock_connect):
+        """send_matrix_message should return None when Matrix client is unavailable."""
+        mock_connect.return_value = None
+
+        async def run_test():
+            result = await MockPlugin().send_matrix_message("!room:matrix.org", "test")
+            self.assertIsNone(result)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_send_matrix_message_formatted(self, mock_connect):
+        """send_matrix_message with formatted=True should include HTML content."""
+        mock_client = AsyncMock()
+        mock_connect.return_value = mock_client
+
+        async def run_test():
+            plugin = MockPlugin()
+            await plugin.send_matrix_message(
+                "!room:matrix.org", "**bold**", formatted=True
+            )
+            call_kwargs = mock_client.room_send.call_args.kwargs
+            self.assertIn("formatted_body", call_kwargs["content"])
+            self.assertIn("format", call_kwargs["content"])
+
+        asyncio.run(run_test())
+
+    def test_get_matching_matrix_command_with_match(self):
+        """get_matching_matrix_command should return the matching command."""
+
+        class MultiCmdPlugin(BasePlugin):
+            plugin_name = "multi"
+            is_core_plugin = True
+
+            async def handle_meshtastic_message(
+                self, packet, formatted_message, longname, meshnet_name
+            ) -> bool:
+                return False
+
+            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+                return False
+
+            def get_matrix_commands(self):
+                return ["cmd1", "cmd2"]
+
+        with patch("mmrelay.plugins.base_plugin.config", {"plugins": {}}):
+            plugin = MultiCmdPlugin()
+
+        mock_event = MagicMock()
+        with patch("mmrelay.matrix_utils.bot_command") as mock_bc:
+            mock_bc.side_effect = lambda cmd, *_, **__: cmd == "cmd2"
+            result = plugin.get_matching_matrix_command(mock_event)
+            self.assertEqual(result, "cmd2")
+
+    def test_get_matching_matrix_command_no_match(self):
+        """get_matching_matrix_command should return None when nothing matches."""
+
+        class MultiCmdPlugin2(BasePlugin):
+            plugin_name = "multi2"
+            is_core_plugin = True
+
+            async def handle_meshtastic_message(
+                self, packet, formatted_message, longname, meshnet_name
+            ) -> bool:
+                return False
+
+            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+                return False
+
+            def get_matrix_commands(self):
+                return ["cmd1"]
+
+        with patch("mmrelay.plugins.base_plugin.config", {"plugins": {}}):
+            plugin = MultiCmdPlugin2()
+
+        mock_event = MagicMock()
+        with patch("mmrelay.matrix_utils.bot_command", return_value=False):
+            result = plugin.get_matching_matrix_command(mock_event)
+            self.assertIsNone(result)
+
+    def test_extract_command_args_with_match(self):
+        """extract_command_args should extract args from full message."""
+        plugin = MockPlugin()
+        with patch(
+            "mmrelay.matrix_utils.bot_command",
+            side_effect=lambda cmd, msg, *_, **__: cmd == "test_plugin",
+        ):
+            mock_event = MagicMock()
+            result = plugin.extract_command_args(
+                "test_plugin", "!test_plugin arg1 arg2"
+            )
+            self.assertEqual(result, "arg1 arg2")
+
+    def test_extract_command_args_no_match(self):
+        """extract_command_args should return None when command doesn't match."""
+        plugin = MockPlugin()
+        with patch("mmrelay.matrix_utils.bot_command", return_value=False):
+            mock_event = MagicMock()
+            result = plugin.extract_command_args("test_plugin", "!other_cmd")
+            self.assertIsNone(result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1550,7 +1550,7 @@ class TestBasePlugin(unittest.TestCase):
             "mmrelay.matrix_utils.bot_command",
             side_effect=lambda cmd, msg, *_, **__: cmd == "test_plugin",
         ):
-            mock_event = MagicMock()
+            MagicMock()
             result = plugin.extract_command_args(
                 "test_plugin", "!test_plugin arg1 arg2"
             )
@@ -1560,7 +1560,7 @@ class TestBasePlugin(unittest.TestCase):
         """extract_command_args should return None when command doesn't match."""
         plugin = MockPlugin()
         with patch("mmrelay.matrix_utils.bot_command", return_value=False):
-            mock_event = MagicMock()
+            MagicMock()
             result = plugin.extract_command_args("test_plugin", "!other_cmd")
             self.assertIsNone(result)
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -529,6 +529,227 @@ class TestHandleMatrixError:
             "Server logout failed due to network issues, proceeding with local cleanup."
         )
 
+    @patch("mmrelay.cli_utils._get_logger")
+    def test_handle_matrix_error_status_code_not_parseable(self, mock_get_logger):
+        """Non-integer status_code should fall through to 'other' category."""
+        from mmrelay.cli_utils import NioLoginError, _handle_matrix_error
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+
+        error = MagicMock(spec=NioLoginError)
+        error.status_code = "not_a_number"
+        error.errcode = None
+        error.message = "weird error"
+
+        result = _handle_matrix_error(error, "Test op")
+        assert result is True
+
+    @patch("mmrelay.cli_utils._get_logger")
+    def test_handle_matrix_error_credentials_non_verification(self, mock_get_logger):
+        """Credentials error with non-verification context uses 'invalid token' messaging."""
+        from mmrelay.cli_utils import NioLoginError, _handle_matrix_error
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+
+        error = MagicMock(spec=NioLoginError)
+        error.status_code = 401
+        error.errcode = "M_FORBIDDEN"
+
+        result = _handle_matrix_error(error, "Server logout", log_level="warning")
+        assert result is True
+        mock_logger.warning.assert_any_call(
+            "Server logout failed due to invalid token (already logged out?), proceeding with local cleanup."
+        )
+
+    @patch("mmrelay.cli_utils._get_logger")
+    def test_handle_matrix_error_network_verification(self, mock_get_logger):
+        """Network error with verification context shows connection advice."""
+        from mmrelay.cli_utils import NioLocalTransportError, _handle_matrix_error
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+
+        error = NioLocalTransportError("Connection refused")
+        result = _handle_matrix_error(error, "Password verification")
+        assert result is True
+        mock_logger.error.assert_any_call(
+            "Password verification failed: Network connection error."
+        )
+        mock_logger.error.assert_any_call(
+            "Please check your internet connection and Matrix server availability."
+        )
+
+    @patch("mmrelay.cli_utils._get_logger")
+    def test_handle_matrix_error_fallback_forbidden_string(self, mock_get_logger):
+        """Fallback string matching should classify 'forbidden' errors as credentials."""
+        from mmrelay.cli_utils import _handle_matrix_error
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+
+        error = RuntimeError("Access forbidden for this resource")
+        result = _handle_matrix_error(error, "Server logout", log_level="warning")
+        assert result is True
+        mock_logger.warning.assert_called_once_with(
+            "Server logout failed due to invalid token (already logged out?), proceeding with local cleanup."
+        )
+
+
+class TestCleanupLocalSessionDataEdgeCases:
+    """Additional tests for _cleanup_local_session_data edge cases."""
+
+    @patch("mmrelay.cli_utils._get_logger")
+    @patch("mmrelay.paths.resolve_all_paths", side_effect=OSError("path error"))
+    @patch("os.path.exists", return_value=False)
+    def test_cleanup_resolve_paths_oserror(
+        self, mock_exists, mock_resolve, mock_get_logger
+    ):
+        from mmrelay.cli_utils import _cleanup_local_session_data
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+        result = _cleanup_local_session_data()
+        assert result is True
+        mock_logger.debug.assert_any_call(
+            "Could not resolve paths for logout cleanup: %s", "OSError"
+        )
+
+    @patch("mmrelay.cli_utils._get_logger")
+    @patch(
+        "mmrelay.paths.resolve_all_paths",
+        return_value={
+            "credentials_path": f"/test/config/matrix/{CREDENTIALS_FILENAME}",
+            "store_dir": "N/A (Windows)",
+        },
+    )
+    @patch("os.path.exists", return_value=False)
+    def test_cleanup_windows_store_dir_skipped(
+        self, mock_exists, mock_resolve, mock_get_logger
+    ):
+        from mmrelay.cli_utils import _cleanup_local_session_data
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+        result = _cleanup_local_session_data()
+        assert result is True
+
+    @patch("mmrelay.cli_utils._get_logger")
+    @patch(
+        "mmrelay.paths.resolve_all_paths",
+        return_value={
+            "credentials_path": f"/test/config/matrix/{CREDENTIALS_FILENAME}",
+            "store_dir": "/test/store",
+        },
+    )
+    @patch("os.path.exists", return_value=False)
+    @patch("mmrelay.config.load_config", return_value={"matrix": "not_a_dict"})
+    def test_cleanup_matrix_config_not_dict(
+        self, mock_load, mock_exists, mock_resolve, mock_get_logger
+    ):
+        from mmrelay.cli_utils import _cleanup_local_session_data
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+        result = _cleanup_local_session_data()
+        assert result is True
+        mock_logger.warning.assert_any_call(
+            "Matrix configuration ('matrix') is not a dictionary; "
+            "cannot resolve E2EE store path from config."
+        )
+
+    @patch("mmrelay.cli_utils._get_logger")
+    @patch(
+        "mmrelay.paths.resolve_all_paths",
+        return_value={
+            "credentials_path": f"/test/config/matrix/{CREDENTIALS_FILENAME}",
+            "store_dir": "/test/store",
+        },
+    )
+    @patch("os.path.exists", return_value=False)
+    @patch(
+        "mmrelay.config.load_config",
+        return_value={
+            "matrix": {"e2ee": "not_a_dict", "encryption": "also_not_a_dict"}
+        },
+    )
+    def test_cleanup_section_config_not_dict(
+        self, mock_load, mock_exists, mock_resolve, mock_get_logger
+    ):
+        from mmrelay.cli_utils import _cleanup_local_session_data
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+        result = _cleanup_local_session_data()
+        assert result is True
+        warning_calls = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert any("is not a dictionary" in w for w in warning_calls)
+
+    @patch("mmrelay.cli_utils._get_logger")
+    @patch(
+        "mmrelay.paths.resolve_all_paths",
+        return_value={
+            "credentials_path": f"/test/config/matrix/{CREDENTIALS_FILENAME}",
+            "store_dir": "/test/store",
+        },
+    )
+    @patch("os.path.exists", return_value=False)
+    @patch("mmrelay.config.load_config", side_effect=ImportError("no module"))
+    def test_cleanup_config_import_error(
+        self, mock_load, mock_exists, mock_resolve, mock_get_logger
+    ):
+        from mmrelay.cli_utils import _cleanup_local_session_data
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+        result = _cleanup_local_session_data()
+        assert result is True
+        mock_logger.debug.assert_any_call(
+            "Could not resolve configured E2EE store path: %s", "ImportError"
+        )
+
+    @patch("mmrelay.cli_utils._get_logger")
+    @patch(
+        "mmrelay.paths.resolve_all_paths",
+        return_value={
+            "credentials_path": f"/test/config/matrix/{CREDENTIALS_FILENAME}",
+            "store_dir": "/test/store",
+        },
+    )
+    @patch("os.path.exists", return_value=False)
+    @patch(
+        "mmrelay.config.load_config",
+        return_value={"matrix": {"e2ee": {"store_path": "/custom/store"}}},
+    )
+    def test_cleanup_config_override_store_path(
+        self, mock_load, mock_exists, mock_resolve, mock_get_logger
+    ):
+        from mmrelay.cli_utils import _cleanup_local_session_data
+
+        mock_logger = MagicMock()
+        mock_get_logger.return_value = mock_logger
+        result = _cleanup_local_session_data()
+        assert result is True
+
+
+class TestGetLoggerRuntimeError:
+    """Test _get_logger RuntimeError edge case."""
+
+    def test_get_logger_raises_runtime_error_when_logger_none(self):
+        import mmrelay.cli_utils as mod
+
+        original = mod.logger
+        try:
+            mod.logger = None
+            with patch("mmrelay.cli_utils.get_logger", return_value=None):
+                from mmrelay.cli_utils import _get_logger
+
+                with pytest.raises(RuntimeError, match="Logger must be initialized"):
+                    _get_logger()
+        finally:
+            mod.logger = original
+
 
 class TestLogoutMatrixBot:
     """Test the logout_matrix_bot function."""
@@ -971,3 +1192,448 @@ class TestLogoutMatrixBot:
             assert result is False
             mock_logger.exception.assert_called_once()
             mock_print.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_no_active_session(self):
+        """Test logout when no credentials are found (lines 666-668)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        with (
+            patch("mmrelay.cli_utils.AsyncClient", MagicMock()),
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            result = await logout_matrix_bot(password="test_password")
+            assert result is True
+            mock_logger.info.assert_any_call(
+                "No active session found. Already logged out."
+            )
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_no_active_session_empty_dict(self):
+        """Test logout when credentials is empty dict (lines 666-668)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        with (
+            patch("mmrelay.cli_utils.AsyncClient", MagicMock()),
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value={}),
+            ),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            result = await logout_matrix_bot(password="test_password")
+            assert result is True
+            mock_logger.info.assert_any_call(
+                "No active session found. Already logged out."
+            )
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_whoami_no_user_id(self, mock_credentials):
+        """Test logout when whoami response has no user_id (lines 711-712)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials()
+
+        mock_whoami_response = MagicMock()
+        mock_whoami_response.user_id = None
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.whoami.return_value = mock_whoami_response
+        mock_temp_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=None),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.return_value = mock_temp_client
+
+            result = await logout_matrix_bot(password="test_password")
+
+            mock_logger.error.assert_any_call(
+                "Failed to fetch user_id from whoami response"
+            )
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_whoami_network_error(self, mock_credentials):
+        """Test logout when whoami raises a network transport error (lines 731-732)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials()
+
+        class MockLocalTransportError(Exception):
+            pass
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.whoami.side_effect = MockLocalTransportError("net fail")
+        mock_temp_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=None),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+            patch("mmrelay.cli_utils.NioLocalTransportError", MockLocalTransportError),
+            patch("mmrelay.cli_utils.NioRemoteTransportError", MockLocalTransportError),
+            patch("mmrelay.cli_utils.NioLocalProtocolError", MockLocalTransportError),
+            patch("mmrelay.cli_utils.NioRemoteProtocolError", MockLocalTransportError),
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.return_value = mock_temp_client
+
+            result = await logout_matrix_bot(password="test_password")
+
+            mock_logger.warning.assert_any_call(
+                "Network error fetching user_id: net fail"
+            )
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_whoami_close_failure(self, mock_credentials):
+        """Test logout when temp client close fails during whoami (lines 740-742)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials()
+
+        mock_whoami_response = MagicMock()
+        mock_whoami_response.user_id = None
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.whoami.return_value = mock_whoami_response
+        mock_temp_client.close.side_effect = Exception("close failed")
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=None),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.return_value = mock_temp_client
+
+            result = await logout_matrix_bot(password="test_password")
+
+            mock_logger.debug.assert_any_call(
+                "Ignoring error while closing temporary Matrix client during logout",
+                exc_info=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_invalid_credentials_cleanup_fails(
+        self, mock_credentials
+    ):
+        """Test logout with invalid credentials and cleanup failure (line 758)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials()
+        del mock_creds["homeserver"]
+
+        with (
+            patch("mmrelay.cli_utils.AsyncClient", MagicMock()),
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=False),
+            patch("builtins.print") as mock_print,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            result = await logout_matrix_bot(password="test_password")
+            assert result is False
+            mock_print.assert_any_call("❌ Local cleanup completed with some errors.")
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_password_login_error(self, mock_credentials):
+        """Test logout when password verification returns LoginError (lines 790-791)."""
+        from mmrelay.cli_utils import NioLoginError, logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_login_error = MagicMock(spec=NioLoginError)
+        mock_login_error.status_code = 401
+        mock_login_error.errcode = "M_FORBIDDEN"
+        mock_login_error.message = "Bad password"
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = mock_login_error
+        mock_temp_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.return_value = mock_temp_client
+
+            result = await logout_matrix_bot(password="wrong_password")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_password_no_access_token(self, mock_credentials):
+        """Test logout when password verification response lacks access_token (lines 807-809)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = MagicMock(spec=[])
+        mock_temp_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.return_value = mock_temp_client
+
+            result = await logout_matrix_bot(password="test_password")
+            assert result is False
+            mock_logger.error.assert_any_call("Password verification failed.")
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_password_verification_timeout(
+        self, mock_credentials
+    ):
+        """Test logout when password verification times out (lines 812-818)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.side_effect = asyncio.TimeoutError()
+        mock_temp_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.return_value = mock_temp_client
+
+            result = await logout_matrix_bot(password="test_password")
+            assert result is False
+            mock_logger.error.assert_any_call(
+                "Password verification timed out. Please check your network connection."
+            )
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_password_close_oserror(self, mock_credentials):
+        """Test logout when closing temp client after password verification raises OSError (lines 823-834)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = MagicMock(access_token="temp_token")
+        mock_temp_client.logout = AsyncMock()
+        mock_temp_client.close.side_effect = OSError("close fail")
+
+        mock_main_client = AsyncMock()
+        mock_main_client.restore_login = MagicMock()
+        mock_main_client.logout.return_value = MagicMock(transport_response=True)
+        mock_main_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=True),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.side_effect = [mock_temp_client, mock_main_client]
+
+            result = await logout_matrix_bot(password="test_password")
+            assert result is True
+            mock_logger.debug.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_server_logout_returns_logout_error(
+        self, mock_credentials
+    ):
+        """Test logout when server returns LogoutError (line 860)."""
+        from mmrelay.cli_utils import NioLogoutError, logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_logout_error = MagicMock(spec=NioLogoutError)
+        mock_logout_error.status_code = 401
+        mock_logout_error.errcode = "M_UNKNOWN_TOKEN"
+        mock_logout_error.message = "Token not recognized"
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = MagicMock(access_token="temp_token")
+        mock_temp_client.logout = AsyncMock()
+        mock_temp_client.close = AsyncMock()
+
+        mock_main_client = AsyncMock()
+        mock_main_client.restore_login = MagicMock()
+        mock_main_client.logout.return_value = mock_logout_error
+        mock_main_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=True),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.side_effect = [mock_temp_client, mock_main_client]
+
+            result = await logout_matrix_bot(password="test_password")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_server_logout_exception(self, mock_credentials):
+        """Test logout when server logout raises an exception (lines 873-875)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = MagicMock(access_token="temp_token")
+        mock_temp_client.logout = AsyncMock()
+        mock_temp_client.close = AsyncMock()
+
+        mock_main_client = AsyncMock()
+        mock_main_client.restore_login = MagicMock()
+        mock_main_client.logout.side_effect = Exception("server error")
+        mock_main_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=True),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.side_effect = [mock_temp_client, mock_main_client]
+
+            result = await logout_matrix_bot(password="test_password")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_main_client_close_oserror(self, mock_credentials):
+        """Test logout when closing main client raises OSError (lines 877-887)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = MagicMock(access_token="temp_token")
+        mock_temp_client.logout = AsyncMock()
+        mock_temp_client.close = AsyncMock()
+
+        mock_main_client = AsyncMock()
+        mock_main_client.restore_login = MagicMock()
+        mock_main_client.logout.return_value = MagicMock(transport_response=True)
+        mock_main_client.close.side_effect = OSError("close fail")
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=True),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.side_effect = [mock_temp_client, mock_main_client]
+
+            result = await logout_matrix_bot(password="test_password")
+            assert result is True
+            mock_logger.debug.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_cleanup_with_errors(self, mock_credentials):
+        """Test logout when final local cleanup has errors (lines 894-896)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = MagicMock(access_token="temp_token")
+        mock_temp_client.logout = AsyncMock()
+        mock_temp_client.close = AsyncMock()
+
+        mock_main_client = AsyncMock()
+        mock_main_client.restore_login = MagicMock()
+        mock_main_client.logout.return_value = MagicMock(transport_response=True)
+        mock_main_client.close = AsyncMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=False),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.side_effect = [mock_temp_client, mock_main_client]
+
+            result = await logout_matrix_bot(password="test_password")
+            assert result is False
+            mock_print.assert_any_call("⚠️  Logout completed with some errors.")

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1262,7 +1262,7 @@ class TestLogoutMatrixBot:
             mock_get_logger.return_value = mock_logger
             mock_async_client.return_value = mock_temp_client
 
-            result = await logout_matrix_bot(password="test_password")
+            await logout_matrix_bot(password="test_password")
 
             mock_logger.error.assert_any_call(
                 "Failed to fetch user_id from whoami response"
@@ -1299,7 +1299,7 @@ class TestLogoutMatrixBot:
             mock_get_logger.return_value = mock_logger
             mock_async_client.return_value = mock_temp_client
 
-            result = await logout_matrix_bot(password="test_password")
+            await logout_matrix_bot(password="test_password")
 
             mock_logger.warning.assert_any_call(
                 "Network error fetching user_id: net fail"
@@ -1332,7 +1332,7 @@ class TestLogoutMatrixBot:
             mock_get_logger.return_value = mock_logger
             mock_async_client.return_value = mock_temp_client
 
-            result = await logout_matrix_bot(password="test_password")
+            await logout_matrix_bot(password="test_password")
 
             mock_logger.debug.assert_any_call(
                 "Ignoring error while closing temporary Matrix client during logout",

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -842,7 +842,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
     ):
         from mmrelay.config import load_credentials
 
-        bad_creds = json.dumps({"homeserver": "https://m.org"}).encode()
+        json.dumps({"homeserver": "https://m.org"}).encode()
         with patch(
             "builtins.open",
             mock_open(
@@ -1009,7 +1009,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         module.__name__ = "mmrelay.meshtastic_utils"
 
         config = {"matrix_rooms": [{"room_id": "!test:matrix.org"}]}
-        result = set_config(module, config)
+        set_config(module, config)
         assert module.matrix_rooms == config["matrix_rooms"]
 
     def test_set_config_calls_setup_config(self):

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -554,5 +554,594 @@ class TestConfigEdgeCases(unittest.TestCase):
                 mock_logger.exception.assert_called()
 
 
+class TestConfigAdditionalCoverage(unittest.TestCase):
+    """Additional tests for config.py uncovered branches."""
+
+    def setUp(self):
+        import mmrelay.config
+
+        mmrelay.config.relay_config = {}
+        mmrelay.config.config_path = None
+
+    def test_credentials_path_error_message(self):
+        from mmrelay.config import CredentialsPathError
+
+        err = CredentialsPathError()
+        assert str(err) == "No candidate credentials paths available"
+
+    @patch("mmrelay.config.logger")
+    def test_emit_legacy_credentials_warning(self, mock_logger):
+        from mmrelay.config import _emit_legacy_credentials_warning
+
+        _emit_legacy_credentials_warning("/some/legacy/path")
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert "legacy location" in call_args[0][0]
+        assert "/some/legacy/path" in call_args[0][1]
+
+    def test_get_credentials_search_paths_empty_config_path(self):
+        from mmrelay.config import get_credentials_search_paths
+
+        paths = get_credentials_search_paths(config_paths=[])
+        assert isinstance(paths, list)
+
+    @patch("mmrelay.config.is_deprecation_window_active", return_value=True)
+    @patch("mmrelay.config.get_legacy_dirs", return_value=["/legacy/dir"])
+    def test_get_credentials_search_paths_deprecation_window(
+        self, mock_legacy, mock_dep
+    ):
+        from mmrelay.config import get_credentials_search_paths
+
+        paths = get_credentials_search_paths(config_paths=None, include_base_data=False)
+        assert any("legacy" in p for p in paths)
+
+    def test_get_explicit_credentials_path_non_string(self):
+        from mmrelay.config import (
+            InvalidCredentialsPathTypeError,
+            get_explicit_credentials_path,
+        )
+
+        with self.assertRaises(InvalidCredentialsPathTypeError):
+            get_explicit_credentials_path({"credentials_path": 123})
+
+    def test_get_explicit_credentials_path_matrix_section_non_string(self):
+        from mmrelay.config import (
+            InvalidCredentialsPathTypeError,
+            get_explicit_credentials_path,
+        )
+
+        with self.assertRaises(InvalidCredentialsPathTypeError):
+            get_explicit_credentials_path({"matrix": {"credentials_path": 456}})
+
+    def test_get_explicit_credentials_path_matrix_section_returns_path(self):
+        from mmrelay.config import get_explicit_credentials_path
+
+        result = get_explicit_credentials_path(
+            {"matrix": {"credentials_path": "/path/to/creds.json"}}
+        )
+        assert result == "/path/to/creds.json"
+
+    def test_get_explicit_credentials_path_matrix_section_empty_returns_none(self):
+        from mmrelay.config import get_explicit_credentials_path
+
+        result = get_explicit_credentials_path({"matrix": {"credentials_path": ""}})
+        assert result is None
+
+    def test_get_data_dir_creates_directory(self):
+        from mmrelay.config import get_data_dir
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_dir = os.path.join(tmpdir, "new_subdir")
+            with patch("mmrelay.config.get_home_dir", return_value=Path(test_dir)):
+                result = get_data_dir(create=True)
+                assert os.path.isdir(result)
+
+    @patch(
+        "mmrelay.config.relay_config", {"community_plugins": {"myplug": {"url": "x"}}}
+    )
+    @patch(
+        "mmrelay.config.get_unified_plugin_data_dir",
+        return_value=Path("/plugins/data/myplug"),
+    )
+    @patch("mmrelay.config.get_plugins_dir", return_value=Path("/plugins/data"))
+    @patch("os.makedirs")
+    def test_get_plugin_data_dir_infers_community_type(
+        self, mock_makedirs, mock_plugins, mock_unified
+    ):
+        from mmrelay.config import get_plugin_data_dir
+
+        result = get_plugin_data_dir("myplug")
+        assert "myplug" in result
+
+    @patch("mmrelay.config.relay_config", {"custom_plugins": {"myplug": {"url": "x"}}})
+    @patch(
+        "mmrelay.config.get_unified_plugin_data_dir",
+        return_value=Path("/plugins/data/myplug"),
+    )
+    @patch("mmrelay.config.get_plugins_dir", return_value=Path("/plugins/data"))
+    @patch("os.makedirs")
+    def test_get_plugin_data_dir_infers_custom_type(
+        self, mock_makedirs, mock_plugins, mock_unified
+    ):
+        from mmrelay.config import get_plugin_data_dir
+
+        result = get_plugin_data_dir("myplug")
+        assert "myplug" in result
+
+    @patch("mmrelay.config.relay_config", {})
+    @patch(
+        "mmrelay.config.get_unified_plugin_data_dir",
+        return_value=Path("/plugins/data/myplug"),
+    )
+    @patch("mmrelay.config.get_plugins_dir", return_value=Path("/plugins/data"))
+    @patch("os.makedirs")
+    def test_get_plugin_data_dir_infers_core_type(
+        self, mock_makedirs, mock_plugins, mock_unified
+    ):
+        from mmrelay.config import get_plugin_data_dir
+
+        result = get_plugin_data_dir("myplug")
+        assert "myplug" in result
+
+    @patch("sys.platform", "win32")
+    def test_get_fallback_store_dir_win32(self):
+        from mmrelay.config import _get_fallback_store_dir
+
+        with patch("mmrelay.config.get_home_dir", return_value=Path("C:/Users/test")):
+            result = _get_fallback_store_dir()
+            assert "matrix" in result
+            assert "store" in result
+
+    @patch(
+        "mmrelay.config.get_unified_store_dir", side_effect=OSError("permission denied")
+    )
+    @patch(
+        "mmrelay.config._get_fallback_store_dir", return_value="/home/fallback/store"
+    )
+    @patch("mmrelay.config.logger")
+    def test_get_e2ee_store_dir_oserror_fallback(
+        self, mock_logger, mock_fallback, mock_store
+    ):
+        from mmrelay.config import get_e2ee_store_dir
+
+        result = get_e2ee_store_dir()
+        assert result == "/home/fallback/store"
+        mock_logger.warning.assert_called()
+
+    def test_convert_env_float_exceeds_max(self):
+        from mmrelay.config import _convert_env_float
+
+        with self.assertRaises(ValueError) as ctx:
+            _convert_env_float("100", "TEST_VAR", max_value=10)
+        assert "must be <=" in str(ctx.exception)
+
+    @patch("sys.platform", "win32")
+    def test_is_e2ee_enabled_win32(self):
+        from mmrelay.config import is_e2ee_enabled
+
+        assert is_e2ee_enabled({"matrix": {"encryption": {"enabled": True}}}) is False
+
+    @patch("sys.platform", "linux")
+    @patch("os.path.isfile", return_value=True)
+    @patch(
+        "builtins.open",
+        new_callable=mock_open,
+        read_data="matrix:\n  encryption:\n    enabled: true\n",
+    )
+    @patch("mmrelay.config.get_config_paths", return_value=["/test/config.yaml"])
+    @patch("mmrelay.config.is_e2ee_enabled", return_value=True)
+    def test_check_e2ee_enabled_silently_found(
+        self, mock_e2ee, mock_paths, mock_file, mock_isfile
+    ):
+        from mmrelay.config import check_e2ee_enabled_silently
+
+        result = check_e2ee_enabled_silently()
+        assert result is True
+
+    @patch("sys.platform", "linux")
+    @patch("os.path.isfile", return_value=False)
+    @patch("mmrelay.config.get_config_paths", return_value=["/nonexistent/config.yaml"])
+    def test_check_e2ee_enabled_silently_no_config(self, mock_paths, mock_isfile):
+        from mmrelay.config import check_e2ee_enabled_silently
+
+        result = check_e2ee_enabled_silently()
+        assert result is False
+
+    @patch("sys.platform", "win32")
+    def test_check_e2ee_enabled_silently_win32(self):
+        from mmrelay.config import check_e2ee_enabled_silently
+
+        assert check_e2ee_enabled_silently() is False
+
+    def test_normalize_optional_dict_sections_with_none(self):
+        from mmrelay.config import _normalize_optional_dict_sections
+
+        config = {"meshtastic": None, "matrix": None}
+        _normalize_optional_dict_sections(config, ("meshtastic", "matrix"))
+        assert config["meshtastic"] == {}
+        assert config["matrix"] == {}
+
+    @patch(
+        "mmrelay.config.load_meshtastic_config_from_env",
+        return_value={"serial_port": "/dev/ttyUSB0"},
+    )
+    @patch("mmrelay.config.load_logging_config_from_env", return_value=None)
+    @patch("mmrelay.config.load_database_config_from_env", return_value=None)
+    @patch("mmrelay.config.load_matrix_config_from_env", return_value=None)
+    @patch("mmrelay.config.logger")
+    def test_apply_env_overrides_section_is_none(
+        self, mock_logger, mock_matrix, mock_db, mock_log, mock_mesh
+    ):
+        from mmrelay.config import apply_env_config_overrides
+
+        config = {"meshtastic": "not_a_dict"}
+        result = apply_env_config_overrides(config)
+        assert "meshtastic" in result
+
+    @patch("mmrelay.config.load_meshtastic_config_from_env", return_value=None)
+    @patch(
+        "mmrelay.config.load_logging_config_from_env", return_value={"level": "DEBUG"}
+    )
+    @patch("mmrelay.config.load_database_config_from_env", return_value=None)
+    @patch("mmrelay.config.load_matrix_config_from_env", return_value=None)
+    @patch("mmrelay.config.logger")
+    def test_apply_env_overrides_logging_section_none(
+        self, mock_logger, mock_matrix, mock_db, mock_log, mock_mesh
+    ):
+        from mmrelay.config import apply_env_config_overrides
+
+        config = {"logging": "not_a_dict"}
+        result = apply_env_config_overrides(config)
+        assert "logging" in result
+
+    @patch("mmrelay.config.load_meshtastic_config_from_env", return_value=None)
+    @patch("mmrelay.config.load_logging_config_from_env", return_value=None)
+    @patch("mmrelay.config.load_database_config_from_env", return_value={"path": "/db"})
+    @patch("mmrelay.config.load_matrix_config_from_env", return_value=None)
+    @patch("mmrelay.config.logger")
+    def test_apply_env_overrides_db_section_none(
+        self, mock_logger, mock_matrix, mock_db, mock_log, mock_mesh
+    ):
+        from mmrelay.config import apply_env_config_overrides
+
+        config = {"database": "not_a_dict"}
+        result = apply_env_config_overrides(config)
+        assert "database" in result
+
+    @patch("mmrelay.config.load_meshtastic_config_from_env", return_value=None)
+    @patch("mmrelay.config.load_logging_config_from_env", return_value=None)
+    @patch("mmrelay.config.load_database_config_from_env", return_value=None)
+    @patch(
+        "mmrelay.config.load_matrix_config_from_env",
+        return_value={"homeserver": "https://m.org"},
+    )
+    @patch("mmrelay.config.logger")
+    def test_apply_env_overrides_matrix_section_none(
+        self, mock_logger, mock_matrix, mock_db, mock_log, mock_mesh
+    ):
+        from mmrelay.config import apply_env_config_overrides
+
+        config = {"matrix": "not_a_dict"}
+        result = apply_env_config_overrides(config)
+        assert "matrix" in result
+
+    @patch("mmrelay.config.get_explicit_credentials_path", side_effect=OSError("fail"))
+    @patch("mmrelay.config.logger")
+    def test_load_credentials_path_error_returns_none(self, mock_logger, mock_explicit):
+        from mmrelay.config import load_credentials
+
+        result = load_credentials()
+        assert result is None
+        mock_logger.exception.assert_called()
+
+    @patch("mmrelay.config.get_credentials_search_paths", return_value=[])
+    @patch("mmrelay.config.get_explicit_credentials_path", return_value=None)
+    @patch("mmrelay.config.os.path.isfile", return_value=True)
+    def test_load_credentials_missing_required_keys(
+        self, mock_isfile, mock_explicit, mock_search
+    ):
+        from mmrelay.config import load_credentials
+
+        bad_creds = json.dumps({"homeserver": "https://m.org"}).encode()
+        with patch(
+            "builtins.open",
+            mock_open(
+                read_data=json.dumps(
+                    {"homeserver": "https://m.org", "access_token": ""}
+                )
+            ),
+        ):
+            result = load_credentials(config_override={})
+            assert result is None
+
+    @patch(
+        "mmrelay.config.get_credentials_search_paths", return_value=["/test/creds.json"]
+    )
+    @patch("mmrelay.config.get_explicit_credentials_path", return_value=None)
+    @patch("mmrelay.config.os.path.isfile", return_value=True)
+    @patch("mmrelay.config.get_credentials_path", return_value="/other/creds.json")
+    @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
+    @patch("mmrelay.config.is_deprecation_window_active", return_value=True)
+    @patch("mmrelay.config.get_legacy_dirs", return_value=[])
+    @patch("mmrelay.config.logger")
+    def test_load_credentials_invalid_device_id(
+        self,
+        mock_logger,
+        mock_legacy,
+        mock_dep,
+        mock_home,
+        mock_creds_path,
+        mock_isfile,
+        mock_explicit,
+        mock_search,
+    ):
+        from mmrelay.config import load_credentials
+
+        creds_data = {
+            "homeserver": "https://matrix.org",
+            "access_token": "tok123",
+            "device_id": "",
+        }
+        with patch("builtins.open", mock_open(read_data=json.dumps(creds_data))):
+            result = load_credentials(config_override={})
+            assert result is not None
+            assert result["device_id"] is None
+
+    @patch(
+        "mmrelay.config.get_credentials_search_paths",
+        return_value=["/legacy/creds.json"],
+    )
+    @patch("mmrelay.config.get_explicit_credentials_path", return_value=None)
+    @patch("mmrelay.config.os.path.isfile", return_value=True)
+    @patch("mmrelay.config.get_credentials_path", return_value="/primary/creds.json")
+    @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
+    @patch("mmrelay.config.is_deprecation_window_active", return_value=True)
+    @patch("mmrelay.config.get_legacy_dirs", return_value=["/legacy"])
+    @patch("mmrelay.config.logger")
+    def test_load_credentials_legacy_dir_warning(
+        self,
+        mock_logger,
+        mock_legacy,
+        mock_dep,
+        mock_home,
+        mock_creds_path,
+        mock_isfile,
+        mock_explicit,
+        mock_search,
+    ):
+        from mmrelay.config import load_credentials
+
+        creds_data = {
+            "homeserver": "https://matrix.org",
+            "access_token": "tok123",
+        }
+        with patch("builtins.open", mock_open(read_data=json.dumps(creds_data))):
+            result = load_credentials(config_override={})
+            assert result is not None
+            warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+            assert any("legacy location" in w for w in warning_calls)
+
+    @patch(
+        "mmrelay.config.get_credentials_search_paths",
+        return_value=["/home/.mmrelay/credentials.json"],
+    )
+    @patch("mmrelay.config.get_explicit_credentials_path", return_value=None)
+    @patch("mmrelay.config.os.path.isfile", return_value=True)
+    @patch("mmrelay.config.get_credentials_path", return_value="/primary/creds.json")
+    @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
+    @patch("mmrelay.config.is_deprecation_window_active", return_value=False)
+    @patch("mmrelay.config.logger")
+    def test_load_credentials_home_dir_legacy_warning(
+        self,
+        mock_logger,
+        mock_dep,
+        mock_home,
+        mock_creds_path,
+        mock_isfile,
+        mock_explicit,
+        mock_search,
+    ):
+        from mmrelay.config import load_credentials
+
+        creds_data = {
+            "homeserver": "https://matrix.org",
+            "access_token": "tok123",
+        }
+        with patch("builtins.open", mock_open(read_data=json.dumps(creds_data))):
+            result = load_credentials(config_override={})
+            assert result is not None
+
+    def test_load_config_search_finds_yaml(self):
+        from mmrelay.config import load_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, "config.yaml")
+            with open(config_file, "w") as f:
+                f.write("matrix:\n  homeserver: https://test.org\n")
+
+            result = load_config(config_paths=[config_file])
+            assert result.get("matrix", {}).get("homeserver") == "https://test.org"
+
+    def test_load_config_null_yaml_in_search(self):
+        from mmrelay.config import load_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = os.path.join(tmpdir, "config.yaml")
+            with open(config_file, "w") as f:
+                f.write("")
+
+            result = load_config(config_paths=[config_file])
+            assert result == {}
+
+    def test_load_config_yaml_error_in_search_continues(self):
+        from mmrelay.config import load_config
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bad_file = os.path.join(tmpdir, "bad.yaml")
+            with open(bad_file, "w") as f:
+                f.write("matrix: [bad: syntax")
+
+            good_file = os.path.join(tmpdir, "good.yaml")
+            with open(good_file, "w") as f:
+                f.write("matrix:\n  homeserver: https://test.org\n")
+
+            result = load_config(config_paths=[bad_file, good_file])
+            assert result.get("matrix", {}).get("homeserver") == "https://test.org"
+
+    @patch("os.path.isfile", return_value=False)
+    @patch("os.path.isdir", return_value=True)
+    @patch("mmrelay.config.get_config_paths", return_value=["/some/dir"])
+    @patch("mmrelay.config.logger")
+    def test_load_config_candidate_is_directory(
+        self, mock_logger, mock_paths, mock_isdir, mock_isfile
+    ):
+        from mmrelay.config import load_config
+
+        result = load_config()
+        assert result == {}
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        assert any("directory" in w for w in warning_calls)
+
+    def test_set_config_meshtastic_utils_with_rooms(self):
+        from mmrelay.config import set_config
+
+        module = MagicMock()
+        module.__name__ = "mmrelay.meshtastic_utils"
+
+        config = {"matrix_rooms": [{"room_id": "!test:matrix.org"}]}
+        result = set_config(module, config)
+        assert module.matrix_rooms == config["matrix_rooms"]
+
+    def test_set_config_calls_setup_config(self):
+        from mmrelay.config import set_config
+
+        module = MagicMock()
+        module.__name__ = "some_module"
+        module.setup_config = MagicMock()
+
+        set_config(module, {})
+        module.setup_config.assert_called_once()
+
+    def test_validate_yaml_syntax_style_warnings(self):
+        from mmrelay.config import validate_yaml_syntax
+
+        content = "key: yes\nother: no\n"
+        is_valid, message, parsed = validate_yaml_syntax(content, "test.yaml")
+        assert is_valid is True
+        assert message is not None
+        assert "Style warning" in message
+
+    def test_validate_yaml_syntax_equals_sign(self):
+        from mmrelay.config import validate_yaml_syntax
+
+        content = "key = value\n"
+        is_valid, message, parsed = validate_yaml_syntax(content, "test.yaml")
+        assert is_valid is False
+        assert message is not None and "=" in message
+
+    def test_validate_yaml_syntax_parse_error_with_mark(self):
+        from mmrelay.config import validate_yaml_syntax
+
+        content = "matrix:\n  rooms:\n    - invalid: [unmatched\n"
+        is_valid, message, parsed = validate_yaml_syntax(content, "test.yaml")
+        assert is_valid is False
+        assert parsed is None
+
+    def test_validate_yaml_syntax_error_with_syntax_issues(self):
+        from mmrelay.config import validate_yaml_syntax
+
+        content = "key = value\nother: yes\nbad: [\n"
+        is_valid, message, parsed = validate_yaml_syntax(content, "test.yaml")
+        assert is_valid is False
+        assert parsed is None
+
+    @patch("mmrelay.config.relay_config", {"credentials_path": "/custom/creds.json"})
+    @patch("os.path.isdir", return_value=False)
+    @patch("os.path.abspath", side_effect=lambda x: x)
+    @patch("os.path.expanduser", side_effect=lambda x: x)
+    def test_resolve_credentials_path_relay_config(
+        self, mock_expand, mock_abs, mock_isdir
+    ):
+        from mmrelay.config import _resolve_credentials_path
+
+        result = _resolve_credentials_path(None, allow_relay_config_sources=True)
+        assert result[0] == "/custom/creds.json"
+
+    @patch(
+        "mmrelay.config.relay_config", {"matrix": {"credentials_path": "/matrix/creds"}}
+    )
+    @patch("os.path.isdir", return_value=False)
+    @patch("os.path.abspath", side_effect=lambda x: x)
+    @patch("os.path.expanduser", side_effect=lambda x: x)
+    def test_resolve_credentials_path_matrix_section(
+        self, mock_expand, mock_abs, mock_isdir
+    ):
+        from mmrelay.config import _resolve_credentials_path
+
+        result = _resolve_credentials_path(None, allow_relay_config_sources=True)
+        assert result[0] == "/matrix/creds"
+
+    @patch("mmrelay.config.relay_config", {})
+    @patch("mmrelay.config.get_home_dir", return_value=Path("/home/user"))
+    def test_resolve_credentials_path_default(self, mock_home):
+        from mmrelay.config import _resolve_credentials_path
+
+        result = _resolve_credentials_path(None, allow_relay_config_sources=False)
+        assert "matrix" in result[1]
+        assert CREDENTIALS_FILENAME in result[0]
+
+    @patch("mmrelay.config.relay_config", {})
+    @patch("os.path.isdir", return_value=True)
+    @patch("os.path.abspath", side_effect=lambda x: x)
+    @patch("os.path.expanduser", side_effect=lambda x: x)
+    def test_resolve_credentials_path_directory_appends_filename(
+        self, mock_expand, mock_abs, mock_isdir
+    ):
+        from mmrelay.config import _resolve_credentials_path
+
+        result = _resolve_credentials_path(
+            "/some/dir", allow_relay_config_sources=False
+        )
+        assert result[0].endswith(CREDENTIALS_FILENAME)
+
+    @patch("mmrelay.config.relay_config", {})
+    @patch("mmrelay.config.relay_config", {})
+    @patch("os.path.isdir", return_value=False)
+    @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
+    def test_resolve_credentials_path_empty_dirname(self, mock_home, mock_isdir):
+        from mmrelay.config import _resolve_credentials_path
+
+        result = _resolve_credentials_path(
+            "creds.json", allow_relay_config_sources=False
+        )
+        assert result[0].endswith(CREDENTIALS_FILENAME)
+
+    @patch("mmrelay.config.relay_config", {})
+    @patch("os.path.isdir", return_value=False)
+    @patch(
+        "os.path.abspath",
+        side_effect=lambda x: "/abs/" + x if not x.startswith("/") else x,
+    )
+    @patch("os.path.expanduser", side_effect=lambda x: x)
+    @patch("os.getenv", return_value="/env/creds.json")
+    def test_resolve_credentials_path_env_var(
+        self, mock_env, mock_expand, mock_abs, mock_isdir
+    ):
+        from mmrelay.config import _resolve_credentials_path
+
+        result = _resolve_credentials_path(None, allow_relay_config_sources=True)
+        assert "env" in result[0]
+
+    def test_backward_compat_alias(self):
+        from mmrelay.config import (
+            get_candidate_credentials_paths,
+            get_credentials_search_paths,
+        )
+
+        result1 = get_candidate_credentials_paths(include_base_data=False)
+        result2 = get_credentials_search_paths(include_base_data=False)
+        assert result1 == result2
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -858,7 +858,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         "mmrelay.config.get_credentials_search_paths", return_value=["/test/creds.json"]
     )
     @patch("mmrelay.config.get_explicit_credentials_path", return_value=None)
-    @patch("mmrelay.config.os.path.isfile", return_value=True)
+    @patch("mmrelay.config.os.path.exists", return_value=True)
     @patch("mmrelay.config.get_credentials_path", return_value="/other/creds.json")
     @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
     @patch("mmrelay.config.is_deprecation_window_active", return_value=True)
@@ -871,7 +871,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         mock_dep,
         mock_home,
         mock_creds_path,
-        mock_isfile,
+        mock_exists,
         mock_explicit,
         mock_search,
     ):
@@ -892,7 +892,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         return_value=["/legacy/creds.json"],
     )
     @patch("mmrelay.config.get_explicit_credentials_path", return_value=None)
-    @patch("mmrelay.config.os.path.isfile", return_value=True)
+    @patch("mmrelay.config.os.path.exists", return_value=True)
     @patch("mmrelay.config.get_credentials_path", return_value="/primary/creds.json")
     @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
     @patch("mmrelay.config.is_deprecation_window_active", return_value=True)
@@ -905,7 +905,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         mock_dep,
         mock_home,
         mock_creds_path,
-        mock_isfile,
+        mock_exists,
         mock_explicit,
         mock_search,
     ):
@@ -926,7 +926,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         return_value=["/home/.mmrelay/credentials.json"],
     )
     @patch("mmrelay.config.get_explicit_credentials_path", return_value=None)
-    @patch("mmrelay.config.os.path.isfile", return_value=True)
+    @patch("mmrelay.config.os.path.exists", return_value=True)
     @patch("mmrelay.config.get_credentials_path", return_value="/primary/creds.json")
     @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
     @patch("mmrelay.config.is_deprecation_window_active", return_value=False)
@@ -937,7 +937,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         mock_dep,
         mock_home,
         mock_creds_path,
-        mock_isfile,
+        mock_exists,
         mock_explicit,
         mock_search,
     ):
@@ -1105,7 +1105,6 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         assert result[0].endswith(CREDENTIALS_FILENAME)
 
     @patch("mmrelay.config.relay_config", {})
-    @patch("mmrelay.config.relay_config", {})
     @patch("os.path.isdir", return_value=False)
     @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
     def test_resolve_credentials_path_empty_dirname(self, mock_home, mock_isdir):
@@ -1114,7 +1113,7 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         result = _resolve_credentials_path(
             "creds.json", allow_relay_config_sources=False
         )
-        assert result[0].endswith(CREDENTIALS_FILENAME)
+        assert result[0].endswith("creds.json")
 
     @patch("mmrelay.config.relay_config", {})
     @patch("os.path.isdir", return_value=False)

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -171,7 +171,6 @@ def test_log_write_future_error_after_cancellation_done_future():
 
     import os
     import tempfile
-    from concurrent.futures import CancelledError as ConcurrentCancelledError
 
     from mmrelay.db_runtime import DatabaseManager
 

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -6,6 +6,7 @@ Covers:
 - _probe_sqlite_json_each_support: json_each support detection
 """
 
+import asyncio
 import sqlite3
 from unittest.mock import MagicMock, patch
 
@@ -103,6 +104,117 @@ class TestGetSqliteRuntimeVersionInfo:
         ):
             result = _get_sqlite_runtime_version_info()
             assert result == (3, 45, 1)
+
+
+@pytest.mark.asyncio
+async def test_await_submitted_future_signal_done_handles_runtime_error():
+    """_signal_done callback should swallow RuntimeError when loop is shutting down."""
+
+    class FakeEvent:
+        def __init__(self):
+            self._set = False
+
+        def set(self):
+            self._set = True
+
+    fake_future = MagicMock()
+    fake_future.done.return_value = False
+    fake_future.result.return_value = "ok"
+
+    manager = MagicMock()
+    manager._resolve_submitted_future_result = staticmethod(lambda f: f.result())
+
+    from concurrent.futures import Future as RealFuture
+
+    worker = RealFuture()
+    worker.set_result("done")
+
+    import os
+    import tempfile
+
+    from mmrelay.db_runtime import DatabaseManager
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    tmp.close()
+    db = DatabaseManager(tmp.name)
+    try:
+        closed_loop = asyncio.new_event_loop()
+        closed_loop.close()
+
+        with (
+            patch(
+                "mmrelay.db_runtime.asyncio.get_running_loop", return_value=closed_loop
+            ),
+            patch("mmrelay.db_runtime.asyncio.Event", return_value=FakeEvent()),
+        ):
+            result = await db._await_submitted_future(worker)
+            assert result == "done"
+    finally:
+        db.close()
+        os.unlink(tmp.name)
+
+
+def test_log_write_future_error_after_cancellation_done_future():
+    """When worker_future is already done, _log_future_error is called immediately."""
+
+    class FakeFuture:
+        def __init__(self, exc=None):
+            self._exc = exc
+
+        def done(self):
+            return True
+
+        def result(self):
+            if self._exc:
+                raise self._exc
+            return None
+
+    import os
+    import tempfile
+    from concurrent.futures import CancelledError as ConcurrentCancelledError
+
+    from mmrelay.db_runtime import DatabaseManager
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    tmp.close()
+    db = DatabaseManager(tmp.name)
+    try:
+        with patch("mmrelay.db_runtime.logger") as mock_logger:
+            db._log_write_future_error_after_cancellation(
+                FakeFuture(exc=RuntimeError("boom"))
+            )
+        mock_logger.warning.assert_called_once()
+    finally:
+        db.close()
+        os.unlink(tmp.name)
+
+
+def test_log_write_future_error_after_cancellation_done_cancelled():
+    """Cancelled worker future should not trigger warning log."""
+    import os
+    import tempfile
+    from concurrent.futures import CancelledError as ConcurrentCancelledError
+
+    from mmrelay.db_runtime import DatabaseManager
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    tmp.close()
+    db = DatabaseManager(tmp.name)
+    try:
+
+        class CancelledFuture:
+            def done(self):
+                return True
+
+            def result(self):
+                raise ConcurrentCancelledError()
+
+        with patch("mmrelay.db_runtime.logger") as mock_logger:
+            db._log_write_future_error_after_cancellation(CancelledFuture())
+        mock_logger.warning.assert_not_called()
+    finally:
+        db.close()
+        os.unlink(tmp.name)
 
 
 class TestProbeSqliteJsonEachSupport:

--- a/tests/test_drop_plugin.py
+++ b/tests/test_drop_plugin.py
@@ -466,7 +466,61 @@ class TestDropPlugin(unittest.TestCase):
 
         asyncio.run(run_test())
 
-    def test_handle_room_message_with_matching_command(self):
+    def test_get_position_no_nodes(self):
+        """get_position returns None when client has no nodes (line 44->52)."""
+        empty_client = MagicMock()
+        empty_client.nodes = None
+        self.assertIsNone(self.plugin.get_position(empty_client, "!12345678"))
+
+    def test_get_position_empty_nodes_dict(self):
+        """get_position returns None when nodes dict is empty (line 44->52)."""
+        empty_client = MagicMock()
+        empty_client.nodes = {}
+        self.assertIsNone(self.plugin.get_position(empty_client, "!12345678"))
+
+    @patch("mmrelay.plugins.drop_plugin.connect_meshtastic")
+    def test_handle_meshtastic_message_drop_no_from_id(self, mock_connect):
+        """Drop command without fromId should return False (lines 140-143)."""
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        packet = {
+            "decoded": {
+                "portnum": TEXT_MESSAGE_APP,
+                "text": "!drop orphan message",
+            },
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.plugins.drop_plugin.connect_meshtastic")
+    def test_handle_meshtastic_message_non_text_portnum(self, mock_connect):
+        """Non-TEXT_MESSAGE_APP packets should return False (line 165)."""
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "data": "some_data",
+            },
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.plugins.drop_plugin.connect_meshtastic")
+    def test_handle_room_message_with_matching_command(self, mock_connect):
         """
         Test that Matrix room messages with matching commands are handled and processed by the plugin.
 

--- a/tests/test_e2ee_utils.py
+++ b/tests/test_e2ee_utils.py
@@ -366,7 +366,6 @@ class TestCheckCredentialsAvailable:
     @patch("mmrelay.e2ee_utils.resolve_all_paths")
     def test_home_string_legacy_same_home_path(self, mock_resolve, mock_exists):
         """When home is a string and primary not found, check legacy same-home location."""
-        call_count = {"n": 0}
 
         def exists_side_effect(path):
             if "primary" in path:

--- a/tests/test_e2ee_utils.py
+++ b/tests/test_e2ee_utils.py
@@ -340,3 +340,257 @@ def test_deprecation_window_not_active(
     paths_checked = [call[0][0] for call in calls]
     assert f"/primary/matrix/{CREDENTIALS_FILENAME}" in paths_checked
     assert not any("legacy" in path for path in paths_checked)
+
+
+# ---- Additional coverage tests for e2ee_utils.py uncovered lines ----
+
+
+class TestCheckCredentialsAvailable:
+    """Tests for _check_credentials_available edge cases."""
+
+    @patch("mmrelay.e2ee_utils.os.path.exists")
+    @patch("mmrelay.e2ee_utils.resolve_all_paths")
+    def test_paths_info_none_triggers_resolve(self, mock_resolve, mock_exists):
+        """When paths_info is None, resolve_all_paths should be called."""
+        mock_resolve.return_value = {
+            "credentials_path": "/found/creds.json",
+            "home": None,
+        }
+        mock_exists.return_value = True
+
+        result = _check_credentials_available(None, paths_info=None)
+        assert result is True
+        mock_resolve.assert_called_once()
+
+    @patch("mmrelay.e2ee_utils.os.path.exists")
+    @patch("mmrelay.e2ee_utils.resolve_all_paths")
+    def test_home_string_legacy_same_home_path(self, mock_resolve, mock_exists):
+        """When home is a string and primary not found, check legacy same-home location."""
+        call_count = {"n": 0}
+
+        def exists_side_effect(path):
+            if "primary" in path:
+                return False
+            if CREDENTIALS_FILENAME in path and "home_root" in path:
+                return True
+            return False
+
+        mock_resolve.return_value = {
+            "credentials_path": "/primary/matrix/credentials.json",
+            "home": "/home_root",
+        }
+        mock_exists.side_effect = exists_side_effect
+
+        result = _check_credentials_available(None)
+        assert result is True
+
+    @patch("mmrelay.e2ee_utils.os.path.exists")
+    @patch("mmrelay.e2ee_utils.resolve_all_paths")
+    @patch("mmrelay.e2ee_utils.is_deprecation_window_active", return_value=True)
+    def test_legacy_sources_during_deprecation_window(
+        self, mock_deprecation, mock_resolve, mock_exists
+    ):
+        """Credentials found in legacy source during deprecation window."""
+        mock_resolve.return_value = {
+            "credentials_path": "/primary/matrix/credentials.json",
+            "home": None,
+            "legacy_sources": ["/legacy1"],
+        }
+        mock_exists.side_effect = lambda p: "legacy1" in p and CREDENTIALS_FILENAME in p
+
+        result = _check_credentials_available(None)
+        assert result is True
+
+
+class MockRoom:
+    def __init__(self, room_id, display_name="Test", encrypted=False):
+        self.room_id = room_id
+        self.display_name = display_name
+        self.encrypted = encrypted
+
+
+class TestRoomEncryptionWarnings:
+    """Tests for get_room_encryption_warnings."""
+
+    def test_no_encrypted_rooms(self):
+        """No warnings when there are no encrypted rooms."""
+        from mmrelay.e2ee_utils import get_room_encryption_warnings
+
+        rooms = {"!r1:t": MockRoom("!r1:t", encrypted=False)}
+        status = {"overall_status": "disabled"}
+        result = get_room_encryption_warnings(rooms, status)
+        assert result == []
+
+    def test_unavailable_status_encrypted_rooms(self):
+        """Warning for encrypted rooms on unsupported platform."""
+        from mmrelay.e2ee_utils import get_room_encryption_warnings
+
+        rooms = {"!r1:t": MockRoom("!r1:t", encrypted=True)}
+        status = {"overall_status": "unavailable"}
+        result = get_room_encryption_warnings(rooms, status)
+        assert len(result) == 2
+        assert "will be blocked" in result[1]
+
+    def test_disabled_status_encrypted_rooms(self):
+        """Warning for encrypted rooms when E2EE is disabled."""
+        from mmrelay.e2ee_utils import get_room_encryption_warnings
+
+        rooms = {"!r1:t": MockRoom("!r1:t", encrypted=True)}
+        status = {"overall_status": "disabled"}
+        result = get_room_encryption_warnings(rooms, status)
+        assert len(result) == 2
+        assert "will be blocked" in result[1]
+
+    def test_incomplete_status_encrypted_rooms(self):
+        """Warning for encrypted rooms when E2EE is incomplete."""
+        from mmrelay.e2ee_utils import get_room_encryption_warnings
+
+        rooms = {"!r1:t": MockRoom("!r1:t", encrypted=True)}
+        status = {"overall_status": "incomplete"}
+        result = get_room_encryption_warnings(rooms, status)
+        assert len(result) == 2
+        assert "may be blocked" in result[1]
+
+
+class TestFormatRoomList:
+    """Tests for format_room_list."""
+
+    def test_incomplete_status_encrypted_room(self):
+        """Encrypted room with incomplete status should show incomplete warning."""
+        from mmrelay.e2ee_utils import format_room_list
+
+        rooms = {"!r1:t": MockRoom("!r1:t", "MyRoom", encrypted=True)}
+        status = {"overall_status": "incomplete"}
+        result = format_room_list(rooms, status)
+        assert len(result) == 1
+        assert "incomplete" in result[0].lower()
+
+
+class TestGetE2eeErrorMessage:
+    """Tests for get_e2ee_error_message."""
+
+    def test_ready_returns_empty(self):
+        """Ready status should return empty string."""
+        from mmrelay.e2ee_utils import get_e2ee_error_message
+
+        result = get_e2ee_error_message({"overall_status": "ready"})
+        assert result == ""
+
+    def test_platform_not_supported(self):
+        """Unavailable platform should return unavailable message."""
+        from mmrelay.e2ee_utils import get_e2ee_error_message
+
+        result = get_e2ee_error_message(
+            {"overall_status": "unavailable", "platform_supported": False}
+        )
+        assert "Windows" in result
+
+    def test_not_enabled(self):
+        """Disabled E2EE should return disabled message."""
+        from mmrelay.e2ee_utils import get_e2ee_error_message
+
+        result = get_e2ee_error_message(
+            {"overall_status": "disabled", "enabled": False, "platform_supported": True}
+        )
+        assert "disabled" in result.lower()
+
+    def test_missing_deps(self):
+        """Missing dependencies should return deps message."""
+        from mmrelay.e2ee_utils import get_e2ee_error_message
+
+        result = get_e2ee_error_message(
+            {
+                "overall_status": "incomplete",
+                "enabled": True,
+                "platform_supported": True,
+                "dependencies_installed": False,
+            }
+        )
+        assert "dependencies" in result.lower()
+
+    def test_missing_credentials(self):
+        """Missing credentials should return auth message."""
+        from mmrelay.e2ee_utils import get_e2ee_error_message
+
+        result = get_e2ee_error_message(
+            {
+                "overall_status": "incomplete",
+                "enabled": True,
+                "platform_supported": True,
+                "dependencies_installed": True,
+                "credentials_available": False,
+            }
+        )
+        assert "auth" in result.lower() or "credentials" in result.lower()
+
+    def test_generic_incomplete(self):
+        """Generic incomplete should return incomplete message."""
+        from mmrelay.e2ee_utils import get_e2ee_error_message
+
+        result = get_e2ee_error_message(
+            {
+                "overall_status": "incomplete",
+                "enabled": True,
+                "platform_supported": True,
+                "dependencies_installed": True,
+                "credentials_available": True,
+            }
+        )
+        assert "incomplete" in result.lower()
+
+
+class TestGetE2eeFixInstructions:
+    """Tests for get_e2ee_fix_instructions."""
+
+    def test_ready_status(self):
+        """Ready status should return confirmation."""
+        from mmrelay.e2ee_utils import get_e2ee_fix_instructions
+
+        result = get_e2ee_fix_instructions({"overall_status": "ready"})
+        assert len(result) == 1
+        assert "fully configured" in result[0]
+
+    def test_missing_deps_step(self):
+        """Missing deps should include install step."""
+        from mmrelay.e2ee_utils import get_e2ee_fix_instructions
+
+        result = get_e2ee_fix_instructions(
+            {
+                "overall_status": "incomplete",
+                "platform_supported": True,
+                "dependencies_installed": False,
+                "credentials_available": True,
+                "enabled": True,
+            }
+        )
+        assert any("Install E2EE" in step for step in result)
+
+    def test_missing_credentials_step(self):
+        """Missing credentials should include auth step."""
+        from mmrelay.e2ee_utils import get_e2ee_fix_instructions
+
+        result = get_e2ee_fix_instructions(
+            {
+                "overall_status": "incomplete",
+                "platform_supported": True,
+                "dependencies_installed": True,
+                "credentials_available": False,
+                "enabled": True,
+            }
+        )
+        assert any("Matrix authentication" in step for step in result)
+
+    def test_not_enabled_step(self):
+        """Not enabled should include config step."""
+        from mmrelay.e2ee_utils import get_e2ee_fix_instructions
+
+        result = get_e2ee_fix_instructions(
+            {
+                "overall_status": "disabled",
+                "platform_supported": True,
+                "dependencies_installed": True,
+                "credentials_available": True,
+                "enabled": False,
+            }
+        )
+        assert any("Enable E2EE" in step for step in result)

--- a/tests/test_health_plugin.py
+++ b/tests/test_health_plugin.py
@@ -282,6 +282,28 @@ class TestHealthPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_generate_response_no_client(self, mock_connect):
+        """generate_response returns error when client is None (lines 60-61)."""
+        mock_connect.return_value = None
+        response = self.plugin.generate_response()
+        self.assertEqual(response, "Unable to connect to Meshtastic device.")
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_generate_response_no_battery_but_has_snr(self, mock_connect):
+        """Nodes with SNR but no battery should show Battery: N/A (line 116)."""
+        nodes = {
+            "node1": {"snr": 5.0},
+        }
+        mock_client = MagicMock()
+        mock_client.nodes = nodes
+        mock_connect.return_value = mock_client
+
+        response = self.plugin.generate_response()
+        self.assertIn("Nodes: 1", response)
+        self.assertIn("Battery: N/A", response)
+        self.assertIn("SNR: 5.00", response)
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     def test_handle_room_message_with_match(self, mock_connect):
         """
         Tests that handle_room_message sends a health summary message to the Matrix room when the event matches.

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -354,6 +354,11 @@ class TestHelpPlugin(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_get_matrix_commands_none_name(self):
+        """get_matrix_commands returns [] when plugin_name is None (line 75)."""
+        self.plugin.plugin_name = None
+        self.assertEqual(self.plugin.get_matrix_commands(), [])
+
     @patch("mmrelay.plugins.help_plugin.load_plugins")
     def test_handle_room_message_no_plugins(self, mock_load_plugins):
         """

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1067,7 +1067,6 @@ class TestLogUtils(unittest.TestCase):
         self, mock_get_log_dir
     ):
         """OSError creating file with no handlers in CLI mode should use print."""
-        import argparse
 
         import mmrelay.log_utils as lu
 
@@ -1132,7 +1131,6 @@ class TestLogUtils(unittest.TestCase):
 
     def test_cli_logging_mode(self):
         """cli_logging_mode should suppress console output temporarily."""
-        import argparse
 
         import mmrelay.log_utils as lu
 
@@ -1142,7 +1140,7 @@ class TestLogUtils(unittest.TestCase):
 
         logger = get_logger("_test_cli_logger")
         pre_mode = lu._cli_mode
-        initial_handler_count = len(logger.handlers)
+        len(logger.handlers)
 
         with lu.cli_logging_mode():
             self.assertTrue(lu._cli_mode)
@@ -1152,7 +1150,6 @@ class TestLogUtils(unittest.TestCase):
     @patch("mmrelay.log_utils.get_log_dir")
     def test_should_log_to_file_cli_mode_default_off(self, mock_get_log_dir):
         """_should_log_to_file defaults off in CLI mode."""
-        import argparse
 
         import mmrelay.log_utils as lu
 
@@ -1176,7 +1173,6 @@ class TestLogUtils(unittest.TestCase):
 
     def test_resolve_log_file_from_config(self):
         """_resolve_log_file should fall back to config filename."""
-        import argparse
 
         import mmrelay.log_utils as lu
 

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1012,7 +1012,7 @@ class TestLogUtils(unittest.TestCase):
             lu._cli_mode = original_cli_mode
 
     @patch("mmrelay.log_utils.get_log_dir")
-    def test_get_logger_oserror_creating_file_no_handlers_prints(
+    def test_get_logger_oserror_creating_file_no_handlers_prints_with_resolved_path(
         self, mock_get_log_dir
     ):
         """OSError creating file with no handlers should use print fallback."""
@@ -1028,11 +1028,11 @@ class TestLogUtils(unittest.TestCase):
             ):
                 logger = get_logger("_test_file_oserror_no_handlers")
 
-        mock_print.assert_called_once()
+        self.assertGreater(mock_print.call_count, 0)
         self.assertIsInstance(logger, logging.Logger)
 
     @patch("mmrelay.log_utils.get_log_dir")
-    def test_get_logger_oserror_creating_file_no_handlers_prints(
+    def test_get_logger_oserror_creating_file_no_handlers_prints_cli_mode(
         self, mock_get_log_dir
     ):
         """OSError creating file with no handlers should use print fallback."""
@@ -1059,7 +1059,7 @@ class TestLogUtils(unittest.TestCase):
             ):
                 logger = get_logger(logger_name)
 
-        mock_print.assert_called_once()
+        self.assertGreater(mock_print.call_count, 0)
         self.assertIsInstance(logger, logging.Logger)
 
     @patch("mmrelay.log_utils.get_log_dir")
@@ -1167,19 +1167,21 @@ class TestLogUtils(unittest.TestCase):
 
         import mmrelay.log_utils as lu
 
-        args = argparse.Namespace(logfile="/tmp/test_resolve.log")
+        expected_logfile = os.path.join(self.test_dir, "test_resolve.log")
+        args = argparse.Namespace(logfile=expected_logfile)
         result = lu._resolve_log_file(args)
-        self.assertEqual(result, "/tmp/test_resolve.log")
+        self.assertEqual(result, expected_logfile)
 
     def test_resolve_log_file_from_config(self):
         """_resolve_log_file should fall back to config filename."""
 
         import mmrelay.log_utils as lu
 
-        lu.config = {"logging": {"filename": "/tmp/config_log.log"}}
+        expected_logfile = os.path.join(self.test_dir, "config_log.log")
+        lu.config = {"logging": {"filename": expected_logfile}}
         try:
             result = lu._resolve_log_file(None)
-            self.assertEqual(result, "/tmp/config_log.log")
+            self.assertEqual(result, expected_logfile)
         finally:
             lu.config = None
 

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -949,6 +949,260 @@ class TestLogUtils(unittest.TestCase):
             self.assertIn("bleak", captured_output)
             self.assertIn(test_message, captured_output)
 
+    def test_configure_component_debug_logging_non_dict_warns(self):
+        """Non-dict debug settings should log a warning."""
+        import mmrelay.log_utils
+        from mmrelay.constants.app import APP_DISPLAY_NAME
+
+        mmrelay.log_utils.config = {"logging": {"debug": "not_a_dict"}}
+
+        logger_name = f"mmrelay.test.{self.id()}"
+        test_logger = logging.getLogger(logger_name)
+        test_logger.handlers.clear()
+        test_logger.setLevel(logging.DEBUG)
+
+        main_logger = logging.getLogger(APP_DISPLAY_NAME)
+        main_logger.handlers.clear()
+        test_handler = logging.StreamHandler()
+        test_handler.setLevel(logging.DEBUG)
+        main_logger.addHandler(test_handler)
+        main_logger.setLevel(logging.DEBUG)
+
+        with self.assertLogs(APP_DISPLAY_NAME, level="WARNING"):
+            configure_component_debug_logging()
+
+    def test_configure_component_debug_logging_non_bool_non_string_uses_debug(self):
+        """Non-bool, non-string component config should fall back to DEBUG."""
+        import mmrelay.log_utils
+
+        mmrelay.log_utils.config = {"logging": {"debug": {"matrix_nio": 42}}}
+
+        configure_component_debug_logging()
+
+        self.assertEqual(logging.getLogger("nio").level, logging.DEBUG)
+
+    @patch("mmrelay.log_utils.get_log_dir")
+    def test_get_logger_oserror_makedirs_no_handlers_prints(self, mock_get_log_dir):
+        """OSError creating log dir with no handlers in CLI mode should use print."""
+        import mmrelay.log_utils as lu
+
+        original_cli_mode = lu._cli_mode
+        lu._cli_mode = True
+        lu.config = {"logging": {"log_to_file": True}}
+        mock_get_log_dir.return_value = self.test_dir
+
+        logger_name = "_test_oserror_no_handlers"
+        logging.getLogger(logger_name).handlers.clear()
+        lu._registered_logger_names.discard(logger_name)
+        lu._logger_config_generations.pop(logger_name, None)
+
+        try:
+            with (
+                patch(
+                    "mmrelay.log_utils.os.makedirs",
+                    side_effect=PermissionError("denied"),
+                ),
+                patch("builtins.print") as mock_print,
+            ):
+                logger = get_logger(logger_name)
+
+            mock_print.assert_called_once()
+            self.assertIsInstance(logger, logging.Logger)
+        finally:
+            lu._cli_mode = original_cli_mode
+
+    @patch("mmrelay.log_utils.get_log_dir")
+    def test_get_logger_oserror_creating_file_no_handlers_prints(
+        self, mock_get_log_dir
+    ):
+        """OSError creating file with no handlers should use print fallback."""
+        import mmrelay.log_utils as lu
+
+        lu.config = {"logging": {"log_to_file": True}}
+        mock_get_log_dir.return_value = self.test_dir
+
+        with patch("builtins.print") as mock_print:
+            with patch(
+                "mmrelay.log_utils.RotatingFileHandler",
+                side_effect=OSError("cannot create file"),
+            ):
+                logger = get_logger("_test_file_oserror_no_handlers")
+
+        mock_print.assert_called_once()
+        self.assertIsInstance(logger, logging.Logger)
+
+    @patch("mmrelay.log_utils.get_log_dir")
+    def test_get_logger_oserror_creating_file_no_handlers_prints(
+        self, mock_get_log_dir
+    ):
+        """OSError creating file with no handlers should use print fallback."""
+        import mmrelay.log_utils as lu
+
+        lu.config = {"logging": {"log_to_file": True}}
+        mock_get_log_dir.return_value = self.test_dir
+
+        logger_name = "_test_file_oserror_no_h"
+        logging.getLogger(logger_name).handlers.clear()
+
+        with (
+            patch("mmrelay.log_utils._should_log_to_file", return_value=True),
+            patch(
+                "mmrelay.log_utils._resolve_log_file",
+                return_value=os.path.join(self.test_dir, "test.log"),
+            ),
+            patch("mmrelay.log_utils.os.makedirs"),
+            patch("builtins.print") as mock_print,
+        ):
+            with patch(
+                "mmrelay.log_utils.RotatingFileHandler",
+                side_effect=OSError("cannot create file"),
+            ):
+                logger = get_logger(logger_name)
+
+        mock_print.assert_called_once()
+        self.assertIsInstance(logger, logging.Logger)
+
+    @patch("mmrelay.log_utils.get_log_dir")
+    def test_get_logger_oserror_creating_file_no_handlers_prints(
+        self, mock_get_log_dir
+    ):
+        """OSError creating file with no handlers in CLI mode should use print."""
+        import argparse
+
+        import mmrelay.log_utils as lu
+
+        lu.config = {"logging": {"log_to_file": True}}
+        mock_get_log_dir.return_value = self.test_dir
+        original_cli_mode = lu._cli_mode
+        lu._cli_mode = True
+
+        logger_name = "_test_file_oserror_no_h"
+        logging.getLogger(logger_name).handlers.clear()
+        lu._registered_logger_names.discard(logger_name)
+        lu._logger_config_generations.pop(logger_name, None)
+
+        try:
+            with patch("builtins.print") as mock_print:
+                with patch(
+                    "mmrelay.log_utils.RotatingFileHandler",
+                    side_effect=OSError("cannot create file"),
+                ):
+                    logger = get_logger(logger_name)
+
+            mock_print.assert_called_once()
+            self.assertIsInstance(logger, logging.Logger)
+        finally:
+            lu._cli_mode = original_cli_mode
+
+    @patch("mmrelay.log_utils.get_log_dir")
+    def test_get_logger_generic_exception_creating_file(self, mock_get_log_dir):
+        """Non-OSError exception creating file with no handlers should use print."""
+        import mmrelay.log_utils as lu
+
+        lu.config = {"logging": {"log_to_file": True}}
+        mock_get_log_dir.return_value = self.test_dir
+        original_cli_mode = lu._cli_mode
+        lu._cli_mode = True
+
+        logger_name = "_test_generic_exc_file"
+        logging.getLogger(logger_name).handlers.clear()
+        lu._registered_logger_names.discard(logger_name)
+        lu._logger_config_generations.pop(logger_name, None)
+
+        try:
+            with patch("builtins.print") as mock_print:
+                with patch(
+                    "mmrelay.log_utils.RotatingFileHandler",
+                    side_effect=RuntimeError("unexpected"),
+                ):
+                    logger = get_logger(logger_name)
+
+            mock_print.assert_called_once()
+            self.assertIsInstance(logger, logging.Logger)
+        finally:
+            lu._cli_mode = original_cli_mode
+
+    def test_get_log_dir_raises_typeerror_for_non_string(self):
+        """get_log_dir should raise LogsDirTypeError for non-string result."""
+        from mmrelay.log_utils import LogsDirTypeError, get_log_dir
+
+        with patch("mmrelay.paths.resolve_all_paths", return_value={"logs_dir": 123}):
+            with self.assertRaises(LogsDirTypeError):
+                get_log_dir()
+
+    def test_cli_logging_mode(self):
+        """cli_logging_mode should suppress console output temporarily."""
+        import argparse
+
+        import mmrelay.log_utils as lu
+
+        lu.config = {"logging": {"log_to_file": False}}
+        lu._registered_logger_names.add("_test_cli_logger")
+        logging.getLogger("_test_cli_logger").handlers.clear()
+
+        logger = get_logger("_test_cli_logger")
+        pre_mode = lu._cli_mode
+        initial_handler_count = len(logger.handlers)
+
+        with lu.cli_logging_mode():
+            self.assertTrue(lu._cli_mode)
+
+        self.assertEqual(lu._cli_mode, pre_mode)
+
+    @patch("mmrelay.log_utils.get_log_dir")
+    def test_should_log_to_file_cli_mode_default_off(self, mock_get_log_dir):
+        """_should_log_to_file defaults off in CLI mode."""
+        import argparse
+
+        import mmrelay.log_utils as lu
+
+        lu._cli_mode = True
+        lu.config = {}
+        try:
+            result = lu._should_log_to_file(None)
+            self.assertFalse(result)
+        finally:
+            lu._cli_mode = False
+
+    def test_resolve_log_file_from_args(self):
+        """_resolve_log_file should use CLI args.logfile when provided."""
+        import argparse
+
+        import mmrelay.log_utils as lu
+
+        args = argparse.Namespace(logfile="/tmp/test_resolve.log")
+        result = lu._resolve_log_file(args)
+        self.assertEqual(result, "/tmp/test_resolve.log")
+
+    def test_resolve_log_file_from_config(self):
+        """_resolve_log_file should fall back to config filename."""
+        import argparse
+
+        import mmrelay.log_utils as lu
+
+        lu.config = {"logging": {"filename": "/tmp/config_log.log"}}
+        try:
+            result = lu._resolve_log_file(None)
+            self.assertEqual(result, "/tmp/config_log.log")
+        finally:
+            lu.config = None
+
+    @patch("mmrelay.log_utils.get_log_dir")
+    def test_get_logger_file_logging_with_no_args(self, mock_get_log_dir):
+        """File logging should work with args=None."""
+        import mmrelay.log_utils as lu
+
+        mock_get_log_dir.return_value = self.test_dir
+        lu.config = {"logging": {"log_to_file": True}}
+
+        logger = get_logger("_test_file_no_args")
+        file_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.handlers.RotatingFileHandler)
+        ]
+        self.assertGreater(len(file_handlers), 0)
+
     @patch("mmrelay.runtime_utils.is_running_as_service")
     def test_rich_import_when_not_running_as_service(self, mock_is_running_as_service):
         """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -620,13 +620,13 @@ class TestMain(unittest.TestCase):
     def test_main_publishes_ready_after_sync_start_and_drain_completion(
         self,
         mock_stop_queue,
-        mock_refresh_node_names,
-        mock_join_room,
+        _mock_refresh_node_names,
+        _mock_join_room,
         mock_connect_matrix,
         mock_connect_meshtastic,
-        mock_start_queue,
-        mock_load_plugins,
-        mock_init_db,
+        _mock_start_queue,
+        _mock_load_plugins,
+        _mock_init_db,
     ):
         """
         Ready publication should wait for sync startup and startup-drain completion.
@@ -667,8 +667,16 @@ class TestMain(unittest.TestCase):
             log_sequence.append(("matrix", rendered))
 
         async def _run_main() -> None:
-            asyncio.create_task(_release_startup_drain())
-            await main(self.mock_config)
+            release_startup_drain_task = asyncio.create_task(_release_startup_drain())
+            try:
+                await main(self.mock_config)
+            finally:
+                if release_startup_drain_task.done():
+                    await release_startup_drain_task
+                else:
+                    release_startup_drain_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await release_startup_drain_task
 
         with (
             patch(
@@ -726,13 +734,13 @@ class TestMain(unittest.TestCase):
     def test_main_sync_failure_before_drain_does_not_publish_ready(
         self,
         mock_stop_queue,
-        mock_refresh_node_names,
-        mock_join_room,
+        _mock_refresh_node_names,
+        _mock_join_room,
         mock_connect_matrix,
         mock_connect_meshtastic,
-        mock_start_queue,
-        mock_load_plugins,
-        mock_init_db,
+        _mock_start_queue,
+        _mock_load_plugins,
+        _mock_init_db,
     ):
         """
         Early sync failures should be handled before startup drain completes.
@@ -761,8 +769,16 @@ class TestMain(unittest.TestCase):
             readiness_calls.append("ready")
 
         async def _run_main() -> None:
-            asyncio.create_task(_request_shutdown())
-            await main(self.mock_config)
+            request_shutdown_task = asyncio.create_task(_request_shutdown())
+            try:
+                await main(self.mock_config)
+            finally:
+                if request_shutdown_task.done():
+                    await request_shutdown_task
+                else:
+                    request_shutdown_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await request_shutdown_task
 
         with (
             patch(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -683,8 +683,8 @@ class TestMain(unittest.TestCase):
                 new_callable=AsyncMock,
             ) as mock_check_conn,
             patch(
-                "mmrelay.main.meshtastic_utils._relay_startup_drain_complete_event",
-                startup_drain_complete_event,
+                "mmrelay.main.meshtastic_utils.get_startup_drain_complete_event",
+                return_value=startup_drain_complete_event,
             ),
             patch(
                 "mmrelay.main._write_ready_file",
@@ -777,8 +777,8 @@ class TestMain(unittest.TestCase):
                 new_callable=AsyncMock,
             ) as mock_check_conn,
             patch(
-                "mmrelay.main.meshtastic_utils._relay_startup_drain_complete_event",
-                startup_drain_complete_event,
+                "mmrelay.main.meshtastic_utils.get_startup_drain_complete_event",
+                return_value=startup_drain_complete_event,
             ),
             patch(
                 "mmrelay.main._write_ready_file",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -654,6 +654,7 @@ class TestMain(unittest.TestCase):
             startup_drain_complete_event.set()
 
         def _write_ready_side_effect() -> None:
+            assert startup_drain_complete_event.is_set()
             readiness_calls.append("ready")
             shutdown_event.set()
 
@@ -756,6 +757,7 @@ class TestMain(unittest.TestCase):
             shutdown_event.set()
 
         def _write_ready_side_effect() -> None:
+            assert startup_drain_complete_event.is_set()
             readiness_calls.append("ready")
 
         async def _run_main() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -656,11 +656,12 @@ class TestMain(unittest.TestCase):
         def _write_ready_side_effect() -> None:
             assert startup_drain_complete_event.is_set()
             readiness_calls.append("ready")
-            shutdown_event.set()
 
         def _capture_main_info(message: str, *args: Any, **_kwargs: Any) -> None:
             rendered = message % args if args else message
             log_sequence.append(("main", rendered))
+            if rendered == "Relay startup complete":
+                shutdown_event.set()
 
         def _capture_matrix_info(message: str, *args: Any, **_kwargs: Any) -> None:
             rendered = message % args if args else message

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -712,6 +712,98 @@ class TestMain(unittest.TestCase):
         self.assertLess(sync_start_index, ready_index)
         mock_stop_queue.assert_called_once()
 
+    @patch("mmrelay.main.initialize_database")
+    @patch("mmrelay.main.load_plugins")
+    @patch("mmrelay.main.start_message_queue")
+    @patch("mmrelay.main.connect_meshtastic")
+    @patch("mmrelay.main.connect_matrix", new_callable=AsyncMock)
+    @patch("mmrelay.main.join_matrix_room", new_callable=AsyncMock)
+    @patch(
+        "mmrelay.main.meshtastic_utils.refresh_node_name_tables", new_callable=AsyncMock
+    )
+    @patch("mmrelay.main.stop_message_queue")
+    def test_main_sync_failure_before_drain_does_not_publish_ready(
+        self,
+        mock_stop_queue,
+        mock_refresh_node_names,
+        mock_join_room,
+        mock_connect_matrix,
+        mock_connect_meshtastic,
+        mock_start_queue,
+        mock_load_plugins,
+        mock_init_db,
+    ):
+        """
+        Early sync failures should be handled before startup drain completes.
+        """
+        shutdown_event = _OnePassEvent()
+        startup_drain_complete_event = threading.Event()
+        readiness_calls: list[str] = []
+
+        mock_matrix_client = AsyncMock()
+        mock_matrix_client.add_event_callback = MagicMock()
+        mock_matrix_client.close = AsyncMock()
+
+        async def _sync_forever_fail_once(*_args: Any, **_kwargs: Any) -> None:
+            raise ConnectionError("sync failed before startup drain")
+
+        mock_matrix_client.sync_forever = AsyncMock(side_effect=_sync_forever_fail_once)
+        mock_connect_matrix.return_value = mock_matrix_client
+        mock_connect_meshtastic.return_value = MagicMock()
+
+        async def _request_shutdown() -> None:
+            await asyncio.sleep(0.2)
+            shutdown_event.set()
+
+        def _write_ready_side_effect() -> None:
+            readiness_calls.append("ready")
+
+        async def _run_main() -> None:
+            asyncio.create_task(_request_shutdown())
+            await main(self.mock_config)
+
+        with (
+            patch(
+                "mmrelay.main.asyncio.get_running_loop",
+                side_effect=_make_patched_get_running_loop(),
+            ),
+            patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+            patch("mmrelay.main.asyncio.Event", return_value=shutdown_event),
+            patch("mmrelay.main.get_message_queue") as mock_get_queue,
+            patch(
+                "mmrelay.main.meshtastic_utils.check_connection",
+                new_callable=AsyncMock,
+            ) as mock_check_conn,
+            patch(
+                "mmrelay.main.meshtastic_utils._relay_startup_drain_complete_event",
+                startup_drain_complete_event,
+            ),
+            patch(
+                "mmrelay.main._write_ready_file",
+                side_effect=_write_ready_side_effect,
+            ) as mock_write_ready,
+            patch("mmrelay.main._ready_heartbeat_seconds", 0),
+            patch("mmrelay.main._STARTUP_DRAIN_WAIT_POLL_SECS", 0.01),
+            patch("mmrelay.main.matrix_logger") as mock_matrix_logger,
+            patch("mmrelay.main.shutdown_plugins"),
+        ):
+            mock_queue = MagicMock()
+            mock_queue.ensure_processor_started = MagicMock()
+            mock_get_queue.return_value = mock_queue
+            mock_check_conn.return_value = True
+
+            asyncio.run(_run_main())
+
+        mock_write_ready.assert_not_called()
+        self.assertEqual(readiness_calls, [])
+        self.assertTrue(
+            any(
+                "Matrix sync failed" in str(call)
+                for call in mock_matrix_logger.exception.call_args_list
+            )
+        )
+        mock_stop_queue.assert_called_once()
+
     def test_main_with_message_map_wipe(self):
         """
         Test that the message map wipe function is called when the configuration enables wiping on restart.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -857,10 +857,16 @@ class TestMain(unittest.TestCase):
         _mock_init_db,
     ):
         """Ready publication should be a safe no-op when startup drain event is None."""
-        shutdown_event = _ImmediateEvent()
+        shutdown_event = _OnePassEvent()
         mock_matrix_client = AsyncMock()
         mock_matrix_client.add_event_callback = MagicMock()
         mock_matrix_client.close = AsyncMock()
+
+        async def _sync_forever_once(*_args, **_kwargs):
+            await asyncio.sleep(0)
+            shutdown_event.set()
+
+        mock_matrix_client.sync_forever = AsyncMock(side_effect=_sync_forever_once)
         mock_connect_matrix.return_value = mock_matrix_client
         mock_connect_meshtastic.return_value = MagicMock()
 
@@ -880,6 +886,7 @@ class TestMain(unittest.TestCase):
                 "mmrelay.main.meshtastic_utils.get_startup_drain_complete_event",
                 return_value=None,
             ),
+            patch("mmrelay.main._write_ready_file") as mock_write_ready,
             patch("mmrelay.main.shutdown_plugins"),
         ):
             mock_queue = MagicMock()
@@ -889,6 +896,7 @@ class TestMain(unittest.TestCase):
 
             asyncio.run(main(self.mock_config))
 
+        mock_write_ready.assert_called_once()
         mock_stop_queue.assert_called_once()
 
     def test_main_with_message_map_wipe(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -607,6 +607,111 @@ class TestMain(unittest.TestCase):
         )
         mock_stop_queue.assert_called_once()
 
+    @patch("mmrelay.main.initialize_database")
+    @patch("mmrelay.main.load_plugins")
+    @patch("mmrelay.main.start_message_queue")
+    @patch("mmrelay.main.connect_meshtastic")
+    @patch("mmrelay.main.connect_matrix", new_callable=AsyncMock)
+    @patch("mmrelay.main.join_matrix_room", new_callable=AsyncMock)
+    @patch(
+        "mmrelay.main.meshtastic_utils.refresh_node_name_tables", new_callable=AsyncMock
+    )
+    @patch("mmrelay.main.stop_message_queue")
+    def test_main_publishes_ready_after_sync_start_and_drain_completion(
+        self,
+        mock_stop_queue,
+        mock_refresh_node_names,
+        mock_join_room,
+        mock_connect_matrix,
+        mock_connect_meshtastic,
+        mock_start_queue,
+        mock_load_plugins,
+        mock_init_db,
+    ):
+        """
+        Ready publication should wait for sync startup and startup-drain completion.
+        """
+        shutdown_event = _OnePassEvent()
+        startup_drain_complete_event = threading.Event()
+        readiness_calls: list[str] = []
+        log_sequence: list[tuple[str, str]] = []
+
+        mock_matrix_client = AsyncMock()
+        mock_matrix_client.add_event_callback = MagicMock()
+        mock_matrix_client.close = AsyncMock()
+
+        async def _sync_forever_wait(*_args: Any, **_kwargs: Any) -> None:
+            await asyncio.sleep(0)
+            assert not readiness_calls
+            await shutdown_event.wait()
+
+        mock_matrix_client.sync_forever = AsyncMock(side_effect=_sync_forever_wait)
+        mock_connect_matrix.return_value = mock_matrix_client
+        mock_connect_meshtastic.return_value = MagicMock()
+
+        async def _release_startup_drain() -> None:
+            await asyncio.sleep(0.01)
+            startup_drain_complete_event.set()
+
+        def _write_ready_side_effect() -> None:
+            readiness_calls.append("ready")
+            shutdown_event.set()
+
+        def _capture_main_info(message: str, *args: Any, **_kwargs: Any) -> None:
+            rendered = message % args if args else message
+            log_sequence.append(("main", rendered))
+
+        def _capture_matrix_info(message: str, *args: Any, **_kwargs: Any) -> None:
+            rendered = message % args if args else message
+            log_sequence.append(("matrix", rendered))
+
+        async def _run_main() -> None:
+            asyncio.create_task(_release_startup_drain())
+            await main(self.mock_config)
+
+        with (
+            patch(
+                "mmrelay.main.asyncio.get_running_loop",
+                side_effect=_make_patched_get_running_loop(),
+            ),
+            patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+            patch("mmrelay.main.asyncio.Event", return_value=shutdown_event),
+            patch("mmrelay.main.get_message_queue") as mock_get_queue,
+            patch(
+                "mmrelay.main.meshtastic_utils.check_connection",
+                new_callable=AsyncMock,
+            ) as mock_check_conn,
+            patch(
+                "mmrelay.main.meshtastic_utils._relay_startup_drain_complete_event",
+                startup_drain_complete_event,
+            ),
+            patch(
+                "mmrelay.main._write_ready_file",
+                side_effect=_write_ready_side_effect,
+            ) as mock_write_ready,
+            patch("mmrelay.main._ready_heartbeat_seconds", 0),
+            patch("mmrelay.main.logger") as mock_main_logger,
+            patch("mmrelay.main.matrix_logger") as mock_matrix_logger,
+            patch("mmrelay.main.shutdown_plugins"),
+        ):
+            mock_queue = MagicMock()
+            mock_queue.ensure_processor_started = MagicMock()
+            mock_get_queue.return_value = mock_queue
+            mock_check_conn.return_value = True
+            mock_main_logger.info.side_effect = _capture_main_info
+            mock_matrix_logger.info.side_effect = _capture_matrix_info
+
+            asyncio.run(_run_main())
+
+        mock_write_ready.assert_called_once()
+        self.assertEqual(readiness_calls, ["ready"])
+        self.assertIn(("matrix", "Starting Matrix sync loop"), log_sequence)
+        self.assertIn(("main", "Relay startup complete"), log_sequence)
+        sync_start_index = log_sequence.index(("matrix", "Starting Matrix sync loop"))
+        ready_index = log_sequence.index(("main", "Relay startup complete"))
+        self.assertLess(sync_start_index, ready_index)
+        mock_stop_queue.assert_called_once()
+
     def test_main_with_message_map_wipe(self):
         """
         Test that the message map wipe function is called when the configuration enables wiping on restart.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -835,6 +835,62 @@ class TestMain(unittest.TestCase):
         self.assertFalse(shutdown_backstop_fired)
         mock_stop_queue.assert_called_once()
 
+    @patch("mmrelay.main.initialize_database")
+    @patch("mmrelay.main.load_plugins")
+    @patch("mmrelay.main.start_message_queue")
+    @patch("mmrelay.main.connect_meshtastic")
+    @patch("mmrelay.main.connect_matrix", new_callable=AsyncMock)
+    @patch("mmrelay.main.join_matrix_room", new_callable=AsyncMock)
+    @patch(
+        "mmrelay.main.meshtastic_utils.refresh_node_name_tables", new_callable=AsyncMock
+    )
+    @patch("mmrelay.main.stop_message_queue")
+    def test_main_none_startup_drain_event_is_safe_noop(
+        self,
+        mock_stop_queue,
+        _mock_refresh_node_names,
+        _mock_join_room,
+        mock_connect_matrix,
+        mock_connect_meshtastic,
+        _mock_start_queue,
+        _mock_load_plugins,
+        _mock_init_db,
+    ):
+        """Ready publication should be a safe no-op when startup drain event is None."""
+        shutdown_event = _ImmediateEvent()
+        mock_matrix_client = AsyncMock()
+        mock_matrix_client.add_event_callback = MagicMock()
+        mock_matrix_client.close = AsyncMock()
+        mock_connect_matrix.return_value = mock_matrix_client
+        mock_connect_meshtastic.return_value = MagicMock()
+
+        with (
+            patch(
+                "mmrelay.main.asyncio.get_running_loop",
+                side_effect=_make_patched_get_running_loop(),
+            ),
+            patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
+            patch("mmrelay.main.asyncio.Event", return_value=shutdown_event),
+            patch("mmrelay.main.get_message_queue") as mock_get_queue,
+            patch(
+                "mmrelay.main.meshtastic_utils.check_connection",
+                new_callable=AsyncMock,
+            ) as mock_check_conn,
+            patch(
+                "mmrelay.main.meshtastic_utils.get_startup_drain_complete_event",
+                return_value=None,
+            ),
+            patch("mmrelay.main.shutdown_plugins"),
+        ):
+            mock_queue = MagicMock()
+            mock_queue.ensure_processor_started = MagicMock()
+            mock_get_queue.return_value = mock_queue
+            mock_check_conn.return_value = True
+
+            asyncio.run(main(self.mock_config))
+
+        mock_stop_queue.assert_called_once()
+
     def test_main_with_message_map_wipe(self):
         """
         Test that the message map wipe function is called when the configuration enables wiping on restart.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -748,6 +748,8 @@ class TestMain(unittest.TestCase):
         shutdown_event = _OnePassEvent()
         startup_drain_complete_event = threading.Event()
         readiness_calls: list[str] = []
+        shutdown_backstop_fired = False
+        sync_failure_logged = False
 
         mock_matrix_client = AsyncMock()
         mock_matrix_client.add_event_callback = MagicMock()
@@ -761,7 +763,14 @@ class TestMain(unittest.TestCase):
         mock_connect_meshtastic.return_value = MagicMock()
 
         async def _request_shutdown() -> None:
-            await asyncio.sleep(0.2)
+            nonlocal shutdown_backstop_fired
+            await asyncio.sleep(1.0)
+            shutdown_backstop_fired = True
+            shutdown_event.set()
+
+        def _capture_sync_failure(*_args: Any, **_kwargs: Any) -> None:
+            nonlocal sync_failure_logged
+            sync_failure_logged = True
             shutdown_event.set()
 
         def _write_ready_side_effect() -> None:
@@ -809,6 +818,7 @@ class TestMain(unittest.TestCase):
             mock_queue.ensure_processor_started = MagicMock()
             mock_get_queue.return_value = mock_queue
             mock_check_conn.return_value = True
+            mock_matrix_logger.exception.side_effect = _capture_sync_failure
 
             asyncio.run(_run_main())
 
@@ -820,6 +830,8 @@ class TestMain(unittest.TestCase):
                 for call in mock_matrix_logger.exception.call_args_list
             )
         )
+        self.assertTrue(sync_failure_logged)
+        self.assertFalse(shutdown_backstop_fired)
         mock_stop_queue.assert_called_once()
 
     def test_main_with_message_map_wipe(self):

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -33,6 +33,7 @@ from mmrelay.plugins.map_plugin import (
     Plugin,
     TextLabel,
     get_map,
+    precision_bits_to_meters,
     textsize,
 )
 from tests.constants import TEST_LAT_SF, TEST_LON_SF
@@ -887,6 +888,296 @@ class TestMapPlugin(unittest.TestCase):
             call_kwargs = mock_matrix_client.room_send.call_args.kwargs
             self.assertEqual(call_kwargs["room_id"], mock_room.room_id)
             self.assertIn("failed", call_kwargs["content"]["body"].lower())
+
+        asyncio.run(run_test())
+
+
+class TestPrecisionBitsToMeters(unittest.TestCase):
+    def test_returns_none_for_zero(self):
+        self.assertIsNone(precision_bits_to_meters(0))
+
+    def test_returns_none_for_negative(self):
+        self.assertIsNone(precision_bits_to_meters(-5))
+
+    def test_returns_value_for_positive(self):
+        result = precision_bits_to_meters(12)
+        self.assertIsInstance(result, float)
+        self.assertGreater(result, 0)
+
+
+class TestGetMapEdgeCases(unittest.TestCase):
+    @patch("staticmaps.Context")
+    def test_get_map_no_valid_locations(self, mock_context_class):
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+
+        get_map([{"lat": None, "lon": None, "label": "X"}])
+
+        mock_context.set_center.assert_not_called()
+
+    @patch("staticmaps.Context")
+    def test_get_map_empty_locations(self, mock_context_class):
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+
+        get_map([])
+
+        mock_context.set_center.assert_not_called()
+        mock_context.render_pillow.assert_called_once_with(1000, 1000)
+
+    @patch("staticmaps.Context")
+    def test_get_map_precision_bits_non_numeric(self, mock_context_class):
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+
+        get_map(
+            [
+                {
+                    "lat": TEST_LAT_SF,
+                    "lon": TEST_LON_SF,
+                    "label": "X",
+                    "precisionBits": "abc",
+                }
+            ]
+        )
+
+        mock_context.add_object.assert_called_once()
+
+    @patch("staticmaps.Context")
+    def test_get_map_precision_bits_zero(self, mock_context_class):
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+
+        get_map(
+            [{"lat": TEST_LAT_SF, "lon": TEST_LON_SF, "label": "X", "precisionBits": 0}]
+        )
+
+        mock_context.add_object.assert_called_once()
+
+    @patch("staticmaps.Context")
+    def test_get_map_with_custom_zoom(self, mock_context_class):
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+
+        get_map([], zoom=15)
+
+        mock_context.set_zoom.assert_called_once_with(15)
+
+    @patch("staticmaps.Context")
+    def test_get_map_with_custom_image_size(self, mock_context_class):
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+        mock_context.render_pillow.return_value = MagicMock()
+
+        get_map([], image_size=(500, 400))
+
+        mock_context.render_pillow.assert_called_once_with(500, 400)
+
+
+class TestMapPluginHandleRoomMessage(unittest.TestCase):
+    def setUp(self):
+        self.plugin = Plugin()
+        self.plugin.config = {
+            "zoom": 10,
+            "image_width": 800,
+            "image_height": 600,
+        }
+
+    def test_get_matrix_commands_none_name(self):
+        self.plugin.plugin_name = None
+        self.assertEqual(self.plugin.get_matrix_commands(), [])
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_invalid_args(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        async def run_test():
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map bogus=xyz"
+
+            with patch.object(self.plugin, "matches", return_value=True):
+                result = await self.plugin.handle_room_message(
+                    mock_room, mock_event, "user: !map bogus=xyz"
+                )
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_config_zoom_out_of_range(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        async def run_test():
+            self.plugin.config["zoom"] = 50
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map"
+
+            mock_matrix_client = MagicMock()
+            mock_matrix_client.room_send = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_mesh = MagicMock()
+            mock_mesh.nodes = {
+                "n1": {
+                    "position": {"latitude": TEST_LAT_SF, "longitude": TEST_LON_SF},
+                    "user": {"shortName": "T"},
+                }
+            }
+            mock_connect_mesh.return_value = mock_mesh
+            mock_get_map.return_value = MagicMock()
+
+            with patch.object(self.plugin, "matches", return_value=True):
+                result = await self.plugin.handle_room_message(
+                    mock_room, mock_event, "!map"
+                )
+
+            self.assertTrue(result)
+            self.assertEqual(mock_get_map.call_args.kwargs["zoom"], DEFAULT_MAP_ZOOM)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_image_size_config_fallback(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        async def run_test():
+            self.plugin.config["image_width"] = "bad"
+            self.plugin.config["image_height"] = "bad"
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map"
+
+            mock_matrix_client = MagicMock()
+            mock_matrix_client.room_send = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_mesh = MagicMock()
+            mock_mesh.nodes = {
+                "n1": {
+                    "position": {"latitude": TEST_LAT_SF, "longitude": TEST_LON_SF},
+                    "user": {"shortName": "T"},
+                }
+            }
+            mock_connect_mesh.return_value = mock_mesh
+            mock_get_map.return_value = MagicMock()
+
+            with patch.object(self.plugin, "matches", return_value=True):
+                result = await self.plugin.handle_room_message(
+                    mock_room, mock_event, "!map"
+                )
+
+            self.assertTrue(result)
+            call_args = mock_get_map.call_args
+            self.assertEqual(call_args[1]["image_size"], (1000, 1000))
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_matrix_unavailable(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        async def run_test():
+            mock_connect_matrix.return_value = None
+            self.plugin.send_matrix_message = AsyncMock()
+
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map"
+
+            with patch.object(self.plugin, "matches", return_value=True):
+                result = await self.plugin.handle_room_message(
+                    mock_room, mock_event, "!map"
+                )
+
+            self.assertTrue(result)
+            self.plugin.send_matrix_message.assert_awaited_once()
+            mock_get_map.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_meshtastic_unavailable(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        async def run_test():
+            mock_matrix_client = MagicMock()
+            mock_matrix_client.room_send = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_connect_mesh.return_value = None
+            self.plugin.send_matrix_message = AsyncMock()
+
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map"
+
+            with patch.object(self.plugin, "matches", return_value=True):
+                result = await self.plugin.handle_room_message(
+                    mock_room, mock_event, "!map"
+                )
+
+            self.assertTrue(result)
+            self.plugin.send_matrix_message.assert_awaited_once()
+            mock_get_map.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_meshtastic_no_nodes(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        async def run_test():
+            mock_matrix_client = MagicMock()
+            mock_matrix_client.room_send = AsyncMock()
+            mock_connect_matrix.return_value = mock_matrix_client
+
+            mock_mesh = MagicMock()
+            mock_mesh.nodes = None
+            mock_connect_mesh.return_value = mock_mesh
+            self.plugin.send_matrix_message = AsyncMock()
+
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map"
+
+            with patch.object(self.plugin, "matches", return_value=True):
+                result = await self.plugin.handle_room_message(
+                    mock_room, mock_event, "!map"
+                )
+
+            self.assertTrue(result)
+            self.plugin.send_matrix_message.assert_awaited_once()
 
         asyncio.run(run_test())
 

--- a/tests/test_matrix_utils_credentials_resolve.py
+++ b/tests/test_matrix_utils_credentials_resolve.py
@@ -1,0 +1,396 @@
+"""Tests for _resolve_and_load_credentials edge cases in credentials.py.
+
+Covers CancelledError, auto-login success reload, missing keys after auto-login,
+OSError during auto-login, various config validation fallbacks, and _get_bot_user_id.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mmrelay.config import InvalidCredentialsPathTypeError
+from mmrelay.matrix_utils import _resolve_and_load_credentials
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_cancelled_error():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError(),
+        ),
+        patch("mmrelay.matrix_utils.logger"),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await _resolve_and_load_credentials(config_data={}, matrix_section=None)
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_auto_login_missing_keys():
+    auto_creds = {"homeserver": "https://matrix.org"}
+
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new=AsyncMock(side_effect=[None, auto_creds]),
+        ),
+        patch(
+            "mmrelay.matrix_utils.login_matrix_bot",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={
+                "matrix": {
+                    "homeserver": "https://matrix.org",
+                    "bot_user_id": "@bot:matrix.org",
+                    "password": "pass",
+                },
+                "matrix_rooms": [],
+            },
+            matrix_section={
+                "homeserver": "https://matrix.org",
+                "bot_user_id": "@bot:matrix.org",
+                "password": "pass",
+            },
+        )
+
+    assert result is None
+    assert any(
+        "missing required keys" in str(call)
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_no_config_data():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data=None,
+            matrix_section=None,
+        )
+
+    assert result is None
+    assert any(
+        "No configuration available" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_non_dict_config():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data="not a dict",
+            matrix_section=None,
+        )
+
+    assert result is None
+    assert any(
+        "Configuration is invalid" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_no_matrix_section():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={"matrix_rooms": []},
+            matrix_section=None,
+        )
+
+    assert result is None
+    assert any(
+        "No Matrix authentication available" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_non_dict_matrix_section():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={"matrix": "not a dict"},
+            matrix_section="not a dict",
+        )
+
+    assert result is None
+    assert any(
+        "empty or invalid" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_no_access_token_in_matrix_section():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={"matrix": {"homeserver": "https://matrix.org"}},
+            matrix_section={"homeserver": "https://matrix.org"},
+        )
+
+    assert result is None
+    assert any(
+        "missing required field" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_matrix_section_non_auth_only():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={"matrix": {"e2ee": True}},
+            matrix_section={"e2ee": True},
+        )
+
+    assert result is None
+    assert any(
+        "non-auth settings only" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_no_homeserver_in_matrix_section():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={
+                "matrix": {
+                    "access_token": "token",
+                },
+            },
+            matrix_section={
+                "access_token": "token",
+            },
+        )
+
+    assert result is None
+    assert any(
+        "missing required field" in str(call)
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_invalid_bot_user_id():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils._normalize_bot_user_id", return_value=None),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={
+                "matrix": {
+                    "access_token": "token",
+                    "homeserver": "https://matrix.org",
+                    "bot_user_id": ":",
+                },
+            },
+            matrix_section={
+                "access_token": "token",
+                "homeserver": "https://matrix.org",
+                "bot_user_id": ":",
+            },
+        )
+
+    assert result is None
+    assert any(
+        "invalid bot_user_id" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_missing_bot_user_id_warning():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={
+                "matrix": {
+                    "access_token": "token",
+                    "homeserver": "https://matrix.org",
+                },
+            },
+            matrix_section={
+                "access_token": "token",
+                "homeserver": "https://matrix.org",
+            },
+        )
+
+    assert result is not None
+    assert result.user_id == ""
+    assert any(
+        "missing bot_user_id" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_auto_login_cancelled():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "mmrelay.matrix_utils.login_matrix_bot",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError(),
+        ),
+        patch("mmrelay.matrix_utils.logger"),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await _resolve_and_load_credentials(
+                config_data={
+                    "matrix": {
+                        "homeserver": "https://matrix.org",
+                        "bot_user_id": "@bot:matrix.org",
+                        "password": "pass",
+                    },
+                    "matrix_rooms": [],
+                },
+                matrix_section={
+                    "homeserver": "https://matrix.org",
+                    "bot_user_id": "@bot:matrix.org",
+                    "password": "pass",
+                },
+            )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_auto_login_reload_json_error():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new=AsyncMock(side_effect=[None, json.JSONDecodeError("err", "", 0)]),
+        ),
+        patch(
+            "mmrelay.matrix_utils.login_matrix_bot",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={
+                "matrix": {
+                    "homeserver": "https://matrix.org",
+                    "bot_user_id": "@bot:matrix.org",
+                    "password": "pass",
+                },
+                "matrix_rooms": [],
+            },
+            matrix_section={
+                "homeserver": "https://matrix.org",
+                "bot_user_id": "@bot:matrix.org",
+                "password": "pass",
+            },
+        )
+
+    assert result is None
+    assert any(
+        "Failed to reload newly created credentials" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_load_credentials_auto_login_reload_returns_none():
+    with (
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new=AsyncMock(side_effect=[None, None]),
+        ),
+        patch(
+            "mmrelay.matrix_utils.login_matrix_bot",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        result = await _resolve_and_load_credentials(
+            config_data={
+                "matrix": {
+                    "homeserver": "https://matrix.org",
+                    "bot_user_id": "@bot:matrix.org",
+                    "password": "pass",
+                },
+                "matrix_rooms": [],
+            },
+            matrix_section={
+                "homeserver": "https://matrix.org",
+                "bot_user_id": "@bot:matrix.org",
+                "password": "pass",
+            },
+        )
+
+    assert result is None
+    mock_logger.error.assert_called_with("Failed to load newly created credentials")

--- a/tests/test_matrix_utils_credentials_resolve.py
+++ b/tests/test_matrix_utils_credentials_resolve.py
@@ -6,12 +6,10 @@ OSError during auto-login, various config validation fallbacks, and _get_bot_use
 
 import asyncio
 import json
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from mmrelay.config import InvalidCredentialsPathTypeError
 from mmrelay.matrix_utils import _resolve_and_load_credentials
 
 

--- a/tests/test_matrix_utils_sync_bootstrap_join.py
+++ b/tests/test_matrix_utils_sync_bootstrap_join.py
@@ -3,7 +3,6 @@
 Covers alias resolution, room joining, and error handling.
 """
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_matrix_utils_sync_bootstrap_join.py
+++ b/tests/test_matrix_utils_sync_bootstrap_join.py
@@ -1,0 +1,236 @@
+"""Tests for join_matrix_room edge cases.
+
+Covers alias resolution, room joining, and error handling.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mmrelay.matrix_utils import join_matrix_room
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_alias_resolution_success():
+    mock_client = MagicMock()
+    mock_client.rooms = {"!resolved:matrix.org": MagicMock()}
+    mock_client.room_resolve_alias = AsyncMock(
+        return_value=MagicMock(room_id="!resolved:matrix.org")
+    )
+
+    with (
+        patch(
+            "mmrelay.matrix_utils.matrix_rooms",
+            {"#test:matrix.org": {"id": "!resolved:matrix.org"}},
+        ),
+        patch("mmrelay.matrix_utils._update_room_id_in_mapping") as mock_update,
+        patch("mmrelay.matrix_utils.logger"),
+    ):
+        await join_matrix_room(mock_client, "#test:matrix.org")
+
+    mock_client.room_resolve_alias.assert_awaited_once_with("#test:matrix.org")
+    mock_update.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_alias_resolution_fails():
+    from mmrelay.matrix_utils import NioLocalTransportError
+
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_client.room_resolve_alias = AsyncMock(
+        side_effect=NioLocalTransportError("error")
+    )
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "#test:matrix.org")
+
+    assert any(
+        "Error resolving alias" in str(call.args[0])
+        for call in mock_logger.exception.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_alias_no_room_id():
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_response = MagicMock()
+    mock_response.room_id = None
+    mock_response.message = "not found"
+    mock_client.room_resolve_alias = AsyncMock(return_value=mock_response)
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "#test:matrix.org")
+
+    assert any(
+        "Failed to resolve alias" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_alias_resolution_no_response():
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_client.room_resolve_alias = AsyncMock(return_value=None)
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "#test:matrix.org")
+
+    assert any(
+        "Failed to resolve alias" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_already_joined():
+    mock_client = MagicMock()
+    mock_room = MagicMock()
+    mock_client.rooms = {"!room:matrix.org": mock_room}
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "!room:matrix.org")
+
+    assert any(
+        "already in room" in str(call.args[0]).lower()
+        for call in mock_logger.debug.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_join_success():
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_client.join = AsyncMock(return_value=MagicMock(room_id="!room:matrix.org"))
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "!room:matrix.org")
+
+    assert any(
+        "Joined room" in str(call.args[0]) for call in mock_logger.info.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_join_failure_no_room_id():
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_response = MagicMock()
+    mock_response.room_id = None
+    mock_response.message = "forbidden"
+    mock_client.join = AsyncMock(return_value=mock_response)
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "!room:matrix.org")
+
+    assert any(
+        "Failed to join room" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_join_nio_exception():
+    from mmrelay.matrix_utils import NioLocalTransportError
+
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_client.join = AsyncMock(side_effect=NioLocalTransportError("net error"))
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "!room:matrix.org")
+
+    assert any(
+        "Error joining room" in str(call.args[0])
+        for call in mock_logger.exception.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_join_unexpected_exception():
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_client.join = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "!room:matrix.org")
+
+    assert any(
+        "Unexpected error joining room" in str(call.args[0])
+        for call in mock_logger.exception.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_non_string_input():
+    mock_client = MagicMock()
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, 123)  # type: ignore
+
+    assert any(
+        "expected a string" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_alias_with_mapping_update_error():
+    mock_client = MagicMock()
+    mock_client.rooms = {"!resolved:matrix.org": MagicMock()}
+    mock_client.room_resolve_alias = AsyncMock(
+        return_value=MagicMock(room_id="!resolved:matrix.org")
+    )
+
+    with (
+        patch(
+            "mmrelay.matrix_utils.matrix_rooms",
+            {"#test:matrix.org": {"id": "#test:matrix.org"}},
+        ),
+        patch(
+            "mmrelay.matrix_utils._update_room_id_in_mapping",
+            side_effect=ValueError("update error"),
+        ),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        await join_matrix_room(mock_client, "#test:matrix.org")
+
+    assert any(
+        "Non-fatal error updating matrix_rooms" in str(call.args[0])
+        for call in mock_logger.debug.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_alias_with_none_mapping():
+    mock_client = MagicMock()
+    mock_client.rooms = {"!resolved:matrix.org": MagicMock()}
+    mock_client.room_resolve_alias = AsyncMock(
+        return_value=MagicMock(room_id="!resolved:matrix.org")
+    )
+
+    with (
+        patch("mmrelay.matrix_utils.matrix_rooms", None),
+        patch("mmrelay.matrix_utils.logger"),
+    ):
+        await join_matrix_room(mock_client, "#test:matrix.org")
+
+    mock_client.room_resolve_alias.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_join_matrix_room_join_no_response():
+    mock_client = MagicMock()
+    mock_client.rooms = {}
+    mock_client.join = AsyncMock(return_value=None)
+
+    with patch("mmrelay.matrix_utils.logger") as mock_logger:
+        await join_matrix_room(mock_client, "!room:matrix.org")
+
+    assert any(
+        "Failed to join room" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )

--- a/tests/test_matrix_utils_sync_bootstrap_login.py
+++ b/tests/test_matrix_utils_sync_bootstrap_login.py
@@ -1,0 +1,1096 @@
+"""Tests for login_matrix_bot edge cases in sync_bootstrap.
+
+Covers discovery, credential reuse, login error paths,
+and various error handling branches.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mmrelay.matrix_utils import login_matrix_bot
+
+
+def _make_login_bot_mocks():
+    mock_temp = MagicMock()
+    mock_temp.discovery_info = AsyncMock(side_effect=Exception("skip discovery"))
+    mock_temp.close = AsyncMock()
+
+    return mock_temp
+
+
+def _make_logged_in_client(**login_overrides):
+    mock_client = MagicMock()
+    defaults = {
+        "access_token": "token",
+        "user_id": "@bot:matrix.org",
+        "device_id": "DEV1",
+    }
+    defaults.update(login_overrides)
+    mock_response = MagicMock(**defaults)
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:matrix.org"))
+    mock_client.close = AsyncMock()
+    return mock_client, mock_response
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_timeout_error(mock_logger, mock_async_client, mock_ssl):
+    mock_client = MagicMock()
+    mock_client.login = AsyncMock(side_effect=asyncio.TimeoutError())
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    mock_client.close.assert_awaited()
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_type_error_known_issue(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_client.login = AsyncMock(
+        side_effect=TypeError("'>=' not supported between instances of 'str' and 'int'")
+    )
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "known issue" in str(call.args[0]) for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_type_error_other(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_client.login = AsyncMock(side_effect=TypeError("some other type error"))
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_ssl_error(mock_logger, mock_async_client, mock_ssl):
+    import ssl
+
+    mock_client = MagicMock()
+    mock_client.login = AsyncMock(side_effect=ssl.SSLError("SSL error"))
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "SSL" in str(call.args[0]) or "TLS" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_generic_exception(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_client.login = AsyncMock(side_effect=RuntimeError("unexpected"))
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_no_access_token_401(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = None
+    mock_response.status_code = 401
+    mock_response.message = "Invalid password"
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "Authentication failed" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_login_failed_404(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = None
+    mock_response.status_code = 404
+    mock_response.message = "Not found"
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "not found" in str(call.args[0]).lower()
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_login_failed_429(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = None
+    mock_response.status_code = 429
+    mock_response.message = "Rate limited"
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "Rate limited" in str(call.args[0]) for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_login_failed_500(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = None
+    mock_response.status_code = 500
+    mock_response.message = "Internal server error"
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "server error" in str(call.args[0]).lower()
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_login_failed_no_status_code(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = None
+    del mock_response.status_code
+    del mock_response.message
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "Unexpected login response" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_m_forbidden_status(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = None
+    mock_response.status_code = "M_FORBIDDEN"
+    mock_response.message = "M_FORBIDDEN"
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="bot",
+            password="wrong",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "Authentication failed" in str(call.args[0])
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_whoami_fallback(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client, _ = _make_logged_in_client()
+    mock_client.whoami = AsyncMock(
+        return_value=MagicMock(user_id="@discovered:matrix.org")
+    )
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_no_credentials_path(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch("mmrelay.matrix_utils._resolve_credentials_save_path", return_value=None),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    mock_logger.error.assert_any_call("Could not resolve credentials save path")
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_discovery_timeout(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_temp = MagicMock()
+    mock_temp.discovery_info = AsyncMock(side_effect=asyncio.TimeoutError())
+    mock_temp.close = AsyncMock()
+
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.side_effect = [mock_temp, mock_client]
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "timed out" in str(call.args[0]).lower()
+        for call in mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_discovery_exception(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_temp = MagicMock()
+    mock_temp.discovery_info = AsyncMock(side_effect=Exception("network error"))
+    mock_temp.close = AsyncMock()
+
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.side_effect = [mock_temp, mock_client]
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_discovery_info_success(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_temp = MagicMock()
+    mock_temp.discovery_info = AsyncMock(
+        return_value=MagicMock(homeserver_url="https://federated.matrix.org")
+    )
+    mock_temp.close = AsyncMock()
+
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.side_effect = [mock_temp, mock_client]
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_discovery_info_error_response(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_temp = MagicMock()
+    mock_error_resp = MagicMock()
+    mock_temp.discovery_info = AsyncMock(return_value=mock_error_resp)
+    mock_temp.close = AsyncMock()
+
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.side_effect = [mock_temp, mock_client]
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch(
+            "mmrelay.matrix_utils.DiscoveryInfoResponse",
+            type("DiscoveryInfoResponse", (), {}),
+        ),
+        patch(
+            "mmrelay.matrix_utils.DiscoveryInfoError",
+            type("DiscoveryInfoError", (), {}),
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_e2ee_store_path_creation(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=True),
+        patch(
+            "mmrelay.matrix_utils.get_e2ee_store_dir", return_value="/tmp/e2ee_store"
+        ),
+        patch("os.makedirs") as mock_makedirs,
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    mock_makedirs.assert_any_call("/tmp/e2ee_store", exist_ok=True)
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_existing_device_id_reuse(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    existing_creds = {
+        "homeserver": "https://matrix.org",
+        "user_id": "@bot:matrix.org",
+        "device_id": "EXISTING_DEV",
+        "access_token": "old_token",
+    }
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("os.path.exists", return_value=True),
+        patch("builtins.open", MagicMock()),
+        patch("json.load", return_value=existing_creds),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "Reusing existing device_id" in str(call.args[0])
+        for call in mock_logger.info.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_ssl_context_none_warning(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "Failed to create SSL context" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_homeserver_with_no_scheme(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils.input")
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_interactive_prompt(
+    mock_logger, mock_async_client, mock_ssl, mock_input
+):
+    mock_input.side_effect = [
+        "https://matrix.org",
+        "@bot:matrix.org",
+        "n",
+    ]
+
+    mock_temp = MagicMock()
+    mock_temp.discovery_info = AsyncMock(side_effect=Exception("skip"))
+    mock_temp.close = AsyncMock()
+
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.side_effect = [mock_temp, mock_client]
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+        patch("mmrelay.matrix_utils.getpass.getpass", return_value="password"),
+    ):
+        result = await login_matrix_bot(config_for_paths={})
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_user_id_required_property_error(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_client.login = AsyncMock(
+        side_effect=Exception("'user_id' is a required property")
+    )
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is False
+    assert any(
+        "server response validation failed" in str(call.args[0]).lower()
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_whoami_no_user_id_fallback(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = "token"
+    mock_response.user_id = "@bot:matrix.org"
+    mock_response.device_id = "DEV"
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.whoami = AsyncMock(return_value=MagicMock(user_id=None))
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "whoami response did not include user_id" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_whoami_exception_fallback(
+    mock_logger, mock_async_client, mock_ssl
+):
+    from mmrelay.matrix_utils import NioLocalTransportError
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.access_token = "token"
+    mock_response.user_id = "@bot:matrix.org"
+    mock_response.device_id = "DEV"
+    mock_client.login = AsyncMock(return_value=mock_response)
+    mock_client.whoami = AsyncMock(side_effect=NioLocalTransportError("whoami fail"))
+    mock_client.close = AsyncMock()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "whoami call failed" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_e2ee_not_supported(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    from mmrelay.paths import E2EENotSupportedError
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=True),
+        patch(
+            "mmrelay.matrix_utils.get_e2ee_store_dir",
+            side_effect=E2EENotSupportedError("no e2ee"),
+        ),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "E2EE is not supported" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_e2ee_os_error(mock_logger, mock_async_client, mock_ssl):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=True),
+        patch(
+            "mmrelay.matrix_utils.get_e2ee_store_dir",
+            side_effect=OSError("no store"),
+        ),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "Could not resolve E2EE store path" in str(call.args[0])
+        for call in mock_logger.warning.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_discovery_has_homeserver_url(
+    mock_logger, mock_async_client, mock_ssl
+):
+    mock_temp = MagicMock()
+    mock_resp = MagicMock()
+    del mock_resp.homeserver_url
+    mock_temp.discovery_info = AsyncMock(return_value=mock_resp)
+    mock_temp.close = AsyncMock()
+
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.side_effect = [mock_temp, mock_client]
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch(
+            "mmrelay.matrix_utils.DiscoveryInfoResponse",
+            type("DIR", (), {}),
+        ),
+        patch(
+            "mmrelay.matrix_utils.DiscoveryInfoError",
+            type("DIE", (), {}),
+        ),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=False,
+            config_for_paths={},
+        )
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+@patch("mmrelay.matrix_utils._create_ssl_context", return_value=None)
+@patch("mmrelay.matrix_utils.AsyncClient")
+@patch("mmrelay.matrix_utils.logger")
+async def test_login_matrix_bot_logout_others(mock_logger, mock_async_client, mock_ssl):
+    mock_client, _ = _make_logged_in_client()
+    mock_async_client.return_value = mock_client
+
+    with (
+        patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
+        patch(
+            "mmrelay.matrix_utils._resolve_credentials_save_path",
+            return_value="/tmp/creds.json",
+        ),
+        patch("mmrelay.matrix_utils.save_credentials"),
+        patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
+    ):
+        result = await login_matrix_bot(
+            homeserver="https://matrix.org",
+            username="@bot:matrix.org",
+            password="password",
+            logout_others=True,
+            config_for_paths={},
+        )
+
+    assert result is True
+    assert any(
+        "Logging out other sessions" in str(call.args[0])
+        for call in mock_logger.info.call_args_list
+    )

--- a/tests/test_matrix_utils_sync_bootstrap_login.py
+++ b/tests/test_matrix_utils_sync_bootstrap_login.py
@@ -5,8 +5,6 @@ and various error handling branches.
 """
 
 import asyncio
-import json
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_matrix_utils_sync_bootstrap_login.py
+++ b/tests/test_matrix_utils_sync_bootstrap_login.py
@@ -5,11 +5,16 @@ and various error handling branches.
 """
 
 import asyncio
+import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from mmrelay.matrix_utils import login_matrix_bot
+
+TEST_CREDS_PATH = str(Path(tempfile.gettempdir()) / "creds.json")
+TEST_E2EE_STORE_PATH = str(Path(tempfile.gettempdir()) / "e2ee_store")
 
 
 def _make_login_bot_mocks():
@@ -49,7 +54,7 @@ async def test_login_matrix_bot_timeout_error(mock_logger, mock_async_client, mo
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -83,7 +88,7 @@ async def test_login_matrix_bot_type_error_known_issue(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -117,7 +122,7 @@ async def test_login_matrix_bot_type_error_other(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -148,7 +153,7 @@ async def test_login_matrix_bot_ssl_error(mock_logger, mock_async_client, mock_s
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -183,7 +188,7 @@ async def test_login_matrix_bot_generic_exception(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -218,7 +223,7 @@ async def test_login_matrix_bot_no_access_token_401(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -257,7 +262,7 @@ async def test_login_matrix_bot_login_failed_404(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -296,7 +301,7 @@ async def test_login_matrix_bot_login_failed_429(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -334,7 +339,7 @@ async def test_login_matrix_bot_login_failed_500(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -373,7 +378,7 @@ async def test_login_matrix_bot_login_failed_no_status_code(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -412,7 +417,7 @@ async def test_login_matrix_bot_m_forbidden_status(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -448,7 +453,7 @@ async def test_login_matrix_bot_whoami_fallback(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -509,7 +514,7 @@ async def test_login_matrix_bot_discovery_timeout(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -547,7 +552,7 @@ async def test_login_matrix_bot_discovery_exception(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -583,7 +588,7 @@ async def test_login_matrix_bot_discovery_info_success(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -618,7 +623,7 @@ async def test_login_matrix_bot_discovery_info_error_response(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch(
@@ -656,12 +661,12 @@ async def test_login_matrix_bot_e2ee_store_path_creation(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=True),
         patch(
-            "mmrelay.matrix_utils.get_e2ee_store_dir", return_value="/tmp/e2ee_store"
+            "mmrelay.matrix_utils.get_e2ee_store_dir", return_value=TEST_E2EE_STORE_PATH
         ),
         patch("os.makedirs") as mock_makedirs,
     ):
@@ -674,7 +679,7 @@ async def test_login_matrix_bot_e2ee_store_path_creation(
         )
 
     assert result is True
-    mock_makedirs.assert_any_call("/tmp/e2ee_store", exist_ok=True)
+    mock_makedirs.assert_any_call(TEST_E2EE_STORE_PATH, exist_ok=True)
 
 
 @pytest.mark.asyncio
@@ -698,7 +703,7 @@ async def test_login_matrix_bot_existing_device_id_reuse(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("os.path.exists", return_value=True),
         patch("builtins.open", MagicMock()),
@@ -735,7 +740,7 @@ async def test_login_matrix_bot_ssl_context_none_warning(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -769,7 +774,7 @@ async def test_login_matrix_bot_homeserver_with_no_scheme(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -810,7 +815,7 @@ async def test_login_matrix_bot_interactive_prompt(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -839,7 +844,7 @@ async def test_login_matrix_bot_user_id_required_property_error(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
     ):
@@ -879,7 +884,7 @@ async def test_login_matrix_bot_whoami_no_user_id_fallback(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -922,7 +927,7 @@ async def test_login_matrix_bot_whoami_exception_fallback(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),
@@ -958,13 +963,13 @@ async def test_login_matrix_bot_e2ee_not_supported(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=True),
         patch(
             "mmrelay.matrix_utils.get_e2ee_store_dir",
-            side_effect=E2EENotSupportedError("no e2ee"),
+            side_effect=E2EENotSupportedError(),
         ),
     ):
         result = await login_matrix_bot(
@@ -994,7 +999,7 @@ async def test_login_matrix_bot_e2ee_os_error(mock_logger, mock_async_client, mo
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=True),
@@ -1038,7 +1043,7 @@ async def test_login_matrix_bot_discovery_has_homeserver_url(
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch(
@@ -1074,7 +1079,7 @@ async def test_login_matrix_bot_logout_others(mock_logger, mock_async_client, mo
         patch("mmrelay.matrix_utils.config_module.load_config", return_value={}),
         patch(
             "mmrelay.matrix_utils._resolve_credentials_save_path",
-            return_value="/tmp/creds.json",
+            return_value=TEST_CREDS_PATH,
         ),
         patch("mmrelay.matrix_utils.save_credentials"),
         patch("mmrelay.matrix_utils.is_e2ee_enabled", return_value=False),

--- a/tests/test_mesh_relay_plugin.py
+++ b/tests/test_mesh_relay_plugin.py
@@ -656,6 +656,158 @@ class TestMeshRelayPlugin(unittest.TestCase):
         self.assertEqual(len(rooms), 1)
         self.assertEqual(rooms[0]["id"], TEST_ROOM_ID_1)
 
+    def test_matches_legacy_dict_packet_upgraded(self):
+        """matches() should serialize dict meshtastic_packet to JSON string (line 233)."""
+        event = MagicMock()
+        event.source = {
+            "content": {
+                MATRIX_SUPPRESS_KEY: True,
+                MATRIX_PACKET_KEY: {"decoded": {"portnum": 1}},
+            }
+        }
+
+        result = self.plugin.matches(event)
+
+        self.assertTrue(result)
+        self.assertIsInstance(event.source["content"][MATRIX_PACKET_KEY], str)
+
+    def test_matches_legacy_body_with_no_packet_data(self):
+        """matches() returns False for legacy body with no packet data (line 242->256)."""
+        event = MagicMock()
+        event.source = {
+            "content": {
+                "body": "Processed TEXT_MESSAGE_APP radio packet",
+            }
+        }
+
+        result = self.plugin.matches(event)
+        self.assertFalse(result)
+
+    def test_matches_legacy_body_with_meshtastic_packet_string(self):
+        """matches() should use meshtastic_packet string when present (line 248-249)."""
+        packet_json = '{"decoded":{"portnum":1,"payload":"QQ=="}}'
+        event = MagicMock()
+        event.source = {
+            "content": {
+                "body": "Processed TEXT_MESSAGE_APP radio packet",
+                "meshtastic_packet": packet_json,
+            }
+        }
+
+        result = self.plugin.matches(event)
+        self.assertTrue(result)
+        self.assertEqual(event.source["content"][MATRIX_PACKET_KEY], packet_json)
+
+    def test_matches_legacy_body_with_json_in_body(self):
+        """matches() should extract JSON payload from body (lines 251-255)."""
+        json_payload = '{"decoded":{"portnum":1}}'
+        event = MagicMock()
+        event.source = {
+            "content": {
+                "body": f"Processed TEXT_MESSAGE_APP radio packet",
+            }
+        }
+
+        result = self.plugin.matches(event)
+        self.assertFalse(result)
+
+    @patch("mmrelay.plugins.mesh_relay_plugin.config")
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_handle_room_message_packet_not_dict(
+        self, mock_connect_meshtastic, mock_config
+    ):
+        """handle_room_message rejects non-dict packets (lines 308-309)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        mock_config.get.return_value = [
+            {"id": "!test:matrix.org", "meshtastic_channel": 0}
+        ]
+        mock_connect_meshtastic.return_value = MagicMock()
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        event.source = {"content": {MATRIX_PACKET_KEY: '"not a dict"'}}
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.logger.error.assert_called_once_with(
+                "Embedded packet must be a JSON object"
+            )
+
+        import asyncio
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.plugins.mesh_relay_plugin.config")
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_handle_room_message_decoded_not_dict(
+        self, mock_connect_meshtastic, mock_config
+    ):
+        """handle_room_message rejects packets with non-dict decoded (lines 321-322)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        mock_config.get.return_value = [
+            {"id": "!test:matrix.org", "meshtastic_channel": 0}
+        ]
+        mock_connect_meshtastic.return_value = MagicMock()
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        event.source = {
+            "content": {MATRIX_PACKET_KEY: '{"decoded": "not_a_dict", "toId": "!dest"}'}
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.logger.error.assert_called_once_with(
+                "Embedded packet decoded field must be a JSON object"
+            )
+
+        import asyncio
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.plugins.mesh_relay_plugin.config")
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_handle_room_message_send_packet_attribute_error(
+        self, mock_connect_meshtastic, mock_config
+    ):
+        """handle_room_message handles missing _sendPacket (lines 346-350)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        mock_config.get.return_value = [
+            {"id": "!test:matrix.org", "meshtastic_channel": 0}
+        ]
+        mock_client = MagicMock()
+        mock_client._sendPacket.side_effect = AttributeError("missing method")
+        mock_connect_meshtastic.return_value = mock_client
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+        event.source = {
+            "content": {
+                MATRIX_PACKET_KEY: '{"decoded": {"portnum": 1, "payload": "QQ=="}, "toId": "!dest"}'
+            }
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertFalse(result)
+            self.plugin.logger.exception.assert_called_once()
+
+        import asyncio
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.plugins.mesh_relay_plugin.config")
+    def test_iter_room_configs_none(self, mock_config):
+        """_iter_room_configs returns empty list when config is None (line 233)."""
+        with patch("mmrelay.plugins.mesh_relay_plugin.config", None):
+            rooms = self.plugin._iter_room_configs()
+            self.assertEqual(rooms, [])
+
     @patch("mmrelay.matrix_utils.connect_matrix", new_callable=AsyncMock)
     def test_handle_meshtastic_message_no_matrix_client(self, mock_connect_matrix):
         """handle_meshtastic_message should fail fast when Matrix client is missing."""

--- a/tests/test_mesh_relay_plugin.py
+++ b/tests/test_mesh_relay_plugin.py
@@ -700,11 +700,10 @@ class TestMeshRelayPlugin(unittest.TestCase):
 
     def test_matches_legacy_body_with_json_in_body(self):
         """matches() should extract JSON payload from body (lines 251-255)."""
-        json_payload = '{"decoded":{"portnum":1}}'
         event = MagicMock()
         event.source = {
             "content": {
-                "body": f"Processed TEXT_MESSAGE_APP radio packet",
+                "body": "Processed TEXT_MESSAGE_APP radio packet",
             }
         }
 

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -1,0 +1,226 @@
+import asyncio
+import threading
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestCoerceNonnegativeFloat:
+    def test_bool_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_nonnegative_float
+
+        assert _coerce_nonnegative_float(True, 1.5) == 1.5
+
+    def test_infinite_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_nonnegative_float
+
+        assert _coerce_nonnegative_float(float("inf"), 2.0) == 2.0
+
+    def test_negative_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_nonnegative_float
+
+        assert _coerce_nonnegative_float(-1.0, 3.0) == 3.0
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestCoercePositiveInt:
+    def test_bool_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_positive_int
+
+        assert _coerce_positive_int(True, 5) == 5
+
+    def test_zero_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_positive_int
+
+        assert _coerce_positive_int(0, 10) == 10
+
+    def test_negative_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_positive_int
+
+        assert _coerce_positive_int(-3, 10) == 10
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestCoercePositiveFloat:
+    def test_bool_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_positive_float
+
+        result = _coerce_positive_float(True, 5.0, "test_setting")
+        assert result == 5.0
+
+    def test_zero_rejected(self):
+        from mmrelay.meshtastic.async_utils import _coerce_positive_float
+
+        result = _coerce_positive_float(0, 5.0, "test_setting")
+        assert result == 5.0
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestCoerceBool:
+    def test_bool_values(self):
+        from mmrelay.meshtastic.async_utils import _coerce_bool
+
+        assert _coerce_bool(True, False, "t") is True
+        assert _coerce_bool(False, True, "f") is False
+
+    def test_string_yes_values(self):
+        from mmrelay.meshtastic.async_utils import _coerce_bool
+
+        for v in ["1", "true", "yes", "on", "TRUE", "YES", "ON"]:
+            assert _coerce_bool(v, False, "t") is True
+
+    def test_string_no_values(self):
+        from mmrelay.meshtastic.async_utils import _coerce_bool
+
+        for v in ["", "0", "false", "no", "off", "FALSE", "NO", "OFF"]:
+            assert _coerce_bool(v, True, "f") is False
+
+    def test_numeric_values(self):
+        from mmrelay.meshtastic.async_utils import _coerce_bool
+
+        assert _coerce_bool(1, False, "t") is True
+        assert _coerce_bool(0, True, "f") is False
+        assert _coerce_bool(0.0, True, "f") is False
+
+    def test_unrecognized_value(self):
+        from mmrelay.meshtastic.async_utils import _coerce_bool
+
+        assert _coerce_bool("maybe", True, "t") is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSubmitCoro:
+    def test_non_awaitable_returns_none(self):
+        from mmrelay.meshtastic.async_utils import _submit_coro
+
+        result = _submit_coro("not_a_coroutine")
+        assert result is None
+
+    def test_awaitable_wrapped(self):
+        from mmrelay.meshtastic.async_utils import _submit_coro
+
+        async def coro():
+            return 42
+
+        c = coro()
+        try:
+            result = _submit_coro(c)
+            assert result is not None
+        finally:
+            c.close()
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestWaitForResult:
+    def test_concurrent_future_timeout(self):
+        from mmrelay.meshtastic.async_utils import _wait_for_result
+
+        fut = Future()
+        with pytest.raises(Exception):
+            _wait_for_result(fut, timeout=0.01)
+
+    def test_concurrent_future_success(self):
+        from mmrelay.meshtastic.async_utils import _wait_for_result
+
+        fut = Future()
+        fut.set_result("ok")
+        result = _wait_for_result(fut, timeout=1.0)
+        assert result == "ok"
+
+    def test_none_returns_false(self):
+        from mmrelay.meshtastic.async_utils import _wait_for_result
+
+        result = _wait_for_result(None, timeout=1.0)
+        assert result is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestFireAndForget:
+    def test_non_coroutine_returns(self):
+        from mmrelay.meshtastic.async_utils import _fire_and_forget
+
+        _fire_and_forget("not_a_coroutine")
+
+    def test_submit_returns_none(self):
+        from mmrelay.meshtastic.async_utils import _fire_and_forget
+
+        async def coro():
+            pass
+
+        with patch.object(mu, "_submit_coro", return_value=None):
+            _fire_and_forget(coro())
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRunBlockingWithTimeout:
+    def test_action_raises(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        with pytest.raises(ValueError, match="test error"):
+            _run_blocking_with_timeout(
+                lambda: (_ for _ in ()).throw(ValueError("test error")),
+                timeout=2.0,
+                label="test-action",
+            )
+
+    def test_action_times_out(self):
+        import threading
+        import time
+
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        block_event = threading.Event()
+
+        def blocker():
+            block_event.wait(timeout=10)
+
+        try:
+            with pytest.raises(TimeoutError):
+                _run_blocking_with_timeout(blocker, timeout=0.1, label="test-timeout")
+        finally:
+            block_event.set()
+
+    def test_action_succeeds(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        _run_blocking_with_timeout(lambda: None, timeout=2.0, label="test-ok")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestWaitForFutureResultWithShutdown:
+    def test_raises_on_shutdown(self):
+        from mmrelay.meshtastic.async_utils import (
+            _wait_for_future_result_with_shutdown,
+        )
+
+        mu.shutting_down = True
+        fut = Future()
+        with pytest.raises(TimeoutError, match="Shutdown"):
+            _wait_for_future_result_with_shutdown(fut, timeout_seconds=5)
+
+    def test_raises_on_deadline(self):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        from mmrelay.meshtastic.async_utils import (
+            _wait_for_future_result_with_shutdown,
+        )
+
+        mu.shutting_down = False
+        fut = Future()
+        with pytest.raises(FuturesTimeoutError):
+            _wait_for_future_result_with_shutdown(fut, timeout_seconds=0.01)
+
+    def test_returns_on_success(self):
+        from mmrelay.meshtastic.async_utils import (
+            _wait_for_future_result_with_shutdown,
+        )
+
+        mu.shutting_down = False
+        fut = Future()
+        fut.set_result(42)
+        result = _wait_for_future_result_with_shutdown(fut, timeout_seconds=5)
+        assert result == 42

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -1,7 +1,5 @@
-import asyncio
-import threading
 from concurrent.futures import Future
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -168,8 +166,6 @@ class TestRunBlockingWithTimeout:
             )
 
     def test_action_times_out(self):
-        import threading
-        import time
 
         from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
 

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -1,4 +1,6 @@
+import threading
 from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from unittest.mock import patch
 
 import pytest
@@ -118,7 +120,7 @@ class TestWaitForResult:
         from mmrelay.meshtastic.async_utils import _wait_for_result
 
         fut = Future()
-        with pytest.raises(Exception):
+        with pytest.raises(FuturesTimeoutError):
             _wait_for_result(fut, timeout=0.01)
 
     def test_concurrent_future_success(self):
@@ -149,8 +151,12 @@ class TestFireAndForget:
         async def coro():
             pass
 
-        with patch.object(mu, "_submit_coro", return_value=None):
-            _fire_and_forget(coro())
+        c = coro()
+        try:
+            with patch.object(mu, "_submit_coro", return_value=None):
+                _fire_and_forget(c)
+        finally:
+            c.close()
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")

--- a/tests/test_meshtastic_ble.py
+++ b/tests/test_meshtastic_ble.py
@@ -1,0 +1,252 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestIsBleDuplicateConnectSuppressedError:
+    def test_empty_message(self):
+        from mmrelay.meshtastic.ble import _is_ble_duplicate_connect_suppressed_error
+
+        exc = Exception("")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is False
+
+    def test_matching_suppressed_token(self):
+        from mmrelay.meshtastic.ble import _is_ble_duplicate_connect_suppressed_error
+
+        exc = Exception("Connection suppressed: recently connected elsewhere")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is True
+
+    def test_matching_dup_connect_token(self):
+        from mmrelay.meshtastic.ble import _is_ble_duplicate_connect_suppressed_error
+
+        exc = Exception("Connection suppressed: recently connected elsewhere")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is True
+
+    def test_non_matching(self):
+        from mmrelay.meshtastic.ble import _is_ble_duplicate_connect_suppressed_error
+
+        exc = Exception("some other error")
+        assert _is_ble_duplicate_connect_suppressed_error(exc) is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestResetBleConnectionGateState:
+    def test_no_callable_returns_false(self):
+        from mmrelay.meshtastic.ble import _reset_ble_connection_gate_state
+
+        mu._ble_gate_reset_callable = None
+        result = _reset_ble_connection_gate_state("AA:BB", reason="test")
+        assert result is False
+
+    def test_callable_succeeds(self):
+        from mmrelay.meshtastic.ble import _reset_ble_connection_gate_state
+
+        mock_callable = MagicMock()
+        mu._ble_gate_reset_callable = mock_callable
+        result = _reset_ble_connection_gate_state("AA:BB", reason="test")
+        assert result is True
+        mock_callable.assert_called_once()
+
+    def test_callable_exception_returns_false(self):
+        from mmrelay.meshtastic.ble import _reset_ble_connection_gate_state
+
+        mock_callable = MagicMock(side_effect=RuntimeError("fail"))
+        mu._ble_gate_reset_callable = mock_callable
+        result = _reset_ble_connection_gate_state("AA:BB", reason="test")
+        assert result is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestAttachLateBleInterfaceDisposer:
+    def test_cancelled_future_noop(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = True
+        _attach_late_ble_interface_disposer(mock_future, "AA:BB", reason="test")
+        mock_future.add_done_callback.assert_called_once()
+
+    def test_successful_future_with_active_iface_skips(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+
+        late_iface = MagicMock()
+        mock_future.result.return_value = late_iface
+
+        mu.meshtastic_iface = late_iface
+        with mu.meshtastic_iface_lock:
+            pass
+
+        _attach_late_ble_interface_disposer(mock_future, "AA:BB", reason="test")
+        mock_future.add_done_callback.assert_called_once()
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSanitizeBleAddress:
+    def test_normal_address(self):
+        from mmrelay.meshtastic.ble import _sanitize_ble_address
+
+        assert _sanitize_ble_address("AA:BB:CC:DD:EE:FF") == "aabbccddeeff"
+
+    def test_empty_address(self):
+        from mmrelay.meshtastic.ble import _sanitize_ble_address
+
+        assert _sanitize_ble_address("") == ""
+
+    def test_dash_separated(self):
+        from mmrelay.meshtastic.ble import _sanitize_ble_address
+
+        assert _sanitize_ble_address("AA-BB-CC") == "aabbcc"
+
+    def test_underscore_separated(self):
+        from mmrelay.meshtastic.ble import _sanitize_ble_address
+
+        assert _sanitize_ble_address("AA_BB_CC") == "aabbcc"
+
+    def test_mixed_separators(self):
+        from mmrelay.meshtastic.ble import _sanitize_ble_address
+
+        assert _sanitize_ble_address("AA:BB_CC-DD") == "aabbccdd"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestIsBleDiscoveryError:
+    def test_no_peripheral_message(self):
+        from mmrelay.meshtastic.ble import _is_ble_discovery_error
+
+        exc = Exception("No Meshtastic BLE peripheral found")
+        assert _is_ble_discovery_error(exc) is True
+
+    def test_timed_out_message(self):
+        from mmrelay.meshtastic.ble import _is_ble_discovery_error
+
+        exc = Exception("Timed out waiting for connection completion")
+        assert _is_ble_discovery_error(exc) is True
+
+    def test_key_error_with_path(self):
+        from mmrelay.meshtastic.ble import _is_ble_discovery_error
+
+        exc = KeyError("path")
+        assert _is_ble_discovery_error(exc) is True
+
+    def test_key_error_without_path(self):
+        from mmrelay.meshtastic.ble import _is_ble_discovery_error
+
+        exc = KeyError("other_key")
+        assert _is_ble_discovery_error(exc) is False
+
+    def test_regular_exception(self):
+        from mmrelay.meshtastic.ble import _is_ble_discovery_error
+
+        exc = Exception("some other error")
+        assert _is_ble_discovery_error(exc) is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestValidateBleConnectionAddress:
+    def test_no_client_returns_true(self):
+        from mmrelay.meshtastic.ble import _validate_ble_connection_address
+
+        iface = MagicMock()
+        iface.client = None
+        result = _validate_ble_connection_address(iface, "AA:BB:CC:DD:EE:FF")
+        assert result is True
+
+    def test_matching_address_returns_true(self):
+        from mmrelay.meshtastic.ble import _validate_ble_connection_address
+
+        iface = MagicMock()
+        iface.client.bleak_client.address = "AA:BB:CC:DD:EE:FF"
+        result = _validate_ble_connection_address(iface, "AA:BB:CC:DD:EE:FF")
+        assert result is True
+
+    def test_mismatched_address_returns_false(self):
+        from mmrelay.meshtastic.ble import _validate_ble_connection_address
+
+        iface = MagicMock()
+        iface.client.bleak_client.address = "11:22:33:44:55:66"
+        result = _validate_ble_connection_address(iface, "AA:BB:CC:DD:EE:FF")
+        assert result is False
+
+    def test_no_bleak_client_returns_true(self):
+        from mmrelay.meshtastic.ble import _validate_ble_connection_address
+
+        iface = MagicMock()
+        iface.client.bleak_client = None
+        iface.client.address = None
+        result = _validate_ble_connection_address(iface, "AA:BB:CC:DD:EE:FF")
+        assert result is True
+
+    def test_exception_returns_true(self):
+        from mmrelay.meshtastic.ble import _validate_ble_connection_address
+
+        iface = MagicMock()
+        type(iface.client).bleak_client = property(
+            lambda self: (_ for _ in ()).throw(RuntimeError("fail"))
+        )
+        result = _validate_ble_connection_address(iface, "AA:BB")
+        assert result is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleInterface:
+    def test_none_iface(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        _disconnect_ble_interface(None, reason="test")
+
+    def test_interface_with_disconnect(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client = None
+        iface.close.return_value = None
+
+        with patch.object(mu.time, "sleep"):
+            _disconnect_ble_interface(iface, reason="test")
+
+        iface.disconnect.assert_called()
+
+    def test_interface_disconnect_raises_then_retries(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.side_effect = [Exception("fail"), None]
+        iface.client = None
+        iface.close.return_value = None
+
+        with patch.object(mu.time, "sleep"):
+            _disconnect_ble_interface(iface, reason="test")
+
+    def test_interface_with_client_disconnect(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client.disconnect.return_value = None
+        iface.client._exit_handler = None
+        iface.close.return_value = None
+
+        with patch.object(mu.time, "sleep"):
+            _disconnect_ble_interface(iface, reason="test")
+
+    def test_shutdown_reason(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client = None
+        iface.close.return_value = None
+
+        with patch.object(mu.time, "sleep"):
+            _disconnect_ble_interface(iface, reason="shutdown")

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -1,0 +1,277 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetConnectionRetryWaitTime:
+    def test_zero_attempts(self):
+        from mmrelay.meshtastic.connection import _get_connection_retry_wait_time
+
+        result = _get_connection_retry_wait_time(0)
+        assert result == 0.0
+
+    def test_negative_attempts(self):
+        from mmrelay.meshtastic.connection import _get_connection_retry_wait_time
+
+        result = _get_connection_retry_wait_time(-1)
+        assert result == 0.0
+
+    def test_positive_attempts(self):
+        from mmrelay.meshtastic.connection import _get_connection_retry_wait_time
+
+        result = _get_connection_retry_wait_time(2)
+        assert result > 0
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSerialPortExists:
+    def test_existing_port(self):
+        from mmrelay.meshtastic.connection import serial_port_exists
+
+        mock_port = MagicMock()
+        mock_port.device = "/dev/ttyUSB0"
+        with patch.object(
+            mu.serial.tools.list_ports, "comports", return_value=[mock_port]
+        ):
+            assert serial_port_exists("/dev/ttyUSB0") is True
+
+    def test_non_existing_port(self):
+        from mmrelay.meshtastic.connection import serial_port_exists
+
+        with patch.object(mu.serial.tools.list_ports, "comports", return_value=[]):
+            assert serial_port_exists("/dev/ttyUSB0") is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetConnectTimeProbeSettings:
+    def test_none_config_returns_defaults(self):
+        from mmrelay.meshtastic.connection import _get_connect_time_probe_settings
+
+        enabled, timeout = _get_connect_time_probe_settings(None, "tcp")
+        assert isinstance(enabled, bool)
+        assert isinstance(timeout, float)
+
+    def test_non_dict_config_returns_defaults(self):
+        from mmrelay.meshtastic.connection import _get_connect_time_probe_settings
+
+        enabled, timeout = _get_connect_time_probe_settings("not_a_dict", "tcp")
+        assert isinstance(enabled, bool)
+
+    def test_valid_config(self):
+        from mmrelay.meshtastic.connection import _get_connect_time_probe_settings
+
+        config = {
+            "meshtastic": {
+                "health_check": {
+                    "enabled": True,
+                    "connect_probe_enabled": True,
+                    "probe_timeout": 30.0,
+                }
+            }
+        }
+        enabled, timeout = _get_connect_time_probe_settings(config, "tcp")
+        assert enabled is True
+        assert timeout == 30.0
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestScheduleConnectTimeCalibrationProbe:
+    def test_disabled_probe(self):
+        from mmrelay.meshtastic.connection import (
+            _schedule_connect_time_calibration_probe,
+        )
+
+        config = {
+            "meshtastic": {
+                "health_check": {
+                    "enabled": False,
+                    "connect_probe_enabled": False,
+                }
+            }
+        }
+        client = MagicMock()
+        client.localNode = MagicMock()
+        _schedule_connect_time_calibration_probe(
+            client, connection_type="tcp", active_config=config
+        )
+
+    def test_no_local_node(self):
+        from mmrelay.meshtastic.connection import (
+            _schedule_connect_time_calibration_probe,
+        )
+
+        config = {
+            "meshtastic": {
+                "health_check": {"enabled": True, "connect_probe_enabled": True}
+            }
+        }
+        client = MagicMock()
+        client.localNode = None
+        _schedule_connect_time_calibration_probe(
+            client, connection_type="tcp", active_config=config
+        )
+
+    def test_degraded_executor_skips(self):
+        from mmrelay.meshtastic.connection import (
+            _schedule_connect_time_calibration_probe,
+        )
+
+        config = {
+            "meshtastic": {
+                "health_check": {"enabled": True, "connect_probe_enabled": True}
+            }
+        }
+        client = MagicMock()
+        client.localNode = MagicMock()
+        client.sendData = MagicMock()
+
+        with patch.object(
+            mu,
+            "_submit_metadata_probe",
+            side_effect=mu.MetadataExecutorDegradedError("degraded"),
+        ):
+            _schedule_connect_time_calibration_probe(
+                client, connection_type="tcp", active_config=config
+            )
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRollbackConnectAttemptState:
+    def test_rollback_with_none_client(self):
+        from mmrelay.meshtastic.connection import _rollback_connect_attempt_state
+
+        result = _rollback_connect_attempt_state(
+            client=None,
+            client_assigned_for_this_connect=False,
+            startup_drain_armed_for_this_connect=False,
+            startup_drain_applied_for_this_connect=False,
+            reconnect_bootstrap_armed_for_this_connect=False,
+        )
+        assert result is False
+
+    def test_rollback_with_assigned_client(self):
+        from mmrelay.meshtastic.connection import _rollback_connect_attempt_state
+
+        mock_client = MagicMock()
+        mu.meshtastic_client = mock_client
+        mu.meshtastic_iface = None
+        mu._relay_active_client_id = id(mock_client)
+
+        result = _rollback_connect_attempt_state(
+            client=mock_client,
+            client_assigned_for_this_connect=True,
+            startup_drain_armed_for_this_connect=False,
+            startup_drain_applied_for_this_connect=False,
+            reconnect_bootstrap_armed_for_this_connect=False,
+        )
+        assert result is False
+        assert mu.meshtastic_client is None
+
+    def test_rollback_drain_state(self):
+        from mmrelay.meshtastic.connection import _rollback_connect_attempt_state
+
+        mock_timer = MagicMock()
+        mu._relay_startup_drain_expiry_timer = mock_timer
+        mu._relay_startup_drain_deadline_monotonic_secs = 999.0
+        mu._startup_packet_drain_applied = True
+        mu._relay_startup_drain_complete_event = MagicMock()
+
+        result = _rollback_connect_attempt_state(
+            client=None,
+            client_assigned_for_this_connect=False,
+            startup_drain_armed_for_this_connect=True,
+            startup_drain_applied_for_this_connect=True,
+            reconnect_bootstrap_armed_for_this_connect=False,
+        )
+        assert result is False
+        assert mu._relay_startup_drain_deadline_monotonic_secs is None
+
+    def test_rollback_reconnect_bootstrap(self):
+        from mmrelay.meshtastic.connection import _rollback_connect_attempt_state
+
+        mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = 999.0
+
+        result = _rollback_connect_attempt_state(
+            client=None,
+            client_assigned_for_this_connect=False,
+            startup_drain_armed_for_this_connect=False,
+            startup_drain_applied_for_this_connect=False,
+            reconnect_bootstrap_armed_for_this_connect=True,
+        )
+        assert result is False
+        assert mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestConnectMeshtastic:
+    def test_shutdown_returns_none(self):
+        from mmrelay.meshtastic.connection import connect_meshtastic
+
+        mu.shutting_down = True
+        result = connect_meshtastic()
+        assert result is None
+        mu.shutting_down = False
+
+    def test_reconnecting_returns_none(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        mu.shutting_down = False
+        mu.reconnecting = True
+        result = _connect_meshtastic_impl()
+        assert result is None
+        mu.reconnecting = False
+
+    def test_no_config_returns_none(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        mu.config = None
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        result = _connect_meshtastic_impl()
+        assert result is None
+
+    def test_no_meshtastic_section(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        mu.config = {}
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        result = _connect_meshtastic_impl()
+        assert result is None
+
+    def test_no_connection_type(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        mu.config = {"meshtastic": {}}
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        result = _connect_meshtastic_impl()
+        assert result is None
+
+    def test_unknown_connection_type(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        mu.config = {"meshtastic": {"connection_type": "unknown"}}
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        result = _connect_meshtastic_impl()
+        assert result is None
+
+    def test_existing_client_returned(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        existing = MagicMock()
+        mu.config = {"meshtastic": {"connection_type": "tcp"}}
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = existing
+        mu.meshtastic_iface = None
+        result = _connect_meshtastic_impl()
+        assert result is existing

--- a/tests/test_meshtastic_events.py
+++ b/tests/test_meshtastic_events.py
@@ -148,12 +148,24 @@ class TestOnLostMeshtasticConnection:
         mock_loop.is_running.return_value = True
         mu.event_loop = mock_loop
 
+        scheduled_reconnect_task = MagicMock()
+
+        def _schedule_coroutine(coro, _loop):
+            coro.close()
+            return scheduled_reconnect_task
+
         with (
             patch.object(mu, "_disconnect_ble_interface"),
             patch.object(mu, "reset_executor_degraded_state"),
+            patch.object(
+                mu.asyncio,
+                "run_coroutine_threadsafe",
+                side_effect=_schedule_coroutine,
+            ),
         ):
             on_lost_meshtastic_connection()
         assert mu.reconnecting is True
+        assert mu.reconnect_task is scheduled_reconnect_task
         mu.reconnecting = False
 
 

--- a/tests/test_meshtastic_events.py
+++ b/tests/test_meshtastic_events.py
@@ -1,0 +1,263 @@
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDeriveDisconnectDetectionSource:
+    def test_known_source_returned(self):
+        from mmrelay.meshtastic.events import _derive_disconnect_detection_source
+
+        result = _derive_disconnect_detection_source(MagicMock(), "tcp_error", None)
+        assert result == "tcp_error"
+
+    def test_interface_source_used(self):
+        from mmrelay.meshtastic.events import _derive_disconnect_detection_source
+
+        iface = MagicMock()
+        iface._last_disconnect_source = "ble.disconnect"
+        result = _derive_disconnect_detection_source(iface, "unknown", None)
+        assert result == "disconnect"
+
+    def test_topic_name_used(self):
+        from mmrelay.meshtastic.events import _derive_disconnect_detection_source
+
+        topic = MagicMock()
+        topic.getName.return_value = "meshtastic.connection.lost"
+        result = _derive_disconnect_detection_source(MagicMock(), "unknown", topic)
+        assert result == "meshtastic.connection.lost"
+
+    def test_fallback_default(self):
+        from mmrelay.meshtastic.events import _derive_disconnect_detection_source
+
+        iface = MagicMock(spec=[])
+        result = _derive_disconnect_detection_source(
+            iface, "unknown", mu.pub.AUTO_TOPIC
+        )
+        assert result == "meshtastic.connection.lost"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestTearDownMeshtasticClientForDisconnect:
+    def test_no_client_returns(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        mu.meshtastic_client = None
+        _tear_down_meshtastic_client_for_disconnect("test")
+
+    def test_ble_interface_disconnect(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        mock_iface = MagicMock()
+        mu.meshtastic_client = mock_iface
+        mu.meshtastic_iface = mock_iface
+
+        with patch.object(mu, "_disconnect_ble_interface"):
+            _tear_down_meshtastic_client_for_disconnect("test")
+        assert mu.meshtastic_iface is None
+
+    def test_non_ble_client_close(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        client = MagicMock()
+        mu.meshtastic_client = client
+        mu.meshtastic_iface = None
+
+        _tear_down_meshtastic_client_for_disconnect("test")
+        client.close.assert_called_once()
+
+    def test_os_error_on_close(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        client = MagicMock()
+        client.close.side_effect = OSError()
+        client.close.side_effect.errno = mu.ERRNO_BAD_FILE_DESCRIPTOR
+        mu.meshtastic_client = client
+        mu.meshtastic_iface = None
+
+        _tear_down_meshtastic_client_for_disconnect("test")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestOnLostMeshtasticConnection:
+    def test_shutdown_returns(self):
+        from mmrelay.meshtastic.events import on_lost_meshtastic_connection
+
+        mu.shutting_down = True
+        on_lost_meshtastic_connection()
+        mu.shutting_down = False
+
+    def test_reconnecting_returns(self):
+        from mmrelay.meshtastic.events import on_lost_meshtastic_connection
+
+        mu.shutting_down = False
+        mu.reconnecting = True
+        mu.meshtastic_client = MagicMock()
+        on_lost_meshtastic_connection()
+        mu.reconnecting = False
+
+    def test_stale_interface_ignored(self):
+        from mmrelay.meshtastic.events import on_lost_meshtastic_connection
+
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = MagicMock()
+        mu._relay_active_client_id = 99999
+
+        stale_iface = MagicMock()
+        on_lost_meshtastic_connection(interface=stale_iface)
+
+    def test_no_client_with_callbacks_tearing_down(self):
+        from mmrelay.meshtastic.events import on_lost_meshtastic_connection
+
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        mu._relay_active_client_id = None
+        mu._callbacks_tearing_down = True
+        mu.subscribed_to_connection_lost = False
+
+        iface = MagicMock()
+        on_lost_meshtastic_connection(interface=iface)
+
+    def test_triggers_reconnect(self):
+        from mmrelay.meshtastic.events import on_lost_meshtastic_connection
+
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = MagicMock()
+        mu._relay_active_client_id = None
+        mu.meshtastic_iface = None
+        mu._ble_future = None
+        mu._ble_future_address = None
+        mu._ble_executor_degraded_addresses = set()
+
+        mock_loop = MagicMock()
+        mock_loop.is_closed.return_value = False
+        mock_loop.is_running.return_value = True
+        mu.event_loop = mock_loop
+
+        with (
+            patch.object(mu, "_disconnect_ble_interface"),
+            patch.object(mu, "reset_executor_degraded_state"),
+        ):
+            on_lost_meshtastic_connection()
+        assert mu.reconnecting is True
+        mu.reconnecting = False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestOnMeshtasticMessage:
+    def test_empty_packet_returns(self):
+        from mmrelay.meshtastic.events import on_meshtastic_message
+
+        on_meshtastic_message({}, MagicMock())
+
+    def test_none_packet_returns(self):
+        from mmrelay.meshtastic.events import on_meshtastic_message
+
+        on_meshtastic_message(None, MagicMock())
+
+    def test_shutdown_returns(self):
+        from mmrelay.meshtastic.events import on_meshtastic_message
+
+        mu.shutting_down = True
+        on_meshtastic_message({"decoded": {}}, MagicMock())
+        mu.shutting_down = False
+
+    def test_no_client_returns(self):
+        from mmrelay.meshtastic.events import on_meshtastic_message
+
+        mu.meshtastic_client = None
+        mu._relay_active_client_id = None
+        mu._callbacks_tearing_down = True
+        mu.subscribed_to_messages = False
+        mu.reconnecting = False
+        mu.shutting_down = False
+        on_meshtastic_message({"decoded": {}}, MagicMock())
+
+    def test_stale_interface_ignored(self):
+        from mmrelay.meshtastic.events import on_meshtastic_message
+
+        mu.meshtastic_client = MagicMock()
+        mu._relay_active_client_id = 99999
+        mu.shutting_down = False
+        mu._callbacks_tearing_down = False
+        mu.subscribed_to_messages = False
+        mu.reconnecting = False
+
+        stale_iface = MagicMock()
+        on_meshtastic_message({"decoded": {}}, stale_iface)
+
+    def test_no_config_returns(self):
+        from mmrelay.meshtastic.events import on_meshtastic_message
+
+        iface = MagicMock()
+        iface.myInfo.my_node_num = 12345
+        mu.meshtastic_client = iface
+        mu._relay_active_client_id = id(iface)
+        mu.config = None
+        mu.shutting_down = False
+        mu._callbacks_tearing_down = False
+        mu.subscribed_to_messages = False
+        mu.reconnecting = False
+        mu._relay_startup_drain_deadline_monotonic_secs = None
+        mu._relay_rx_time_clock_skew_secs = None
+
+        packet = {
+            "decoded": {"portnum": "TEXT_MESSAGE_APP", "text": "hello"},
+            "fromId": "!abc",
+            "to": 4294967295,
+            "rxTime": 0,
+        }
+        on_meshtastic_message(packet, iface)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestScheduleStartupDrainDeadlineCleanup:
+    def test_schedule_with_future_deadline(self):
+        from mmrelay.meshtastic.events import _schedule_startup_drain_deadline_cleanup
+
+        deadline = time.monotonic() + 10.0
+        mu._relay_startup_drain_expiry_timer = None
+        mu._relay_startup_drain_deadline_monotonic_secs = deadline
+
+        _schedule_startup_drain_deadline_cleanup(deadline)
+        assert mu._relay_startup_drain_expiry_timer is not None
+        mu._relay_startup_drain_expiry_timer.cancel()
+        mu._relay_startup_drain_expiry_timer = None
+
+    def test_schedule_replaces_existing_timer(self):
+        from mmrelay.meshtastic.events import _schedule_startup_drain_deadline_cleanup
+
+        old_timer = MagicMock()
+        mu._relay_startup_drain_expiry_timer = old_timer
+
+        deadline = time.monotonic() + 10.0
+        with patch("threading.Timer") as MockTimer:
+            mock_timer = MagicMock()
+            MockTimer.return_value = mock_timer
+            _schedule_startup_drain_deadline_cleanup(deadline)
+            old_timer.cancel.assert_called_once()
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestReconnect:
+    @pytest.mark.asyncio
+    async def test_shutdown_skips(self):
+        from mmrelay.meshtastic.events import reconnect
+
+        mu.shutting_down = True
+        await reconnect()
+        assert mu.reconnecting is False

--- a/tests/test_meshtastic_executors.py
+++ b/tests/test_meshtastic_executors.py
@@ -1,6 +1,5 @@
-import threading
 from concurrent.futures import Future, ThreadPoolExecutor
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_meshtastic_executors.py
+++ b/tests/test_meshtastic_executors.py
@@ -1,0 +1,335 @@
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestShutdownSharedExecutors:
+    def test_shutdown_cancels_pending_ble_future(self):
+        from mmrelay.meshtastic.executors import _shutdown_shared_executors
+
+        mock_future = MagicMock()
+        mock_future.done.return_value = False
+        mu._ble_future = mock_future
+        mu._ble_future_address = "AA:BB:CC:DD:EE:FF"
+        mu._ble_future_started_at = None
+        mu._ble_future_timeout_secs = None
+
+        mock_executor = MagicMock()
+        mock_executor._shutdown = False
+        mu._ble_executor = mock_executor
+
+        _shutdown_shared_executors()
+
+        mock_future.cancel.assert_called_once()
+
+    def test_shutdown_cancels_pending_metadata_future(self):
+        from mmrelay.meshtastic.executors import _shutdown_shared_executors
+
+        mock_future = MagicMock()
+        mock_future.done.return_value = False
+        mu._metadata_future = mock_future
+        mu._metadata_future_started_at = None
+
+        mock_executor = MagicMock()
+        mock_executor._shutdown = False
+        mu._metadata_executor = mock_executor
+
+        _shutdown_shared_executors()
+
+        mock_future.cancel.assert_called_once()
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetBleExecutor:
+    def test_creates_when_none(self):
+        from mmrelay.meshtastic.executors import _get_ble_executor
+
+        mu._ble_executor = None
+        with mu._ble_executor_lock:
+            executor = _get_ble_executor()
+        assert executor is not None
+        assert isinstance(executor, ThreadPoolExecutor)
+        executor.shutdown(wait=False)
+
+    def test_recreates_when_shutdown(self):
+        from mmrelay.meshtastic.executors import _get_ble_executor
+
+        old = ThreadPoolExecutor(max_workers=1)
+        old.shutdown(wait=False)
+        old._shutdown = True
+        mu._ble_executor = old
+        with mu._ble_executor_lock:
+            executor = _get_ble_executor()
+        assert executor is not old
+        assert isinstance(executor, ThreadPoolExecutor)
+        executor.shutdown(wait=False)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetMetadataExecutor:
+    def test_creates_when_none(self):
+        from mmrelay.meshtastic.executors import _get_metadata_executor
+
+        mu._metadata_executor = None
+        with mu._metadata_future_lock:
+            executor = _get_metadata_executor()
+        assert executor is not None
+        assert isinstance(executor, ThreadPoolExecutor)
+        executor.shutdown(wait=False)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRecordBleTimeout:
+    def test_increments_count(self):
+        from mmrelay.meshtastic.executors import _record_ble_timeout
+
+        count = _record_ble_timeout("AA:BB")
+        assert count == 1
+        count = _record_ble_timeout("AA:BB")
+        assert count == 2
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestClearBleFuture:
+    def test_clears_matching_future(self):
+        from mmrelay.meshtastic.executors import _clear_ble_future
+
+        fut = Future()
+        fut.set_result(None)
+        mu._ble_future = fut
+        mu._ble_future_address = "AA:BB:CC:DD:EE:FF"
+        mu._ble_future_started_at = 123.0
+        mu._ble_future_timeout_secs = 10.0
+        mu._ble_timeout_counts = {"AA:BB:CC:DD:EE:FF": 3}
+
+        _clear_ble_future(fut)
+
+        assert mu._ble_future is None
+        assert mu._ble_future_address is None
+        assert "AA:BB:CC:DD:EE:FF" not in mu._ble_timeout_counts
+
+    def test_ignores_non_matching_future(self):
+        from mmrelay.meshtastic.executors import _clear_ble_future
+
+        other = Future()
+        other.set_result(None)
+        mu._ble_future = other
+        mu._ble_future_address = "AA:BB"
+        mu._ble_future_started_at = 123.0
+
+        wrong = Future()
+        wrong.set_result(None)
+
+        _clear_ble_future(wrong)
+
+        assert mu._ble_future is other
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestResetMetadataExecutorForStaleProbe:
+    def test_degraded_state_refuses_reset(self):
+        from mmrelay.meshtastic.executors import (
+            _reset_metadata_executor_for_stale_probe,
+        )
+
+        mu._metadata_executor_degraded = True
+        _reset_metadata_executor_for_stale_probe()
+        assert mu._metadata_executor_degraded is True
+
+    def test_enters_degraded_at_threshold(self):
+        from mmrelay.meshtastic.executors import (
+            _reset_metadata_executor_for_stale_probe,
+        )
+
+        mu._metadata_executor_degraded = False
+        mu._metadata_executor_orphaned_workers = mu.EXECUTOR_ORPHAN_THRESHOLD - 1
+        mock_executor = MagicMock()
+        mock_executor._shutdown = False
+        mu._metadata_executor = mock_executor
+
+        _reset_metadata_executor_for_stale_probe()
+
+        assert mu._metadata_executor_degraded is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestResetExecutorDegradedState:
+    def test_reset_all(self):
+        from mmrelay.meshtastic.executors import reset_executor_degraded_state
+
+        mu._ble_executor_degraded_addresses = {"AA:BB"}
+        mu._ble_executor_orphaned_workers_by_address = {"AA:BB": 5}
+        mu._metadata_executor_degraded = True
+        mu._metadata_executor_orphaned_workers = 3
+
+        mock_executor = MagicMock()
+        mock_executor._shutdown = False
+        mu._ble_executor = mock_executor
+        mu._metadata_executor = MagicMock()
+        mu._metadata_executor._shutdown = False
+
+        result = reset_executor_degraded_state(reset_all=True)
+        assert result is True
+        assert len(mu._ble_executor_degraded_addresses) == 0
+        assert mu._metadata_executor_degraded is False
+
+    def test_reset_specific_address(self):
+        from mmrelay.meshtastic.executors import reset_executor_degraded_state
+
+        mu._ble_executor_degraded_addresses = {"AA:BB", "CC:DD"}
+        mu._ble_executor_orphaned_workers_by_address = {"AA:BB": 5}
+        mu._metadata_executor_degraded = True
+
+        mock_executor = MagicMock()
+        mock_executor._shutdown = False
+        mu._ble_executor = mock_executor
+        mu._metadata_executor = MagicMock()
+        mu._metadata_executor._shutdown = False
+
+        result = reset_executor_degraded_state(ble_address="AA:BB")
+        assert result is True
+        assert "AA:BB" not in mu._ble_executor_degraded_addresses
+        assert "CC:DD" in mu._ble_executor_degraded_addresses
+
+    def test_nothing_to_reset(self):
+        from mmrelay.meshtastic.executors import reset_executor_degraded_state
+
+        mu._ble_executor_degraded_addresses = set()
+        mu._metadata_executor_degraded = False
+
+        result = reset_executor_degraded_state(ble_address="AA:BB")
+        assert result is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestClearMetadataFutureIfCurrent:
+    def test_clears_matching(self):
+        from mmrelay.meshtastic.executors import _clear_metadata_future_if_current
+
+        fut = Future()
+        fut.set_result(None)
+        mu._metadata_future = fut
+        mu._metadata_future_started_at = 100.0
+
+        _clear_metadata_future_if_current(fut)
+        assert mu._metadata_future is None
+        assert mu._metadata_future_started_at is None
+
+    def test_ignores_non_matching(self):
+        from mmrelay.meshtastic.executors import _clear_metadata_future_if_current
+
+        other = Future()
+        other.set_result(None)
+        mu._metadata_future = other
+        mu._metadata_future_started_at = 100.0
+
+        wrong = Future()
+        wrong.set_result(None)
+        _clear_metadata_future_if_current(wrong)
+        assert mu._metadata_future is other
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestEnsureBleWorkerAvailable:
+    def test_no_active_future_returns(self):
+        from mmrelay.meshtastic.executors import _ensure_ble_worker_available
+
+        mu._ble_future = None
+        _ensure_ble_worker_available("AA:BB", operation="test")
+
+    def test_done_future_returns(self):
+        from mmrelay.meshtastic.executors import _ensure_ble_worker_available
+
+        fut = Future()
+        fut.set_result(None)
+        mu._ble_future = fut
+        _ensure_ble_worker_available("AA:BB", operation="test")
+
+    def test_stale_future_gets_reset(self):
+        from mmrelay.meshtastic.executors import _ensure_ble_worker_available
+
+        fut = MagicMock()
+        fut.done.return_value = False
+        mu._ble_future = fut
+        mu._ble_future_started_at = 0.0
+        mu._ble_future_timeout_secs = 0.1
+        mu._ble_future_address = "AA:BB"
+
+        with (
+            patch.object(mu, "_reset_ble_connection_gate_state"),
+            patch.object(mu, "_maybe_reset_ble_executor"),
+            patch.object(mu, "_record_ble_timeout", return_value=5),
+        ):
+            with pytest.raises(TimeoutError):
+                _ensure_ble_worker_available("AA:BB", operation="test")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestMaybeResetBleExecutor:
+    def test_below_threshold_returns(self):
+        from mmrelay.meshtastic.executors import _maybe_reset_ble_executor
+
+        mu._ble_executor_degraded_addresses = set()
+        _maybe_reset_ble_executor("AA:BB", timeout_count=1)
+        assert mu._ble_executor is not None
+
+    def test_at_threshold_recreates(self):
+        from mmrelay.meshtastic.executors import _maybe_reset_ble_executor
+
+        threshold = mu.BLE_TIMEOUT_RESET_THRESHOLD
+        mu._ble_executor_degraded_addresses = set()
+        mu._ble_executor_orphaned_workers_by_address = {"AA:BB": 0}
+
+        mock_executor = MagicMock()
+        mock_executor._shutdown = False
+        mu._ble_executor = mock_executor
+
+        _maybe_reset_ble_executor("AA:BB", timeout_count=threshold)
+        assert mu._ble_executor is not mock_executor
+
+    def test_degraded_address_refuses(self):
+        from mmrelay.meshtastic.executors import _maybe_reset_ble_executor
+
+        mu._ble_executor_degraded_addresses = {"AA:BB"}
+        old_executor = mu._ble_executor
+        _maybe_reset_ble_executor("AA:BB", timeout_count=999)
+        assert mu._ble_executor is old_executor
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSubmitMetadataProbe:
+    def test_returns_none_when_already_running(self):
+        from mmrelay.meshtastic.executors import _submit_metadata_probe
+
+        fut = MagicMock()
+        fut.done.return_value = False
+        mu._metadata_future = fut
+        mu._metadata_future_started_at = mu.time.monotonic()
+
+        result = _submit_metadata_probe(lambda: None)
+        assert result is None
+
+    def test_raises_on_degraded(self):
+        from mmrelay.meshtastic.executors import _submit_metadata_probe
+
+        mu._metadata_executor_degraded = True
+        mu._metadata_future = None
+
+        with pytest.raises(mu.MetadataExecutorDegradedError):
+            _submit_metadata_probe(lambda: None)
+
+    def test_submits_successfully(self):
+        from mmrelay.meshtastic.executors import _submit_metadata_probe
+
+        mu._metadata_executor_degraded = False
+        mu._metadata_future = None
+        mu._metadata_executor = ThreadPoolExecutor(max_workers=1)
+
+        result = _submit_metadata_probe(lambda: 42)
+        assert result is not None
+        result.result(timeout=2.0)

--- a/tests/test_meshtastic_executors.py
+++ b/tests/test_meshtastic_executors.py
@@ -273,9 +273,12 @@ class TestMaybeResetBleExecutor:
     def test_below_threshold_returns(self):
         from mmrelay.meshtastic.executors import _maybe_reset_ble_executor
 
+        existing_executor = MagicMock()
+        existing_executor._shutdown = False
+        mu._ble_executor = existing_executor
         mu._ble_executor_degraded_addresses = set()
         _maybe_reset_ble_executor("AA:BB", timeout_count=1)
-        assert mu._ble_executor is not None
+        assert mu._ble_executor is existing_executor
 
     def test_at_threshold_recreates(self):
         from mmrelay.meshtastic.executors import _maybe_reset_ble_executor

--- a/tests/test_meshtastic_health.py
+++ b/tests/test_meshtastic_health.py
@@ -1,5 +1,4 @@
 import time
-from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_meshtastic_health.py
+++ b/tests/test_meshtastic_health.py
@@ -1,0 +1,373 @@
+import time
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestExtractPacketRequestId:
+    def test_non_dict_returns_none(self):
+        from mmrelay.meshtastic.health import _extract_packet_request_id
+
+        assert _extract_packet_request_id("not_a_dict") is None
+
+    def test_dict_with_request_id(self):
+        from mmrelay.meshtastic.health import _extract_packet_request_id
+
+        assert _extract_packet_request_id({"requestId": 42}) == 42
+
+    def test_dict_with_decoded_request_id(self):
+        from mmrelay.meshtastic.health import _extract_packet_request_id
+
+        assert _extract_packet_request_id({"decoded": {"requestId": 99}}) == 99
+
+    def test_dict_with_no_request_id(self):
+        from mmrelay.meshtastic.health import _extract_packet_request_id
+
+        assert _extract_packet_request_id({}) is None
+
+    def test_dict_with_zero_request_id(self):
+        from mmrelay.meshtastic.health import _extract_packet_request_id
+
+        assert _extract_packet_request_id({"requestId": 0}) is None
+
+    def test_dict_with_negative_request_id(self):
+        from mmrelay.meshtastic.health import _extract_packet_request_id
+
+        assert _extract_packet_request_id({"requestId": -1}) is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestPruneHealthProbeTracking:
+    def test_prunes_expired(self):
+        from mmrelay.meshtastic.health import _prune_health_probe_tracking
+
+        mu._health_probe_request_deadlines = {1: 100.0, 2: 200.0}
+        _prune_health_probe_tracking(now=150.0)
+        assert 1 not in mu._health_probe_request_deadlines
+        assert 2 in mu._health_probe_request_deadlines
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestTrackHealthProbeRequestId:
+    def test_returns_none_for_invalid_id(self):
+        from mmrelay.meshtastic.health import _track_health_probe_request_id
+
+        result = _track_health_probe_request_id("invalid", 10.0)
+        assert result is None
+
+    def test_tracks_valid_id(self):
+        from mmrelay.meshtastic.health import _track_health_probe_request_id
+
+        result = _track_health_probe_request_id(42, 10.0)
+        assert result == 42
+        assert 42 in mu._health_probe_request_deadlines
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSeedConnectTimeSkew:
+    def test_zero_rx_time_returns_false(self):
+        from mmrelay.meshtastic.health import _seed_connect_time_skew
+
+        assert _seed_connect_time_skew(0) is False
+
+    def test_already_calibrated_returns_false(self):
+        from mmrelay.meshtastic.health import _seed_connect_time_skew
+
+        mu._relay_rx_time_clock_skew_secs = 1.0
+        assert _seed_connect_time_skew(time.time()) is False
+
+    def test_calibrates_from_post_start_packet(self):
+        from mmrelay.meshtastic.health import _seed_connect_time_skew
+
+        mu._relay_rx_time_clock_skew_secs = None
+        mu.RELAY_START_TIME = time.time() - 10
+        mu._relay_connection_started_monotonic_secs = time.monotonic() - 1
+        mu._relay_startup_drain_deadline_monotonic_secs = time.monotonic() + 10
+        mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = None
+
+        rx_time = time.time()
+        result = _seed_connect_time_skew(rx_time)
+        assert result is True
+        assert mu._relay_rx_time_clock_skew_secs is not None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestIsHealthProbeResponsePacket:
+    def test_no_request_id(self):
+        from mmrelay.meshtastic.health import _is_health_probe_response_packet
+
+        assert _is_health_probe_response_packet({}, MagicMock()) is False
+
+    def test_different_sender(self):
+        from mmrelay.meshtastic.health import _is_health_probe_response_packet
+
+        packet = {"requestId": 42, "from": 9999}
+        interface = MagicMock()
+        interface.myInfo.my_node_num = 1234
+        mu._health_probe_request_deadlines = {42: time.monotonic() + 60}
+        assert _is_health_probe_response_packet(packet, interface) is False
+
+    def test_valid_response(self):
+        from mmrelay.meshtastic.health import _is_health_probe_response_packet
+
+        packet = {"requestId": 42, "from": 1234}
+        interface = MagicMock()
+        interface.myInfo.my_node_num = 1234
+        mu._health_probe_request_deadlines = {42: time.monotonic() + 60}
+        assert _is_health_probe_response_packet(packet, interface) is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestClaimHealthProbeResponseAndMaybeCalibrate:
+    def test_no_request_id(self):
+        from mmrelay.meshtastic.health import (
+            _claim_health_probe_response_and_maybe_calibrate,
+        )
+
+        assert (
+            _claim_health_probe_response_and_maybe_calibrate({}, MagicMock(), 0)
+            is False
+        )
+
+    def test_claims_and_calibrates(self):
+        from mmrelay.meshtastic.health import (
+            _claim_health_probe_response_and_maybe_calibrate,
+        )
+
+        mu._relay_rx_time_clock_skew_secs = None
+        mu._health_probe_request_deadlines = {42: time.monotonic() + 60}
+        packet = {"requestId": 42, "from": 1234}
+        interface = MagicMock()
+        interface.myInfo.my_node_num = 1234
+
+        result = _claim_health_probe_response_and_maybe_calibrate(
+            packet, interface, time.time()
+        )
+        assert result is True
+        assert 42 not in mu._health_probe_request_deadlines
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSetProbeAckFlagFromPacket:
+    def test_no_iface(self):
+        from mmrelay.meshtastic.health import _set_probe_ack_flag_from_packet
+
+        local_node = MagicMock()
+        local_node.iface = None
+        result = _set_probe_ack_flag_from_packet(local_node, {})
+        assert result is False
+
+    def test_no_ack_state(self):
+        from mmrelay.meshtastic.health import _set_probe_ack_flag_from_packet
+
+        local_node = MagicMock()
+        local_node.iface._acknowledgment = None
+        result = _set_probe_ack_flag_from_packet(local_node, {})
+        assert result is False
+
+    def test_sets_received_impl_ack(self):
+        from mmrelay.meshtastic.health import _set_probe_ack_flag_from_packet
+
+        local_node = MagicMock()
+        iface = local_node.iface
+        iface.localNode.nodeNum = 1234
+        iface._acknowledgment.receivedImplAck = False
+        result = _set_probe_ack_flag_from_packet(local_node, {"from": 1234})
+        assert result is True
+
+    def test_sets_received_ack(self):
+        from mmrelay.meshtastic.health import _set_probe_ack_flag_from_packet
+
+        local_node = MagicMock()
+        iface = local_node.iface
+        del iface.localNode
+        iface._acknowledgment.receivedAck = False
+        result = _set_probe_ack_flag_from_packet(local_node, {})
+        assert result is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestResetProbeAckState:
+    def test_calls_reset_when_available(self):
+        from mmrelay.meshtastic.health import _reset_probe_ack_state
+
+        ack = MagicMock()
+        _reset_probe_ack_state(ack)
+        ack.reset.assert_called_once()
+
+    def test_manually_clears_flags(self):
+        from mmrelay.meshtastic.health import _reset_probe_ack_state
+
+        ack = MagicMock(spec=[])
+        ack.receivedAck = True
+        ack.receivedNak = True
+        ack.receivedImplAck = True
+        _reset_probe_ack_state(ack)
+        assert ack.receivedAck is False
+        assert ack.receivedNak is False
+        assert ack.receivedImplAck is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestHandleProbeAckCallback:
+    def test_no_ack_state_raises(self):
+        from mmrelay.meshtastic.health import _handle_probe_ack_callback
+
+        local_node = MagicMock()
+        local_node.iface._acknowledgment = None
+        with pytest.raises(RuntimeError):
+            _handle_probe_ack_callback(local_node, {})
+
+    def test_nak_with_error_reason(self):
+        from mmrelay.meshtastic.health import _handle_probe_ack_callback
+
+        local_node = MagicMock()
+        ack = local_node.iface._acknowledgment
+        packet = {"decoded": {"routing": {"errorReason": "NO_ROUTE"}}}
+        _handle_probe_ack_callback(local_node, packet)
+        assert ack.receivedNak is True
+
+    def test_no_routing_uses_fallback(self):
+        from mmrelay.meshtastic.health import _handle_probe_ack_callback
+
+        local_node = MagicMock()
+        ack = local_node.iface._acknowledgment
+        local_node.iface.localNode.nodeNum = 1234
+        _handle_probe_ack_callback(local_node, {"decoded": {}, "from": 1234})
+        assert ack.receivedImplAck is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestWaitForProbeAck:
+    def test_none_raises(self):
+        from mmrelay.meshtastic.health import _wait_for_probe_ack
+
+        with pytest.raises(RuntimeError, match="missing acknowledgment"):
+            _wait_for_probe_ack(None, 1.0)
+
+    def test_ack_already_set(self):
+        from mmrelay.meshtastic.health import _wait_for_probe_ack
+
+        ack = MagicMock()
+        ack.receivedAck = True
+        ack.receivedNak = False
+        ack.receivedImplAck = False
+        _wait_for_probe_ack(ack, 1.0)
+        ack.reset.assert_called_once()
+
+    def test_timeout_raises(self):
+        from mmrelay.meshtastic.health import _wait_for_probe_ack
+
+        ack = MagicMock()
+        ack.receivedAck = False
+        ack.receivedNak = False
+        ack.receivedImplAck = False
+        with patch.object(mu.time, "sleep"):
+            with pytest.raises(TimeoutError):
+                _wait_for_probe_ack(ack, 0.01)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRequiresContinuousHealthMonitor:
+    def test_ble_returns_false(self):
+        from mmrelay.meshtastic.health import requires_continuous_health_monitor
+
+        config = {"meshtastic": {"connection_type": "ble"}}
+        assert requires_continuous_health_monitor(config) is False
+
+    def test_disabled_returns_false(self):
+        from mmrelay.meshtastic.health import requires_continuous_health_monitor
+
+        config = {
+            "meshtastic": {
+                "connection_type": "tcp",
+                "health_check": {"enabled": False},
+            }
+        }
+        assert requires_continuous_health_monitor(config) is False
+
+    def test_tcp_enabled_returns_true(self):
+        from mmrelay.meshtastic.health import requires_continuous_health_monitor
+
+        config = {
+            "meshtastic": {
+                "connection_type": "tcp",
+                "health_check": {"enabled": True},
+            }
+        }
+        assert requires_continuous_health_monitor(config) is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestParseHealthCheckConfig:
+    def test_returns_none_when_disabled(self):
+        from mmrelay.meshtastic.health import _parse_health_check_config
+
+        config = {
+            "meshtastic": {
+                "connection_type": "tcp",
+                "health_check": {"enabled": False},
+            }
+        }
+        assert _parse_health_check_config(config) is None
+
+    def test_returns_parsed_when_enabled(self):
+        from mmrelay.meshtastic.health import _parse_health_check_config
+
+        config = {
+            "meshtastic": {
+                "connection_type": "tcp",
+                "health_check": {"enabled": True},
+            }
+        }
+        result = _parse_health_check_config(config)
+        assert result is not None
+        assert result[0] == "tcp"
+
+    def test_invalid_meshtastic_section(self):
+        from mmrelay.meshtastic.health import _parse_health_check_config
+
+        config = {"meshtastic": "not_a_dict"}
+        result = _parse_health_check_config(config)
+        assert result is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestProbeDeviceConnection:
+    def test_no_local_node_raises(self):
+        from mmrelay.meshtastic.health import _probe_device_connection
+
+        client = MagicMock()
+        client.localNode = None
+        with pytest.raises(RuntimeError):
+            _probe_device_connection(client)
+
+    def test_no_send_data_raises(self):
+        from mmrelay.meshtastic.health import _probe_device_connection
+
+        client = MagicMock()
+        client.localNode = MagicMock()
+        client.sendData = None
+        with pytest.raises(RuntimeError):
+            _probe_device_connection(client)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestCheckConnection:
+    @pytest.mark.asyncio
+    async def test_no_config_returns(self):
+        from mmrelay.meshtastic.health import check_connection
+
+        mu.config = None
+        await check_connection()
+
+    @pytest.mark.asyncio
+    async def test_ble_returns_early(self):
+        from mmrelay.meshtastic.health import check_connection
+
+        mu.config = {"meshtastic": {"connection_type": "ble"}}
+        await check_connection()

--- a/tests/test_meshtastic_messaging.py
+++ b/tests/test_meshtastic_messaging.py
@@ -2,8 +2,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import mmrelay.meshtastic_utils as mu
-
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestGetNodeDisplayName:

--- a/tests/test_meshtastic_messaging.py
+++ b/tests/test_meshtastic_messaging.py
@@ -1,0 +1,200 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetNodeDisplayName:
+    def test_short_name_from_interface(self):
+        from mmrelay.meshtastic.messaging import _get_node_display_name
+
+        interface = MagicMock()
+        interface.nodes = {
+            "123": {
+                "user": {
+                    "shortName": "Short",
+                    "longName": "Long Name",
+                }
+            }
+        }
+        result = _get_node_display_name("123", interface)
+        assert result == "Short"
+
+    def test_short_name_from_db_fallback(self):
+        from mmrelay.meshtastic.messaging import _get_node_display_name
+
+        interface = MagicMock()
+        interface.nodes = {}
+        with (
+            patch("mmrelay.db_utils.get_shortname", return_value="DBShort"),
+            patch("mmrelay.db_utils.get_longname", return_value="DBLong"),
+        ):
+            result = _get_node_display_name("456", interface)
+        assert result == "DBShort"
+
+    def test_long_name_from_db_fallback(self):
+        from mmrelay.meshtastic.messaging import _get_node_display_name
+
+        interface = MagicMock()
+        interface.nodes = {}
+        with (
+            patch("mmrelay.db_utils.get_shortname", return_value=None),
+            patch("mmrelay.db_utils.get_longname", return_value="DBLong"),
+        ):
+            result = _get_node_display_name("456", interface)
+        assert result == "DBLong"
+
+    def test_fallback_to_id(self):
+        from mmrelay.meshtastic.messaging import _get_node_display_name
+
+        interface = MagicMock()
+        interface.nodes = {}
+        with (
+            patch("mmrelay.db_utils.get_shortname", return_value=None),
+            patch("mmrelay.db_utils.get_longname", return_value=None),
+        ):
+            result = _get_node_display_name("456", interface)
+        assert result == "456"
+
+    def test_fallback_to_provided_fallback(self):
+        from mmrelay.meshtastic.messaging import _get_node_display_name
+
+        interface = MagicMock()
+        interface.nodes = {}
+        with (
+            patch("mmrelay.db_utils.get_shortname", return_value=None),
+            patch("mmrelay.db_utils.get_longname", return_value=None),
+        ):
+            result = _get_node_display_name("456", interface, fallback="custom")
+        assert result == "custom"
+
+    def test_no_interface(self):
+        from mmrelay.meshtastic.messaging import _get_node_display_name
+
+        with patch("mmrelay.db_utils.get_shortname", return_value="Short"):
+            result = _get_node_display_name("123", None)
+        assert result == "Short"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSendTextReply:
+    def test_send_text_reply_none_interface(self):
+        from mmrelay.meshtastic.messaging import send_text_reply
+
+        result = send_text_reply(None, "hello", 123)
+        assert result is None
+
+    def test_send_text_reply_system_exit(self):
+        from mmrelay.meshtastic.messaging import send_text_reply
+
+        iface = MagicMock()
+        iface._generatePacketId.return_value = 42
+        iface._sendPacket.side_effect = SystemExit(0)
+        with pytest.raises(SystemExit):
+            send_text_reply(iface, "hello", 123)
+
+    def test_send_text_reply_send_error(self):
+        from mmrelay.meshtastic.messaging import send_text_reply
+
+        iface = MagicMock()
+        iface._generatePacketId.return_value = 42
+        iface._sendPacket.side_effect = OSError("fail")
+        result = send_text_reply(iface, "hello", 123)
+        assert result is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestNormalizeRoomChannel:
+    def test_valid_integer(self):
+        from mmrelay.meshtastic.messaging import _normalize_room_channel
+
+        assert _normalize_room_channel({"meshtastic_channel": 3}) == 3
+
+    def test_string_integer(self):
+        from mmrelay.meshtastic.messaging import _normalize_room_channel
+
+        assert _normalize_room_channel({"meshtastic_channel": "2"}) == 2
+
+    def test_none_returns_none(self):
+        from mmrelay.meshtastic.messaging import _normalize_room_channel
+
+        assert _normalize_room_channel({"meshtastic_channel": None}) is None
+
+    def test_missing_key_returns_none(self):
+        from mmrelay.meshtastic.messaging import _normalize_room_channel
+
+        assert _normalize_room_channel({}) is None
+
+    def test_invalid_value_returns_none(self):
+        from mmrelay.meshtastic.messaging import _normalize_room_channel
+
+        assert _normalize_room_channel({"meshtastic_channel": "abc"}) is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetPacketDetails:
+    def test_telemetry_device_metrics(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        decoded = {
+            "telemetry": {
+                "deviceMetrics": {"batteryLevel": 85, "voltage": 3.72},
+            }
+        }
+        result = _get_packet_details(decoded, {}, "TELEMETRY_APP")
+        assert result["batt"] == "85%"
+        assert result["voltage"] == "3.72V"
+
+    def test_telemetry_environment_metrics(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        decoded = {
+            "telemetry": {
+                "environmentMetrics": {
+                    "temperature": 22.5,
+                    "relativeHumidity": 60,
+                },
+            }
+        }
+        result = _get_packet_details(decoded, {}, "TELEMETRY_APP")
+        assert "temp" in result
+        assert "humidity" in result
+
+    def test_signal_info(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        result = _get_packet_details({}, {"rxRssi": -70, "rxSnr": 7.5}, "UNKNOWN")
+        assert "RSSI:-70" in result["signal"]
+        assert "SNR:7.5" in result["signal"]
+
+    def test_relay_node(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        result = _get_packet_details({}, {"relayNode": 42}, "UNKNOWN")
+        assert result["relayed"] == "via 42"
+
+    def test_relay_node_zero_excluded(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        result = _get_packet_details({}, {"relayNode": 0}, "UNKNOWN")
+        assert "relayed" not in result
+
+    def test_priority(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        result = _get_packet_details({}, {"priority": "HIGH"}, "UNKNOWN")
+        assert result["priority"] == "HIGH"
+
+    def test_normal_priority_excluded(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        result = _get_packet_details({}, {"priority": "NORMAL"}, "UNKNOWN")
+        assert "priority" not in result
+
+    def test_none_decoded(self):
+        from mmrelay.meshtastic.messaging import _get_packet_details
+
+        result = _get_packet_details(None, {}, "UNKNOWN")
+        assert result == {}

--- a/tests/test_meshtastic_metadata.py
+++ b/tests/test_meshtastic_metadata.py
@@ -1,0 +1,304 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestNormalizeFirmwareVersion:
+    def test_bytes_decoded(self):
+        from mmrelay.meshtastic.metadata import _normalize_firmware_version
+
+        result = _normalize_firmware_version(b"2.3.1 ")
+        assert result == "2.3.1"
+
+    def test_unknown_string_returns_none(self):
+        from mmrelay.meshtastic.metadata import _normalize_firmware_version
+
+        result = _normalize_firmware_version("unknown")
+        assert result is None
+
+    def test_empty_string_returns_none(self):
+        from mmrelay.meshtastic.metadata import _normalize_firmware_version
+
+        result = _normalize_firmware_version("")
+        assert result is None
+
+    def test_none_returns_none(self):
+        from mmrelay.meshtastic.metadata import _normalize_firmware_version
+
+        result = _normalize_firmware_version(None)
+        assert result is None
+
+    def test_int_returns_none(self):
+        from mmrelay.meshtastic.metadata import _normalize_firmware_version
+
+        result = _normalize_firmware_version(42)
+        assert result is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestExtractFirmwareVersionFromMetadata:
+    def test_none_source(self):
+        from mmrelay.meshtastic.metadata import (
+            _extract_firmware_version_from_metadata,
+        )
+
+        result = _extract_firmware_version_from_metadata(None)
+        assert result is None
+
+    def test_dict_with_firmware_version(self):
+        from mmrelay.meshtastic.metadata import (
+            _extract_firmware_version_from_metadata,
+        )
+
+        result = _extract_firmware_version_from_metadata({"firmware_version": "2.3.1"})
+        assert result == "2.3.1"
+
+    def test_dict_with_camel_case(self):
+        from mmrelay.meshtastic.metadata import (
+            _extract_firmware_version_from_metadata,
+        )
+
+        result = _extract_firmware_version_from_metadata({"firmwareVersion": "2.3.1"})
+        assert result == "2.3.1"
+
+    def test_object_with_firmware_version(self):
+        from mmrelay.meshtastic.metadata import (
+            _extract_firmware_version_from_metadata,
+        )
+
+        source = MagicMock()
+        source.firmware_version = "2.3.1"
+        source.firmwareVersion = None
+        result = _extract_firmware_version_from_metadata(source)
+        assert result == "2.3.1"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestExtractFirmwareVersionFromClient:
+    def test_client_with_metadata(self):
+        from mmrelay.meshtastic.metadata import (
+            _extract_firmware_version_from_client,
+        )
+
+        client = MagicMock()
+        client.metadata = {"firmware_version": "2.3.1"}
+        client.localNode.metadata = None
+        result = _extract_firmware_version_from_client(client)
+        assert result == "2.3.1"
+
+    def test_client_no_metadata(self):
+        from mmrelay.meshtastic.metadata import (
+            _extract_firmware_version_from_client,
+        )
+
+        client = MagicMock()
+        client.metadata = None
+        client.localNode.metadata = None
+        client.localNode.iface.metadata = None
+        result = _extract_firmware_version_from_client(client)
+        assert result is None
+
+    def test_client_no_local_node(self):
+        from mmrelay.meshtastic.metadata import (
+            _extract_firmware_version_from_client,
+        )
+
+        client = MagicMock()
+        client.localNode = None
+        client.metadata = None
+        result = _extract_firmware_version_from_client(client)
+        assert result is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetDeviceMetadata:
+    def test_cached_firmware_returns(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.metadata = {"firmware_version": "2.3.1"}
+        client.localNode = MagicMock()
+        result = _get_device_metadata(client)
+        assert result["firmware_version"] == "2.3.1"
+        assert result["success"] is True
+
+    def test_no_local_node(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode = None
+        result = _get_device_metadata(client, force_refresh=True)
+        assert result["success"] is False
+
+    def test_no_get_metadata_callable(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode = MagicMock()
+        client.localNode.getMetadata = None
+        result = _get_device_metadata(client, force_refresh=True)
+        assert result["success"] is False
+
+    def test_raise_on_error(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode = None
+        with pytest.raises(RuntimeError):
+            _get_device_metadata(client, force_refresh=True, raise_on_error=True)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetNameSafely:
+    def test_function_returns_name(self):
+        from mmrelay.meshtastic.metadata import _get_name_safely
+
+        result = _get_name_safely(lambda x: "TestName", "sender")
+        assert result == "TestName"
+
+    def test_function_returns_none(self):
+        from mmrelay.meshtastic.metadata import _get_name_safely
+
+        result = _get_name_safely(lambda x: None, "sender")
+        assert result == "sender"
+
+    def test_function_raises(self):
+        from mmrelay.meshtastic.metadata import _get_name_safely
+
+        result = _get_name_safely(lambda x: (_ for _ in ()).throw(TypeError), "sender")
+        assert result == "sender"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetNameOrNone:
+    def test_function_returns_name(self):
+        from mmrelay.meshtastic.metadata import _get_name_or_none
+
+        result = _get_name_or_none(lambda x: "TestName", "sender")
+        assert result == "TestName"
+
+    def test_function_returns_none(self):
+        from mmrelay.meshtastic.metadata import _get_name_or_none
+
+        result = _get_name_or_none(lambda x: None, "sender")
+        assert result is None
+
+    def test_function_raises(self):
+        from mmrelay.meshtastic.metadata import _get_name_or_none
+
+        result = _get_name_or_none(lambda x: (_ for _ in ()).throw(TypeError), "sender")
+        assert result is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetDeviceMetadataDeep:
+    def test_force_refresh_with_success(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        client.metadata = {"firmware_version": "2.3.1"}
+        future = MagicMock()
+        future.result.return_value = None
+        future.done.return_value = True
+        with patch.object(mu, "_submit_metadata_probe", return_value=future):
+            result = _get_device_metadata(client, force_refresh=True)
+        assert result["firmware_version"] == "2.3.1"
+        assert result["success"] is True
+
+    def test_force_refresh_timeout(self):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        client.metadata = None
+        client.localNode.metadata = None
+        future = MagicMock()
+        future.result.side_effect = FuturesTimeoutError()
+        future.done.return_value = False
+        with patch.object(mu, "_submit_metadata_probe", return_value=future):
+            result = _get_device_metadata(client, force_refresh=True)
+        assert result["success"] is False
+
+    def test_force_refresh_degraded_executor(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        with patch.object(
+            mu,
+            "_submit_metadata_probe",
+            side_effect=mu.MetadataExecutorDegradedError("degraded"),
+        ):
+            result = _get_device_metadata(client, force_refresh=True)
+        assert result["success"] is False
+
+    def test_force_refresh_runtime_error_submission(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        with patch.object(
+            mu,
+            "_submit_metadata_probe",
+            side_effect=RuntimeError("no executor"),
+        ):
+            result = _get_device_metadata(client, force_refresh=True)
+        assert result["success"] is False
+
+    def test_force_refresh_future_none(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        with patch.object(mu, "_submit_metadata_probe", return_value=None):
+            result = _get_device_metadata(client, force_refresh=True)
+        assert result["success"] is False
+
+    def test_force_refresh_exception_during_future(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        client.metadata = None
+        client.localNode.metadata = None
+        future = MagicMock()
+        future.result.side_effect = RuntimeError("probe failed")
+        future.done.return_value = True
+        with patch.object(mu, "_submit_metadata_probe", return_value=future):
+            result = _get_device_metadata(client, force_refresh=True)
+        assert result["success"] is False
+
+    def test_raise_on_error_with_degraded(self):
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        with patch.object(
+            mu,
+            "_submit_metadata_probe",
+            side_effect=mu.MetadataExecutorDegradedError("degraded"),
+        ):
+            with pytest.raises(mu.MetadataExecutorDegradedError):
+                _get_device_metadata(client, force_refresh=True, raise_on_error=True)
+
+    def test_force_refresh_timeout_with_raise(self):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        from mmrelay.meshtastic.metadata import _get_device_metadata
+
+        client = MagicMock()
+        client.localNode.getMetadata.return_value = None
+        client.metadata = None
+        client.localNode.metadata = None
+        future = MagicMock()
+        future.result.side_effect = FuturesTimeoutError()
+        future.done.return_value = False
+        with patch.object(mu, "_submit_metadata_probe", return_value=future):
+            with pytest.raises(FuturesTimeoutError):
+                _get_device_metadata(client, force_refresh=True, raise_on_error=True)

--- a/tests/test_meshtastic_node_refresh.py
+++ b/tests/test_meshtastic_node_refresh.py
@@ -1,0 +1,169 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestParseRefreshIntervalSeconds:
+    def test_bool_rejected(self):
+        from mmrelay.meshtastic.node_refresh import _parse_refresh_interval_seconds
+
+        assert _parse_refresh_interval_seconds(True) is None
+
+    def test_infinite_rejected(self):
+        from mmrelay.meshtastic.node_refresh import _parse_refresh_interval_seconds
+
+        assert _parse_refresh_interval_seconds(float("inf")) is None
+
+    def test_negative_rejected(self):
+        from mmrelay.meshtastic.node_refresh import _parse_refresh_interval_seconds
+
+        assert _parse_refresh_interval_seconds(-1.0) is None
+
+    def test_zero_valid(self):
+        from mmrelay.meshtastic.node_refresh import _parse_refresh_interval_seconds
+
+        assert _parse_refresh_interval_seconds(0) == 0.0
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetNodeDBRefreshIntervalSeconds:
+    def test_invalid_interval_uses_default(self):
+        from mmrelay.constants.config import DEFAULT_NODEDB_REFRESH_INTERVAL
+        from mmrelay.meshtastic.node_refresh import get_nodedb_refresh_interval_seconds
+
+        cfg = {"meshtastic": {"nodedb_refresh_interval": True}}
+        result = get_nodedb_refresh_interval_seconds(cfg)
+        assert result == DEFAULT_NODEDB_REFRESH_INTERVAL
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSnapshotNodeNameRows:
+    def test_client_none(self):
+        from mmrelay.meshtastic.node_refresh import _snapshot_node_name_rows
+
+        mu.meshtastic_client = None
+        snapshot, missing = _snapshot_node_name_rows()
+        assert snapshot is None
+        assert missing is True
+
+    def test_nodes_not_dict(self):
+        from mmrelay.meshtastic.node_refresh import _snapshot_node_name_rows
+
+        client = MagicMock()
+        client.nodes = "not_a_dict"
+        mu.meshtastic_client = client
+        snapshot, missing = _snapshot_node_name_rows()
+        assert snapshot is None
+        assert missing is False
+
+    def test_non_dict_node_entry(self):
+        from mmrelay.meshtastic.node_refresh import _snapshot_node_name_rows
+
+        client = MagicMock()
+        client.nodes = {"!abc": "not_a_dict"}
+        mu.meshtastic_client = client
+        snapshot, missing = _snapshot_node_name_rows()
+        assert snapshot is not None
+        assert snapshot["!abc"]["user"] is None
+
+    def test_non_dict_user_entry(self):
+        from mmrelay.meshtastic.node_refresh import _snapshot_node_name_rows
+
+        client = MagicMock()
+        client.nodes = {"!abc": {"user": "not_a_dict"}}
+        mu.meshtastic_client = client
+        snapshot, missing = _snapshot_node_name_rows()
+        assert snapshot is not None
+        assert snapshot["!abc"]["user"]["id"] is None
+
+    def test_valid_node_snapshot(self):
+        from mmrelay.meshtastic.node_refresh import _snapshot_node_name_rows
+
+        client = MagicMock()
+        client.nodes = {
+            "!abc": {
+                "user": {
+                    "id": "!abc",
+                    "longName": "Long",
+                    "shortName": "Srt",
+                }
+            }
+        }
+        mu.meshtastic_client = client
+        snapshot, missing = _snapshot_node_name_rows()
+        assert missing is False
+        assert snapshot["!abc"]["user"]["longName"] == "Long"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRefreshNodeNameTables:
+    @pytest.mark.asyncio
+    async def test_zero_interval_runs_once_then_returns(self):
+        from mmrelay.meshtastic.node_refresh import refresh_node_name_tables
+
+        shutdown_event = asyncio.Event()
+
+        with patch(
+            "mmrelay.meshtastic.node_refresh._snapshot_node_name_rows",
+            return_value=(None, True),
+        ):
+            task = asyncio.create_task(
+                refresh_node_name_tables(shutdown_event, refresh_interval_seconds=0)
+            )
+            await asyncio.sleep(0.1)
+            assert task.done()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_event_stops_loop(self):
+        from mmrelay.meshtastic.node_refresh import refresh_node_name_tables
+
+        shutdown_event = asyncio.Event()
+        shutdown_event.set()
+
+        with patch(
+            "mmrelay.meshtastic.node_refresh._snapshot_node_name_rows",
+            return_value=(None, True),
+        ):
+            await refresh_node_name_tables(shutdown_event, refresh_interval_seconds=10)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_exception_propagates(self):
+        from mmrelay.meshtastic.node_refresh import refresh_node_name_tables
+
+        shutdown_event = asyncio.Event()
+
+        with patch(
+            "mmrelay.meshtastic.node_refresh._snapshot_node_name_rows",
+            side_effect=RuntimeError("db error"),
+        ):
+            with patch(
+                "mmrelay.meshtastic.node_refresh.get_nodedb_refresh_interval_seconds",
+                return_value=10,
+            ):
+                with pytest.raises(RuntimeError, match="db error"):
+                    await refresh_node_name_tables(
+                        shutdown_event, refresh_interval_seconds=None
+                    )
+
+    @pytest.mark.asyncio
+    async def test_invalid_override_uses_configured(self):
+        from mmrelay.meshtastic.node_refresh import refresh_node_name_tables
+
+        shutdown_event = asyncio.Event()
+        shutdown_event.set()
+
+        with patch(
+            "mmrelay.meshtastic.node_refresh._snapshot_node_name_rows",
+            return_value=(None, True),
+        ):
+            with patch(
+                "mmrelay.meshtastic.node_refresh.get_nodedb_refresh_interval_seconds",
+                return_value=30,
+            ):
+                await refresh_node_name_tables(
+                    shutdown_event, refresh_interval_seconds=True
+                )

--- a/tests/test_meshtastic_plugins.py
+++ b/tests/test_meshtastic_plugins.py
@@ -1,0 +1,191 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestResolvePluginTimeout:
+    def test_timeout_with_bool_value(self):
+        from mmrelay.meshtastic.plugins import _resolve_plugin_timeout
+
+        cfg = {"meshtastic": {"plugin_timeout": True}}
+        result = _resolve_plugin_timeout(cfg)
+        assert isinstance(result, float)
+        assert result > 0
+
+    def test_timeout_with_non_positive_value(self):
+        from mmrelay.meshtastic.plugins import _resolve_plugin_timeout
+
+        cfg = {"meshtastic": {"plugin_timeout": -5}}
+        result = _resolve_plugin_timeout(cfg)
+        assert result > 0
+
+    def test_timeout_with_none_cfg(self):
+        from mmrelay.meshtastic.plugins import _resolve_plugin_timeout
+
+        result = _resolve_plugin_timeout(None)
+        assert result > 0
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestResolvePluginResult:
+    def test_awaitable_submit_returns_none(self):
+        from mmrelay.meshtastic.plugins import _resolve_plugin_result
+
+        plugin = MagicMock()
+        plugin.plugin_name = "test_plugin"
+        loop = MagicMock()
+
+        async def handler():
+            return True
+
+        coro = handler()
+        try:
+            with patch.object(mu, "_submit_coro", return_value=None):
+                result = _resolve_plugin_result(coro, plugin, 5.0, loop)
+            assert result is False
+        finally:
+            coro.close()
+
+    def test_sync_false_result(self):
+        from mmrelay.meshtastic.plugins import _resolve_plugin_result
+
+        plugin = MagicMock()
+        plugin.plugin_name = "test_plugin"
+        loop = MagicMock()
+        result = _resolve_plugin_result(False, plugin, 5.0, loop)
+        assert result is False
+
+    def test_awaitable_timeout_returns_true(self):
+        from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+        from mmrelay.meshtastic.plugins import _resolve_plugin_result
+
+        plugin = MagicMock()
+        plugin.plugin_name = "test_plugin"
+        loop = MagicMock()
+
+        fake_awaitable = MagicMock()
+        fake_awaitable.__await__ = lambda self: iter([None])
+
+        with patch.object(mu, "_submit_coro", return_value=MagicMock()):
+            with patch.object(mu, "_wait_for_result", side_effect=FuturesTimeoutError):
+                result = _resolve_plugin_result(fake_awaitable, plugin, 1.0, loop)
+        assert result is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRunMeshtasticPlugins:
+    def test_no_plugins_returns_false(self):
+        from mmrelay.meshtastic.plugins import _run_meshtastic_plugins
+
+        with patch("mmrelay.plugin_loader.load_plugins", return_value=[]):
+            result = _run_meshtastic_plugins(
+                packet={},
+                formatted_message="test",
+                longname="user",
+                meshnet_name="mesh",
+                loop=MagicMock(),
+                cfg={},
+            )
+        assert result is False
+
+    def test_plugin_handles_message(self):
+        from mmrelay.meshtastic.plugins import _run_meshtastic_plugins
+
+        plugin = MagicMock()
+        plugin.plugin_name = "test_plugin"
+        plugin.handle_meshtastic_message.return_value = True
+
+        with patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]):
+            with patch.object(mu, "_resolve_plugin_result", return_value=True):
+                result = _run_meshtastic_plugins(
+                    packet={},
+                    formatted_message="test",
+                    longname="user",
+                    meshnet_name="mesh",
+                    loop=MagicMock(),
+                    cfg={},
+                )
+        assert result is True
+
+    def test_plugin_does_not_handle(self):
+        from mmrelay.meshtastic.plugins import _run_meshtastic_plugins
+
+        plugin = MagicMock()
+        plugin.plugin_name = "test_plugin"
+        plugin.handle_meshtastic_message.return_value = False
+
+        with patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]):
+            with patch.object(mu, "_resolve_plugin_result", return_value=False):
+                result = _run_meshtastic_plugins(
+                    packet={},
+                    formatted_message="test",
+                    longname="user",
+                    meshnet_name="mesh",
+                    loop=MagicMock(),
+                    cfg={},
+                )
+        assert result is False
+
+    def test_keyword_args_mode(self):
+        from mmrelay.meshtastic.plugins import _run_meshtastic_plugins
+
+        plugin = MagicMock()
+        plugin.plugin_name = "test_plugin"
+        plugin.handle_meshtastic_message.return_value = True
+
+        with patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]):
+            with patch.object(mu, "_resolve_plugin_result", return_value=True):
+                _run_meshtastic_plugins(
+                    packet={},
+                    formatted_message="test",
+                    longname="user",
+                    meshnet_name="mesh",
+                    loop=MagicMock(),
+                    cfg={},
+                    use_keyword_args=True,
+                    log_with_portnum=True,
+                    portnum="TELEMETRY_APP",
+                )
+        plugin.handle_meshtastic_message.assert_called_with(
+            {},
+            formatted_message="test",
+            longname="user",
+            meshnet_name="mesh",
+        )
+
+    def test_plugin_exception_continues(self):
+        from mmrelay.meshtastic.plugins import _run_meshtastic_plugins
+
+        bad_plugin = MagicMock()
+        bad_plugin.plugin_name = "bad_plugin"
+        bad_plugin.handle_meshtastic_message.side_effect = RuntimeError("fail")
+
+        good_plugin = MagicMock()
+        good_plugin.plugin_name = "good_plugin"
+        good_plugin.handle_meshtastic_message.return_value = True
+
+        with patch(
+            "mmrelay.plugin_loader.load_plugins",
+            return_value=[bad_plugin, good_plugin],
+        ):
+            with patch.object(mu, "_resolve_plugin_result", return_value=True):
+                result = _run_meshtastic_plugins(
+                    packet={},
+                    formatted_message="test",
+                    longname="user",
+                    meshnet_name="mesh",
+                    loop=MagicMock(),
+                    cfg={},
+                )
+        assert result is True
+
+    def test_timeout_with_attribute_error(self):
+        from mmrelay.meshtastic.plugins import _resolve_plugin_timeout
+
+        cfg = {"meshtastic": None}
+        result = _resolve_plugin_timeout(cfg)
+        assert result > 0

--- a/tests/test_meshtastic_subscriptions.py
+++ b/tests/test_meshtastic_subscriptions.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from pubsub.core.topicexc import TopicNameError

--- a/tests/test_meshtastic_subscriptions.py
+++ b/tests/test_meshtastic_subscriptions.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pubsub.core.topicexc import TopicNameError
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestUnsubscribeMeshtasticCallbacks:
+    def test_unsubscribe_messages_topic_name_error(self):
+        from mmrelay.meshtastic.subscriptions import unsubscribe_meshtastic_callbacks
+
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = False
+        with patch.object(
+            mu.pub,
+            "unsubscribe",
+            side_effect=TopicNameError("meshtastic.receive", "missing"),
+        ):
+            unsubscribe_meshtastic_callbacks()
+        assert mu.subscribed_to_messages is False
+
+    def test_unsubscribe_connection_lost_topic_name_error(self):
+        from mmrelay.meshtastic.subscriptions import unsubscribe_meshtastic_callbacks
+
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = True
+        call_count = 0
+
+        def _unsub(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TopicNameError("meshtastic.connection.lost", "missing")
+
+        with patch.object(mu.pub, "unsubscribe", side_effect=_unsub):
+            unsubscribe_meshtastic_callbacks()
+        assert mu.subscribed_to_connection_lost is False
+
+    def test_unsubscribe_messages_generic_exception_keeps_flag(self):
+        from mmrelay.meshtastic.subscriptions import unsubscribe_meshtastic_callbacks
+
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = False
+        with patch.object(mu.pub, "unsubscribe", side_effect=RuntimeError("boom")):
+            unsubscribe_meshtastic_callbacks()
+        assert mu.subscribed_to_messages is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestEnsureMeshtasticCallbacksSubscribed:
+    def test_subscribes_messages_and_connection_lost(self):
+        from mmrelay.meshtastic.subscriptions import (
+            ensure_meshtastic_callbacks_subscribed,
+        )
+
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = False
+        with patch.object(mu.pub, "subscribe") as mock_sub:
+            ensure_meshtastic_callbacks_subscribed()
+            assert mock_sub.call_count == 2
+            assert mu.subscribed_to_messages is True
+            assert mu.subscribed_to_connection_lost is True
+
+    def test_skips_already_subscribed(self):
+        from mmrelay.meshtastic.subscriptions import (
+            ensure_meshtastic_callbacks_subscribed,
+        )
+
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = True
+        with patch.object(mu.pub, "subscribe") as mock_sub:
+            ensure_meshtastic_callbacks_subscribed()
+            mock_sub.assert_not_called()
+
+    def test_clears_tearing_down_flag(self):
+        from mmrelay.meshtastic.subscriptions import (
+            ensure_meshtastic_callbacks_subscribed,
+        )
+
+        mu._callbacks_tearing_down = True
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = True
+        with patch.object(mu.pub, "subscribe"):
+            ensure_meshtastic_callbacks_subscribed()
+        assert mu._callbacks_tearing_down is False
+
+    def test_unsubscribe_messages_success(self):
+        from mmrelay.meshtastic.subscriptions import unsubscribe_meshtastic_callbacks
+
+        mu.subscribed_to_messages = True
+        mu.subscribed_to_connection_lost = False
+        with patch.object(mu.pub, "unsubscribe"):
+            unsubscribe_meshtastic_callbacks()
+        assert mu.subscribed_to_messages is False
+
+    def test_unsubscribe_connection_lost_success(self):
+        from mmrelay.meshtastic.subscriptions import unsubscribe_meshtastic_callbacks
+
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = True
+        with patch.object(mu.pub, "unsubscribe"):
+            unsubscribe_meshtastic_callbacks()
+        assert mu.subscribed_to_connection_lost is False
+
+    def test_unsubscribe_connection_lost_generic_exception_keeps_flag(self):
+        from mmrelay.meshtastic.subscriptions import unsubscribe_meshtastic_callbacks
+
+        mu.subscribed_to_messages = False
+        mu.subscribed_to_connection_lost = True
+        with patch.object(mu.pub, "unsubscribe", side_effect=RuntimeError("fail")):
+            unsubscribe_meshtastic_callbacks()
+        assert mu.subscribed_to_connection_lost is True

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -67,17 +67,24 @@ from tests.constants import (
 TEST_PACKET_RX_TIME = 1234567890
 
 
+def _cancel_startup_drain_timer() -> None:
+    """Best-effort cancellation of the startup-drain expiry timer."""
+    import mmrelay.meshtastic_utils as _mu
+
+    _timer = getattr(_mu, "_relay_startup_drain_expiry_timer", None)
+    if _timer is not None:
+        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            _timer.cancel()
+
+
 @pytest.fixture(autouse=True)
 def reset_meshtastic_relay_state(monkeypatch):
     """Reset all Meshtastic relay module globals to prevent cross-test leakage."""
-    import mmrelay.meshtastic_utils as mu
+
+    _cancel_startup_drain_timer()
 
     startup_drain_complete_event = threading.Event()
     startup_drain_complete_event.set()
-    startup_drain_timer = getattr(mu, "_relay_startup_drain_expiry_timer", None)
-    if startup_drain_timer is not None:
-        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-            startup_drain_timer.cancel()
     monkeypatch.setattr(
         "mmrelay.meshtastic_utils._relay_active_client_id",
         None,
@@ -133,6 +140,10 @@ def reset_meshtastic_relay_state(monkeypatch):
         {},
         raising=False,
     )
+
+    yield
+
+    _cancel_startup_drain_timer()
 
 
 @pytest.fixture
@@ -5357,6 +5368,22 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             self.assertIsNone(result)
 
             mock_scan.assert_not_called()
+
+
+def test_none_startup_drain_event_is_safe_noop(reset_meshtastic_globals):
+    """Code paths that call .set()/.clear() on the startup drain event must handle None gracefully."""
+    import mmrelay.meshtastic_utils as mu
+
+    with patch.object(mu, "get_startup_drain_complete_event", return_value=None):
+        event = mu.get_startup_drain_complete_event()
+        assert event is None
+        mu._rollback_connect_attempt_state(
+            client=None,
+            client_assigned_for_this_connect=False,
+            startup_drain_armed_for_this_connect=True,
+            startup_drain_applied_for_this_connect=True,
+            reconnect_bootstrap_armed_for_this_connect=False,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -68,13 +68,20 @@ TEST_PACKET_RX_TIME = 1234567890
 
 
 def _cancel_startup_drain_timer() -> None:
-    """Best-effort cancellation of the startup-drain expiry timer."""
+    """Best-effort cancellation and join of the startup-drain expiry timer."""
     import mmrelay.meshtastic_utils as _mu
 
     _timer = getattr(_mu, "_relay_startup_drain_expiry_timer", None)
-    if _timer is not None:
+    if _timer is None:
+        return
+    with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+        _timer.cancel()
+    _join = getattr(_timer, "join", None)
+    if callable(_join):
         with contextlib.suppress(AttributeError, RuntimeError, TypeError):
-            _timer.cancel()
+            _join(0.2)
+    with contextlib.suppress(AttributeError):
+        _mu._relay_startup_drain_expiry_timer = None
 
 
 @pytest.fixture(autouse=True)
@@ -5370,7 +5377,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             mock_scan.assert_not_called()
 
 
-def test_none_startup_drain_event_is_safe_noop(reset_meshtastic_globals):
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_none_startup_drain_event_is_safe_noop():
     """Code paths that call .set()/.clear() on the startup drain event must handle None gracefully."""
     import mmrelay.meshtastic_utils as mu
 

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -70,8 +70,14 @@ TEST_PACKET_RX_TIME = 1234567890
 @pytest.fixture(autouse=True)
 def reset_meshtastic_relay_state(monkeypatch):
     """Reset all Meshtastic relay module globals to prevent cross-test leakage."""
+    import mmrelay.meshtastic_utils as mu
+
     startup_drain_complete_event = threading.Event()
     startup_drain_complete_event.set()
+    startup_drain_timer = getattr(mu, "_relay_startup_drain_expiry_timer", None)
+    if startup_drain_timer is not None:
+        with contextlib.suppress(AttributeError, RuntimeError, TypeError):
+            startup_drain_timer.cancel()
     monkeypatch.setattr(
         "mmrelay.meshtastic_utils._relay_active_client_id",
         None,

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -5382,9 +5382,12 @@ def test_none_startup_drain_event_is_safe_noop():
     """Code paths that call .set()/.clear() on the startup drain event must handle None gracefully."""
     import mmrelay.meshtastic_utils as mu
 
-    with patch.object(mu, "get_startup_drain_complete_event", return_value=None):
-        event = mu.get_startup_drain_complete_event()
-        assert event is None
+    mu._relay_startup_drain_expiry_timer = MagicMock()
+    mu._relay_startup_drain_deadline_monotonic_secs = 123.0
+    mu._startup_packet_drain_applied = True
+    with patch.object(
+        mu, "get_startup_drain_complete_event", return_value=None
+    ) as mock_get_event:
         mu._rollback_connect_attempt_state(
             client=None,
             client_assigned_for_this_connect=False,
@@ -5392,6 +5395,7 @@ def test_none_startup_drain_event_is_safe_noop():
             startup_drain_applied_for_this_connect=True,
             reconnect_bootstrap_armed_for_this_connect=False,
         )
+    mock_get_event.assert_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -88,6 +88,11 @@ def reset_meshtastic_relay_state(monkeypatch):
         raising=False,
     )
     monkeypatch.setattr(
+        "mmrelay.meshtastic_utils._relay_startup_drain_expiry_timer",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
         "mmrelay.meshtastic_utils._relay_startup_drain_complete_event",
         startup_drain_complete_event,
         raising=False,

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -14,6 +14,7 @@ import asyncio
 import contextlib
 import os
 import sys
+import threading
 import unittest
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
 from types import SimpleNamespace
@@ -69,6 +70,8 @@ TEST_PACKET_RX_TIME = 1234567890
 @pytest.fixture(autouse=True)
 def reset_meshtastic_relay_state(monkeypatch):
     """Reset all Meshtastic relay module globals to prevent cross-test leakage."""
+    startup_drain_complete_event = threading.Event()
+    startup_drain_complete_event.set()
     monkeypatch.setattr(
         "mmrelay.meshtastic_utils._relay_active_client_id",
         None,
@@ -82,6 +85,11 @@ def reset_meshtastic_relay_state(monkeypatch):
     monkeypatch.setattr(
         "mmrelay.meshtastic_utils._relay_startup_drain_deadline_monotonic_secs",
         None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "mmrelay.meshtastic_utils._relay_startup_drain_complete_event",
+        startup_drain_complete_event,
         raising=False,
     )
     monkeypatch.setattr(
@@ -840,6 +848,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         mu.reconnecting = False
         mu._startup_packet_drain_applied = False
         mu._relay_startup_drain_deadline_monotonic_secs = None
+        mu._relay_startup_drain_complete_event.set()
 
         with (
             patch("mmrelay.meshtastic_utils.time.time", return_value=100.0),
@@ -852,6 +861,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         assert mu._relay_startup_drain_deadline_monotonic_secs == pytest.approx(
             1_000.0 + STARTUP_PACKET_DRAIN_SECS
         )
+        assert mu._relay_startup_drain_complete_event.is_set() is False
 
         with (
             patch("mmrelay.meshtastic_utils.time.time", return_value=200.0),
@@ -862,6 +872,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         assert result_second is second_client
         assert mu._startup_packet_drain_applied is True
         assert mu._relay_startup_drain_deadline_monotonic_secs is None
+        assert mu._relay_startup_drain_complete_event.is_set() is True
 
     @patch("mmrelay.meshtastic_utils.serial_port_exists")
     @patch("mmrelay.meshtastic_utils.meshtastic.serial_interface.SerialInterface")
@@ -907,6 +918,7 @@ class TestMeshtasticUtils(unittest.TestCase):
         mu.subscribed_to_connection_lost = False
         mu._startup_packet_drain_applied = False
         mu._relay_startup_drain_deadline_monotonic_secs = None
+        mu._relay_startup_drain_complete_event.set()
 
         with (
             patch("mmrelay.meshtastic_utils.time.sleep"),
@@ -924,6 +936,27 @@ class TestMeshtasticUtils(unittest.TestCase):
         first_client.close.assert_called_once()
         assert mu._startup_packet_drain_applied is True
         assert mu._relay_startup_drain_deadline_monotonic_secs is not None
+        assert mu._relay_startup_drain_complete_event.is_set() is False
+
+    def test_rollback_connect_attempt_marks_startup_drain_complete(self):
+        """Rollback should set startup-drain completion state to avoid dead waits."""
+        import mmrelay.meshtastic_utils as mu
+
+        mu._relay_startup_drain_complete_event.clear()
+        mu._relay_startup_drain_expiry_timer = MagicMock()
+        mu._relay_startup_drain_deadline_monotonic_secs = 123.0
+        mu._startup_packet_drain_applied = True
+
+        result = mu._rollback_connect_attempt_state(
+            client=None,
+            client_assigned_for_this_connect=False,
+            startup_drain_armed_for_this_connect=True,
+            startup_drain_applied_for_this_connect=True,
+            reconnect_bootstrap_armed_for_this_connect=False,
+        )
+
+        assert result is False
+        assert mu._relay_startup_drain_complete_event.is_set() is True
 
     def test_send_text_reply_success(self):
         """
@@ -2355,6 +2388,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         mu.RELAY_START_TIME = 200_000.0
         mu._relay_startup_drain_deadline_monotonic_secs = 1_000.0
         mu._relay_startup_drain_expiry_timer = None
+        mu._relay_startup_drain_complete_event.clear()
         packet = {
             "from": TEST_PACKET_FROM_ID,
             "to": TEST_PACKET_FROM_ID,
@@ -2374,12 +2408,14 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
             on_meshtastic_message(packet, mock_interface)
 
         assert mu._relay_startup_drain_deadline_monotonic_secs is None
+        assert mu._relay_startup_drain_complete_event.is_set() is True
 
     def test_startup_drain_expiry_timer_clears_deadline_and_logs(self):
         """Drain deadline should clear and log even when no packet arrives."""
         import mmrelay.meshtastic_utils as mu
 
         mu._relay_startup_drain_deadline_monotonic_secs = 1_010.0
+        mu._relay_startup_drain_complete_event.clear()
         created_timers = []
 
         class _FakeTimer:
@@ -2414,6 +2450,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
 
         assert mu._relay_startup_drain_deadline_monotonic_secs is None
         assert mu._relay_startup_drain_expiry_timer is None
+        assert mu._relay_startup_drain_complete_event.is_set() is True
         log_calls = [str(call) for call in mock_logger.debug.call_args_list]
         assert any("Startup drain window has ended" in c for c in log_calls)
 
@@ -2422,6 +2459,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         import mmrelay.meshtastic_utils as mu
 
         mu._relay_startup_drain_deadline_monotonic_secs = 1_010.0
+        mu._relay_startup_drain_complete_event.clear()
         created_timers = []
 
         class _FakeTimer:
@@ -2455,6 +2493,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
 
         assert mu._relay_startup_drain_deadline_monotonic_secs == 1_020.0
         assert mu._relay_startup_drain_expiry_timer is None
+        assert mu._relay_startup_drain_complete_event.is_set() is False
         log_calls = [str(call) for call in mock_logger.debug.call_args_list]
         assert not any("Startup drain window has ended" in c for c in log_calls)
 
@@ -2463,6 +2502,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         import mmrelay.meshtastic_utils as mu
 
         mu._relay_startup_drain_deadline_monotonic_secs = 1_010.0
+        mu._relay_startup_drain_complete_event.clear()
         created_timers = []
 
         class _FakeTimer:
@@ -2497,6 +2537,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
 
         assert mu._relay_startup_drain_deadline_monotonic_secs is None
         assert mu._relay_startup_drain_expiry_timer is None
+        assert mu._relay_startup_drain_complete_event.is_set() is True
         log_calls = [str(call) for call in mock_logger.debug.call_args_list]
         assert any("Startup drain window has ended" in c for c in log_calls)
 
@@ -2873,6 +2914,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         mu._relay_rx_time_clock_skew_secs = None
         mu._relay_startup_drain_deadline_monotonic_secs = 1_000.0
         mu._relay_startup_drain_expiry_timer = None
+        mu._relay_startup_drain_complete_event.clear()
         packet = {
             "from": TEST_PACKET_FROM_ID,
             "to": TEST_PACKET_FROM_ID,
@@ -2893,6 +2935,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
             on_meshtastic_message(packet, mock_interface)
 
         assert mu._relay_startup_drain_deadline_monotonic_secs is None
+        assert mu._relay_startup_drain_complete_event.is_set() is True
         log_calls = [str(c) for c in mock_logger.debug.call_args_list]
         assert any("Startup drain window has ended" in c for c in log_calls)
 
@@ -2906,6 +2949,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         mu._relay_rx_time_clock_skew_secs = None
         mu._relay_startup_drain_deadline_monotonic_secs = 1_000.0
         mu._relay_startup_drain_expiry_timer = None
+        mu._relay_startup_drain_complete_event.clear()
         packet = {
             "from": TEST_PACKET_FROM_ID,
             "to": TEST_PACKET_FROM_ID,
@@ -2927,6 +2971,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
                 on_meshtastic_message(packet, mock_interface)
 
         assert mu._relay_startup_drain_deadline_monotonic_secs == 1_000.0
+        assert mu._relay_startup_drain_complete_event.is_set() is False
         log_calls = [str(c) for c in mock_logger.debug.call_args_list]
         assert not any("Startup drain window has ended" in c for c in log_calls)
 
@@ -2937,6 +2982,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         mu.RELAY_START_TIME = 100_000.0
         mu._relay_rx_time_clock_skew_secs = None
         mu._relay_startup_drain_deadline_monotonic_secs = 1_000.0
+        mu._relay_startup_drain_complete_event.clear()
         packet = {
             "from": TEST_PACKET_FROM_ID,
             "to": TEST_PACKET_FROM_ID,
@@ -2957,6 +3003,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
             on_meshtastic_message(packet, mock_interface)
 
         assert mu._relay_startup_drain_deadline_monotonic_secs is None
+        assert mu._relay_startup_drain_complete_event.is_set() is True
 
     def test_on_meshtastic_message_drain_cleared_only_once_on_first_packet(self):
         """After drain window expires, subsequent packets should not re-clear the deadline."""
@@ -2966,6 +3013,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
         mu._relay_rx_time_clock_skew_secs = None
         mu._relay_startup_drain_deadline_monotonic_secs = 1_000.0
         mu._relay_startup_drain_expiry_timer = None
+        mu._relay_startup_drain_complete_event.clear()
 
         packet1 = {
             "from": TEST_PACKET_FROM_ID,
@@ -3002,6 +3050,7 @@ class TestMessageProcessingEdgeCases(unittest.TestCase):
             on_meshtastic_message(packet2, mock_interface)
 
         assert mu._relay_startup_drain_deadline_monotonic_secs is None
+        assert mu._relay_startup_drain_complete_event.is_set() is True
         drain_end_count = sum(
             1 for msg in debug_log_messages if "Startup drain window has ended" in msg
         )

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -728,6 +728,45 @@ def test_connect_meshtastic_resets_timing_before_get_my_node_info_on_reconnect()
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_meshtastic_preserves_active_startup_drain_on_reconnect():
+    """Reconnect during an active startup-drain window should not signal drain complete."""
+    mock_client = MagicMock()
+    mock_client.myInfo.my_node_num = 456
+    mock_client.localNode.nodeNum = 456
+    mock_client.getMyNodeInfo.return_value = {
+        "user": {"shortName": "Node", "hwModel": "HW"}
+    }
+
+    mu.subscribed_to_messages = True
+    mu.subscribed_to_connection_lost = True
+    mu._startup_packet_drain_applied = True
+    mu._relay_startup_drain_deadline_monotonic_secs = 1_200.0
+    mu._relay_startup_drain_complete_event.clear()
+
+    with (
+        patch(
+            "mmrelay.meshtastic_utils.meshtastic.tcp_interface.TCPInterface",
+            return_value=mock_client,
+        ),
+        patch(
+            "mmrelay.meshtastic_utils._get_device_metadata",
+            return_value={"firmware_version": "unknown", "success": False},
+        ),
+        patch("mmrelay.meshtastic_utils.logger"),
+        patch("mmrelay.meshtastic_utils.time.time", return_value=100_000.0),
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=1_000.0),
+    ):
+        config = {
+            "meshtastic": {"connection_type": CONNECTION_TYPE_TCP, "host": "127.0.0.1"}
+        }
+        result = connect_meshtastic(passed_config=config)
+
+    assert result is mock_client
+    assert mu._relay_startup_drain_deadline_monotonic_secs == 1_200.0
+    assert mu._relay_startup_drain_complete_event.is_set() is False
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
 def test_connect_meshtastic_schedules_one_shot_probe_when_periodic_health_disabled():
     """Connect should schedule one-shot probe when explicitly enabled, even with periodic checks off."""
     mock_client = MagicMock()

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -741,7 +741,9 @@ def test_connect_meshtastic_preserves_active_startup_drain_on_reconnect():
     mu.subscribed_to_connection_lost = True
     mu._startup_packet_drain_applied = True
     mu._relay_startup_drain_deadline_monotonic_secs = 1_200.0
-    mu._relay_startup_drain_complete_event.clear()
+    _event = mu.get_startup_drain_complete_event()
+    assert _event is not None
+    _event.clear()
 
     with (
         patch(
@@ -763,7 +765,7 @@ def test_connect_meshtastic_preserves_active_startup_drain_on_reconnect():
 
     assert result is mock_client
     assert mu._relay_startup_drain_deadline_monotonic_secs == 1_200.0
-    assert mu._relay_startup_drain_complete_event.is_set() is False
+    assert mu.get_startup_drain_complete_event().is_set() is False
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")

--- a/tests/test_message_queue_additional_coverage.py
+++ b/tests/test_message_queue_additional_coverage.py
@@ -619,7 +619,7 @@ def test_reset_message_queue_failed_state_function() -> None:
 
 def test_get_queue_status_function() -> None:
     """get_queue_status should return status from global queue."""
-    from mmrelay.message_queue import _message_queue, get_queue_status
+    from mmrelay.message_queue import get_queue_status
 
     status = get_queue_status()
     assert "running" in status

--- a/tests/test_message_queue_additional_coverage.py
+++ b/tests/test_message_queue_additional_coverage.py
@@ -343,3 +343,326 @@ async def test_handle_message_mapping_logs_exception_if_store_fails() -> None:
         await queue._handle_message_mapping(result, mapping_info)
 
     mock_logger.exception.assert_called_once_with("Error handling message mapping")
+
+
+# ---- Additional coverage for remaining uncovered lines ----
+
+
+def test_start_returns_false_when_stopping() -> None:
+    """start() should return False when _stopping is True."""
+    queue = MessageQueue()
+    queue._stopping = True
+    result = queue.start()
+    assert result is False
+
+
+def test_start_handles_runtime_error_from_get_running_loop() -> None:
+    """start() should handle RuntimeError when no event loop is available."""
+    queue = MessageQueue()
+    with patch(
+        "mmrelay.message_queue.asyncio.get_running_loop", side_effect=RuntimeError
+    ):
+        result = queue.start()
+    assert result is True
+
+
+def test_start_with_loop_not_running() -> None:
+    """start() should defer when loop exists but is not running."""
+    queue = MessageQueue()
+    loop = MagicMock()
+    loop.is_running.return_value = False
+    with patch("mmrelay.message_queue.asyncio.get_running_loop", return_value=loop):
+        result = queue.start()
+    assert result is True
+    assert queue._processor_task is None
+
+
+def test_stop_closed_task_loop() -> None:
+    """stop() should handle closed task loop."""
+    queue = MessageQueue()
+    queue._running = True
+    queue._executor = None
+
+    task_loop = MagicMock()
+    task_loop.is_closed.return_value = True
+
+    task = MagicMock()
+    task.get_loop.return_value = task_loop
+    queue._processor_task = task
+
+    queue.stop()
+    assert queue._running is False
+
+
+def test_stop_same_loop_cancel_scheduled_runtime_error() -> None:
+    """stop() should handle RuntimeError when scheduling cancel on same loop."""
+    queue = MessageQueue()
+    queue._running = True
+    queue._executor = None
+
+    task_loop = MagicMock()
+    task_loop.is_closed.return_value = False
+    task_loop.call_soon.side_effect = RuntimeError("closed")
+
+    task = MagicMock()
+    task.get_loop.return_value = task_loop
+    task.done.return_value = False
+    queue._processor_task = task
+
+    with patch(
+        "mmrelay.message_queue.asyncio.get_running_loop", return_value=task_loop
+    ):
+        queue.stop()
+
+    assert queue._running is False
+
+
+def test_stop_other_loop_running_with_no_current_loop() -> None:
+    """stop() from non-loop thread when task is on a different running loop."""
+    queue = MessageQueue()
+    queue._running = True
+    queue._executor = None
+
+    task_loop = MagicMock()
+    task_loop.is_closed.return_value = False
+    task_loop.is_running.return_value = True
+
+    task = MagicMock()
+    task.get_loop.return_value = task_loop
+    task.done.return_value = False
+    queue._processor_task = task
+
+    with patch(
+        "mmrelay.message_queue.asyncio.get_running_loop", side_effect=RuntimeError
+    ):
+        queue.stop()
+
+    assert queue._running is False
+
+
+def test_enqueue_rejects_when_stopping() -> None:
+    """enqueue() should reject when _stopping is True."""
+    queue = MessageQueue()
+    queue._running = False
+    queue._stopping = True
+    result = queue.enqueue(lambda: None, description="test")
+    assert result is False
+
+
+def test_reset_failed_stop_state_while_stopping() -> None:
+    """reset_failed_stop_state() should return False while stopping."""
+    queue = MessageQueue()
+    queue._stopping = True
+    result = queue.reset_failed_stop_state()
+    assert result is False
+
+
+def test_reset_failed_stop_state_not_failed() -> None:
+    """reset_failed_stop_state() should return True when not in failed state."""
+    queue = MessageQueue()
+    queue._stop_failed = False
+    result = queue.reset_failed_stop_state()
+    assert result is True
+
+
+def test_reset_failed_stop_state_cannot_recover() -> None:
+    """reset_failed_stop_state() should return False when resources still active."""
+    queue = MessageQueue()
+    queue._stop_failed = True
+    queue._stopping = False
+    queue._processor_task = MagicMock()
+    queue._processor_task.done.return_value = False
+    result = queue.reset_failed_stop_state()
+    assert result is False
+
+
+def test_enqueue_logs_queue_full_periodically() -> None:
+    """enqueue with wait should log queue full warning periodically."""
+    queue = MessageQueue()
+    queue._running = True
+    for i in range(MAX_QUEUE_SIZE):
+        queue._queue.append(_queued_message(f"fill-{i}"))
+
+    sleep_count = {"n": 0}
+
+    def sleep_then_stop(_delay: float) -> None:
+        sleep_count["n"] += 1
+        if sleep_count["n"] >= 2:
+            queue._running = False
+
+    with (
+        patch.object(queue, "ensure_processor_started"),
+        patch("mmrelay.message_queue.time.sleep", side_effect=sleep_then_stop),
+        patch("mmrelay.message_queue.logger") as mock_logger,
+    ):
+        accepted = queue.enqueue(
+            lambda: None, description="wait-msg", wait=True, timeout=None
+        )
+
+    assert accepted is False
+    warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+    assert any("queue full" in w.lower() for w in warning_calls)
+
+
+@pytest.mark.asyncio
+async def test_process_queue_logs_queue_depth_high() -> None:
+    """_process_queue should log warning when queue depth exceeds high water mark."""
+    import mmrelay.meshtastic_utils as meshtastic_utils
+
+    queue = MessageQueue()
+    queue._running = True
+    queue._message_delay = 0.01
+
+    from mmrelay.constants.queue import QUEUE_HIGH_WATER_MARK
+
+    connected_client = MagicMock()
+    connected_client.is_connected.return_value = True
+
+    sent_count = {"n": 0}
+
+    def _send_fn():
+        sent_count["n"] += 1
+        if sent_count["n"] >= 2:
+            queue._running = False
+        return {"id": sent_count["n"]}
+
+    for i in range(QUEUE_HIGH_WATER_MARK + 1):
+        queue._queue.append(
+            QueuedMessage(
+                timestamp=time.time(),
+                send_function=_send_fn,
+                args=(),
+                kwargs={},
+                description=f"depth-{i}",
+            )
+        )
+
+    real_loop = asyncio.get_running_loop()
+
+    class _SyncExecutor:
+        def run_in_executor(self, _exc, func):
+            fut = real_loop.create_future()
+            try:
+                result = func()
+                fut.set_result(result)
+            except Exception as e:
+                fut.set_exception(e)
+            return fut
+
+    sync_exec = _SyncExecutor()
+
+    async def _sleep_then_stop(delay: float) -> None:
+        if sent_count["n"] >= 2:
+            queue._running = False
+
+    with (
+        patch.object(meshtastic_utils, "reconnecting", False),
+        patch.object(meshtastic_utils, "meshtastic_client", connected_client),
+        patch("mmrelay.message_queue.asyncio.get_running_loop", return_value=sync_exec),
+        patch(
+            "mmrelay.message_queue.asyncio.sleep",
+            new=AsyncMock(side_effect=_sleep_then_stop),
+        ),
+    ):
+        queue._executor = MagicMock()
+        await queue._process_queue()
+
+
+def test_should_send_message_returns_true_when_connected() -> None:
+    """_should_send_message should return True when client is connected."""
+    import mmrelay.meshtastic_utils as meshtastic_utils
+
+    queue = MessageQueue()
+    client = MagicMock()
+    client.is_connected.return_value = True
+    with (
+        patch.object(meshtastic_utils, "reconnecting", False),
+        patch.object(meshtastic_utils, "meshtastic_client", client),
+    ):
+        assert queue._should_send_message() is True
+
+
+def test_should_send_message_callable_is_connected() -> None:
+    """_should_send_message should handle callable is_connected."""
+    import mmrelay.meshtastic_utils as meshtastic_utils
+
+    queue = MessageQueue()
+    client = MagicMock()
+    client.is_connected = lambda: True
+    with (
+        patch.object(meshtastic_utils, "reconnecting", False),
+        patch.object(meshtastic_utils, "meshtastic_client", client),
+    ):
+        assert queue._should_send_message() is True
+
+
+def test_stop_message_queue_function() -> None:
+    """stop_message_queue should call stop on the global queue."""
+    from mmrelay.message_queue import _message_queue, stop_message_queue
+
+    with patch.object(_message_queue, "stop") as mock_stop:
+        stop_message_queue()
+    mock_stop.assert_called_once()
+
+
+def test_reset_message_queue_failed_state_function() -> None:
+    """reset_message_queue_failed_state should delegate to global queue."""
+    from mmrelay.message_queue import _message_queue, reset_message_queue_failed_state
+
+    with patch.object(
+        _message_queue, "reset_failed_stop_state", return_value=True
+    ) as mock_reset:
+        result = reset_message_queue_failed_state()
+    assert result is True
+    mock_reset.assert_called_once()
+
+
+def test_get_queue_status_function() -> None:
+    """get_queue_status should return status from global queue."""
+    from mmrelay.message_queue import _message_queue, get_queue_status
+
+    status = get_queue_status()
+    assert "running" in status
+    assert "queue_size" in status
+
+
+@pytest.mark.asyncio
+async def test_handle_message_mapping_dict_result_with_id() -> None:
+    """_handle_message_mapping should work with SimpleNamespace result from dict extraction."""
+    from types import SimpleNamespace
+
+    queue = MessageQueue()
+    result = SimpleNamespace(id="42")
+    mapping_info = {
+        "matrix_event_id": "$evt",
+        "room_id": "!room:example.org",
+        "text": "hello",
+    }
+
+    with (
+        patch(
+            "mmrelay.db_utils.async_store_message_map", new_callable=AsyncMock
+        ) as mock_store,
+        patch("mmrelay.db_utils.async_prune_message_map", new_callable=AsyncMock),
+    ):
+        await queue._handle_message_mapping(result, mapping_info)
+
+    mock_store.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_mapping_missing_fields_skips_store() -> None:
+    """_handle_message_mapping should skip store when required fields are missing."""
+    queue = MessageQueue()
+    result = MagicMock()
+    result.id = 42
+    mapping_info = {"room_id": "!room:example.org"}
+
+    with (
+        patch(
+            "mmrelay.db_utils.async_store_message_map", new_callable=AsyncMock
+        ) as mock_store,
+    ):
+        await queue._handle_message_mapping(result, mapping_info)
+
+    mock_store.assert_not_awaited()

--- a/tests/test_nodes_plugin.py
+++ b/tests/test_nodes_plugin.py
@@ -383,6 +383,34 @@ class TestNodesPlugin(unittest.TestCase):
         self.assertIn("?% ?V", response)  # Default values for null battery/voltage
         self.assertIn("/ ?", response)  # No last heard time
 
+    def test_get_relative_time_future_timestamp(self):
+        """Future timestamps should return 'Just now' (line 73)."""
+        future_ts = (datetime.now() + timedelta(hours=1)).timestamp()
+        result = get_relative_time(future_ts)
+        self.assertEqual(result, "Just now")
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_generate_response_no_client(self, mock_connect):
+        """generate_response returns error when client is None (line 108)."""
+        mock_connect.return_value = None
+        response = self.plugin.generate_response()
+        self.assertEqual(response, "Unable to connect to Meshtastic device.")
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_generate_response_zero_last_heard(self, mock_connect):
+        """lastHeard of 0 should render as '?' (line 143->151)."""
+        client = MagicMock()
+        client.nodes = {
+            "node_zero_lh": {
+                "user": {"shortName": "ZER", "longName": "Zero LH", "hwModel": "T"},
+                "lastHeard": 0,
+            }
+        }
+        mock_connect.return_value = client
+        response = self.plugin.generate_response()
+        self.assertIn("ZER Zero LH", response)
+        self.assertIn("/ ?", response)
+
     def test_handle_meshtastic_message_always_false(self):
         """
         Test that handle_meshtastic_message always returns False regardless of input.

--- a/tests/test_paths_coverage.py
+++ b/tests/test_paths_coverage.py
@@ -562,3 +562,503 @@ def test_get_diagnostics_maps_resolved_fields() -> None:
     assert diagnostics["matrix_dir"] == "/h/matrix"
     assert diagnostics["database_path"] == "/h/database/db.sqlite"
     assert diagnostics["sources_used"] == "CLI (--home)"
+
+
+def test_has_mmrelay_artifacts_oserror_on_directory_scan() -> None:
+    """OSError during scandir of a directory marker should be caught gracefully."""
+    import os as _os
+
+    from mmrelay.paths import _has_mmrelay_artifacts
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+        plugin_dir = root / "plugins"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+
+        original_scandir = _os.scandir
+
+        def _faulty_scandir(path):
+            if str(path) == str(plugin_dir):
+                raise OSError("permission denied")
+            return original_scandir(path)
+
+        with patch("os.scandir", side_effect=_faulty_scandir):
+            result = _has_mmrelay_artifacts(root)
+
+        assert result is False
+
+
+def test_dir_has_entries_oserror() -> None:
+    """_dir_has_entries returns False when scandir raises OSError."""
+    from mmrelay.paths import _dir_has_entries
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        p = Path(tmp_dir)
+        with patch("os.scandir", side_effect=OSError("fail")):
+            assert _dir_has_entries(p) is False
+
+
+def test_dir_has_entries_not_a_directory() -> None:
+    """_dir_has_entries returns False for non-directory paths."""
+    from mmrelay.paths import _dir_has_entries
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        file_path = Path(tmp_dir) / "file.txt"
+        file_path.write_text("hello")
+        assert _dir_has_entries(file_path) is False
+
+
+def test_score_home_credentials_and_store_and_plugins() -> None:
+    """_score_mmrelay_home_state should score credentials, store content, and plugins content."""
+    from mmrelay.constants.app import (
+        DATABASE_DIRNAME,
+        DATABASE_FILENAME,
+        LEGACY_DATA_SUBDIR,
+        LOG_FILENAME,
+        LOGS_DIRNAME,
+        MATRIX_DIRNAME,
+        PLUGINS_DIRNAME,
+        STORE_DIRNAME,
+    )
+    from mmrelay.constants.config import DEFAULT_CONFIG_FILENAME
+    from mmrelay.paths import _score_mmrelay_home_state
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+        (root / DEFAULT_CONFIG_FILENAME).write_text("test: true")
+        (root / MATRIX_DIRNAME / "credentials.json").parent.mkdir(parents=True)
+        (root / MATRIX_DIRNAME / "credentials.json").write_text("{}")
+        (root / DATABASE_DIRNAME).mkdir()
+        (root / DATABASE_DIRNAME / DATABASE_FILENAME).write_text("")
+        (root / MATRIX_DIRNAME / STORE_DIRNAME).mkdir(parents=True)
+        (root / MATRIX_DIRNAME / STORE_DIRNAME / "key.db").write_bytes(b"\x00")
+        (root / PLUGINS_DIRNAME).mkdir()
+        (root / PLUGINS_DIRNAME / "my_plugin.py").write_text("")
+        (root / LOGS_DIRNAME).mkdir()
+        (root / LOGS_DIRNAME / LOG_FILENAME).write_text("log")
+
+        score = _score_mmrelay_home_state(root)
+        assert score >= 6 + 6 + 6 + 3 + 2 + 1 + 1
+
+
+def test_score_home_nonexistent() -> None:
+    """_score_mmrelay_home_state returns 0 for nonexistent directory."""
+    from mmrelay.paths import _score_mmrelay_home_state
+
+    assert _score_mmrelay_home_state(Path("/nonexistent_dir_xyz_123")) == 0
+
+
+def test_get_e2ee_store_dir_on_windows() -> None:
+    """get_e2ee_store_dir should raise E2EENotSupportedError on Windows."""
+    from mmrelay.paths import E2EENotSupportedError, get_e2ee_store_dir
+
+    with patch("mmrelay.paths.sys.platform", "win32"):
+        with pytest.raises(E2EENotSupportedError):
+            get_e2ee_store_dir()
+
+
+def test_validate_plugin_name_empty() -> None:
+    """_validate_plugin_name raises ValueError for empty string."""
+    from mmrelay.paths import _validate_plugin_name
+
+    with pytest.raises(ValueError, match="Invalid plugin name"):
+        _validate_plugin_name("")
+
+
+def test_validate_plugin_name_dot() -> None:
+    """_validate_plugin_name raises ValueError for '.' name."""
+    from mmrelay.paths import _validate_plugin_name
+
+    with pytest.raises(ValueError, match="Invalid plugin name"):
+        _validate_plugin_name(".")
+
+
+def test_validate_plugin_name_dotdot() -> None:
+    """_validate_plugin_name raises ValueError for '..' name."""
+    from mmrelay.paths import _validate_plugin_name
+
+    with pytest.raises(ValueError, match="Invalid plugin name"):
+        _validate_plugin_name("..")
+
+
+def test_validate_plugin_name_absolute() -> None:
+    """_validate_plugin_name raises ValueError for absolute path."""
+    from mmrelay.paths import _validate_plugin_name
+
+    with pytest.raises(ValueError, match="Invalid plugin name"):
+        _validate_plugin_name("/etc/passwd")
+
+
+def test_validate_plugin_name_traversal() -> None:
+    """_validate_plugin_name raises ValueError for path traversal."""
+    from mmrelay.paths import _validate_plugin_name
+
+    with pytest.raises(ValueError, match="Invalid plugin name"):
+        _validate_plugin_name("../etc/passwd")
+
+
+def test_validate_plugin_subdir_traversal() -> None:
+    """_validate_plugin_subdir raises ValueError for path traversal."""
+    from mmrelay.paths import _validate_plugin_subdir
+
+    with pytest.raises(ValueError, match="Invalid plugin subdir"):
+        _validate_plugin_subdir("../../etc")
+
+
+def test_validate_plugin_subdir_dot_component() -> None:
+    """_validate_plugin_subdir raises ValueError for path with '..' component."""
+    from mmrelay.paths import _validate_plugin_subdir
+
+    with pytest.raises(ValueError, match="Invalid plugin subdir"):
+        _validate_plugin_subdir("foo/../bar")
+
+
+def test_get_plugin_code_dir_fallback_to_core() -> None:
+    """get_plugin_code_dir falls back to core when plugin not found in custom/community."""
+    from mmrelay.paths import get_plugin_code_dir
+
+    with (
+        patch("mmrelay.paths.get_custom_plugins_dir", return_value=Path("/custom")),
+        patch(
+            "mmrelay.paths.get_community_plugins_dir", return_value=Path("/community")
+        ),
+    ):
+        result = get_plugin_code_dir("nonexistent_plugin")
+        assert "plugins" in str(result)
+        assert "nonexistent_plugin" in str(result)
+
+
+def test_get_plugin_data_dir_core_type() -> None:
+    """get_plugin_data_dir with core type uses core plugins dir."""
+    from mmrelay.paths import get_plugin_data_dir
+
+    with patch("mmrelay.paths.get_core_plugins_dir", return_value=Path("/core")):
+        result = get_plugin_data_dir("test", plugin_type="core")
+        assert result == Path("/core/test/data")
+
+
+def test_get_plugin_data_dir_fallback_core() -> None:
+    """get_plugin_data_dir falls back to core when plugin not found."""
+    from mmrelay.paths import get_plugin_data_dir
+
+    with (
+        patch("mmrelay.paths.get_custom_plugins_dir", return_value=Path("/custom")),
+        patch(
+            "mmrelay.paths.get_community_plugins_dir", return_value=Path("/community")
+        ),
+        patch("mmrelay.paths.get_core_plugins_dir", return_value=Path("/core")),
+    ):
+        result = get_plugin_data_dir("nonexistent_plugin")
+        assert result == Path("/core/nonexistent_plugin/data")
+
+
+def test_get_legacy_dirs_platform_user_data_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing platform user data dir should be reported as a legacy dir."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        platform_data = Path(tmp_dir) / "platform_data"
+        platform_data.mkdir()
+        (platform_data / "config.yaml").write_text("test: true")
+
+        monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+        monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+
+        with (
+            patch("mmrelay.paths.get_home_dir", return_value=Path("/current/home")),
+            patch(
+                "mmrelay.paths.platformdirs.user_data_dir",
+                return_value=str(platform_data),
+            ),
+        ):
+            legacy = get_legacy_dirs()
+
+        assert platform_data in legacy
+
+
+def test_get_legacy_dirs_platform_user_data_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RuntimeError from platformdirs should be handled gracefully."""
+    monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+    monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+
+    with (
+        patch("mmrelay.paths.get_home_dir", return_value=Path("/current/home")),
+        patch(
+            "mmrelay.paths.platformdirs.user_data_dir",
+            side_effect=RuntimeError("fail"),
+        ),
+    ):
+        legacy = get_legacy_dirs()
+
+    assert isinstance(legacy, list)
+
+
+def test_get_legacy_dirs_windows_installer_path_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OSError when checking Windows installer path should be handled."""
+    monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+    monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", "/fake/localappdata")
+
+    installer_path_str = str(
+        Path("/fake/localappdata") / "Programs" / WINDOWS_INSTALLER_DIR_NAME
+    )
+
+    original_exists = Path.exists
+
+    def _selective_exists(self):
+        if installer_path_str in str(self):
+            raise OSError("access denied")
+        return original_exists(self)
+
+    with (
+        patch("sys.platform", "win32"),
+        patch("mmrelay.paths.get_home_dir", return_value=Path("/current/home")),
+        patch("mmrelay.paths.platformdirs.user_data_dir", return_value="/platform"),
+        patch.object(Path, "exists", _selective_exists),
+    ):
+        legacy = get_legacy_dirs()
+
+    assert isinstance(legacy, list)
+
+
+def test_get_legacy_dirs_base_dir_same_as_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MMRELAY_BASE_DIR pointing to same dir as home should be excluded."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        home = Path(tmp_dir)
+        (home / "config.yaml").write_text("test: true")
+
+        monkeypatch.setenv("MMRELAY_BASE_DIR", str(home))
+        monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+
+        with patch("mmrelay.paths.get_home_dir", return_value=home):
+            legacy = get_legacy_dirs()
+
+        assert home not in legacy
+
+
+def test_get_legacy_dirs_data_dir_same_as_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MMRELAY_DATA_DIR pointing to same dir as home should be excluded."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        home = Path(tmp_dir)
+        (home / "config.yaml").write_text("test: true")
+
+        monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+        monkeypatch.setenv("MMRELAY_DATA_DIR", str(home))
+
+        with patch("mmrelay.paths.get_home_dir", return_value=home):
+            legacy = get_legacy_dirs()
+
+        assert home not in legacy
+
+
+def test_get_legacy_dirs_docker_path_same_as_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Docker legacy path equal to home should be excluded."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        home = Path(tmp_dir)
+        (home / "config.yaml").write_text("test: true")
+
+        monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+        monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+
+        with (
+            patch("mmrelay.paths.get_home_dir", return_value=home),
+            patch("mmrelay.paths.DOCKER_LEGACY_PATHS", [str(home)]),
+        ):
+            legacy = get_legacy_dirs()
+
+        assert home not in legacy
+
+
+def test_get_config_paths_platformdirs_runtime_error() -> None:
+    """RuntimeError from platformdirs in get_config_paths should be handled."""
+    with (
+        patch("mmrelay.paths.get_home_dir", return_value=Path("/home")),
+        patch.object(Path, "cwd", return_value=Path("/home")),
+        patch.object(Path, "home", return_value=Path("/home")),
+        patch(
+            "mmrelay.paths.platformdirs.user_data_dir",
+            side_effect=RuntimeError("fail"),
+        ),
+    ):
+        paths = get_config_paths()
+
+    assert isinstance(paths, list)
+
+
+def test_get_config_paths_platform_user_data_exists_and_differs() -> None:
+    """Platform user data dir that exists and differs from home should be included."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        platform_data = Path(tmp_dir) / "platform_data"
+        platform_data.mkdir()
+
+        with (
+            patch("mmrelay.paths.get_home_dir", return_value=Path("/home")),
+            patch.object(Path, "cwd", return_value=Path("/cwd")),
+            patch.object(Path, "home", return_value=Path("/home")),
+            patch(
+                "mmrelay.paths.platformdirs.user_data_dir",
+                return_value=str(platform_data),
+            ),
+        ):
+            paths = get_config_paths()
+
+        assert isinstance(paths, list)
+        assert any(str(platform_data) in str(p) for p in paths)
+
+
+def test_resolve_all_paths_home_source_data_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve_all_paths should identify MMRELAY_DATA_DIR as home source."""
+    import mmrelay.paths as paths_module
+
+    paths_module._reset_deprecation_warning_flag()
+    monkeypatch.delenv("MMRELAY_HOME", raising=False)
+    monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+    monkeypatch.setenv("MMRELAY_DATA_DIR", "/legacy/data")
+
+    try:
+        resolved = resolve_all_paths()
+        assert resolved["home_source"] == "MMRELAY_DATA_DIR env var"
+    finally:
+        paths_module._reset_deprecation_warning_flag()
+
+
+def test_resolve_all_paths_home_source_platform_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve_all_paths should identify Platform defaults when no env vars or CLI overrides."""
+    import mmrelay.paths as paths_module
+
+    paths_module._reset_deprecation_warning_flag()
+    monkeypatch.delenv("MMRELAY_HOME", raising=False)
+    monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+    monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+    monkeypatch.delenv("MMRELAY_LOG_PATH", raising=False)
+
+    try:
+        resolved = resolve_all_paths()
+        assert resolved["home_source"] == "Platform defaults"
+    finally:
+        paths_module._reset_deprecation_warning_flag()
+
+
+def test_resolve_all_paths_cli_data_dir_source() -> None:
+    """resolve_all_paths should identify CLI --data-dir as home source."""
+    from mmrelay.paths import set_home_override
+
+    set_home_override("/data/home", source="--data-dir")
+    try:
+        resolved = resolve_all_paths()
+        assert resolved["home_source"] == "CLI (--data-dir)"
+    finally:
+        reset_home_override()
+
+
+def test_get_home_dir_windows_weak_installer_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Weak installer artifacts (score < 6) with empty platform should prefer platform home."""
+    from mmrelay.constants.config import DEFAULT_CONFIG_FILENAME
+    from mmrelay.paths import get_home_dir
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+        local_app_data = root / "LocalAppData"
+        installer_path = local_app_data / "Programs" / WINDOWS_INSTALLER_DIR_NAME
+        installer_logs = installer_path / "logs"
+        installer_logs.mkdir(parents=True, exist_ok=True)
+        (installer_logs / LOG_FILENAME).write_text("log\n", encoding="utf-8")
+
+        platform_home = root / "PlatformData" / "mmrelay"
+
+        monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+        monkeypatch.delenv("MMRELAY_HOME", raising=False)
+        monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+        monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "mmrelay.paths.platformdirs.user_data_dir",
+                return_value=str(platform_home),
+            ),
+        ):
+            result = get_home_dir()
+
+        assert result == platform_home
+
+
+def test_get_home_dir_windows_installer_with_score_above_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Installer with score >= 6 and empty platform should be preferred."""
+    from mmrelay.paths import get_home_dir
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        root = Path(tmp_dir)
+        local_app_data = root / "LocalAppData"
+        installer_path = local_app_data / "Programs" / WINDOWS_INSTALLER_DIR_NAME
+        installer_path.mkdir(parents=True, exist_ok=True)
+        (installer_path / DEFAULT_CONFIG_FILENAME).write_text(
+            "test: true\n", encoding="utf-8"
+        )
+
+        platform_home = root / "PlatformData" / "mmrelay"
+
+        monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+        monkeypatch.delenv("MMRELAY_HOME", raising=False)
+        monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+        monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+        with (
+            patch("sys.platform", "win32"),
+            patch(
+                "mmrelay.paths.platformdirs.user_data_dir",
+                return_value=str(platform_home),
+            ),
+        ):
+            result = get_home_dir()
+
+        assert result == installer_path
+
+
+def test_deprecation_window_not_active_when_home_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deprecation window should not be active when MMRELAY_HOME is set."""
+    import mmrelay.paths as paths_module
+
+    paths_module._reset_deprecation_warning_flag()
+    monkeypatch.setenv("MMRELAY_HOME", "/home")
+    monkeypatch.setenv("MMRELAY_BASE_DIR", "/base")
+
+    try:
+        assert is_deprecation_window_active() is False
+    finally:
+        paths_module._reset_deprecation_warning_flag()
+
+
+def test_deprecation_window_not_active_no_legacy_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deprecation window should not be active when no legacy vars are set."""
+    import mmrelay.paths as paths_module
+
+    paths_module._reset_deprecation_warning_flag()
+    monkeypatch.delenv("MMRELAY_HOME", raising=False)
+    monkeypatch.delenv("MMRELAY_BASE_DIR", raising=False)
+    monkeypatch.delenv("MMRELAY_DATA_DIR", raising=False)
+
+    try:
+        assert is_deprecation_window_active() is False
+    finally:
+        paths_module._reset_deprecation_warning_flag()

--- a/tests/test_paths_coverage.py
+++ b/tests/test_paths_coverage.py
@@ -613,7 +613,6 @@ def test_score_home_credentials_and_store_and_plugins() -> None:
     from mmrelay.constants.app import (
         DATABASE_DIRNAME,
         DATABASE_FILENAME,
-        LEGACY_DATA_SUBDIR,
         LOG_FILENAME,
         LOGS_DIRNAME,
         MATRIX_DIRNAME,
@@ -969,7 +968,6 @@ def test_get_home_dir_windows_weak_installer_artifacts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Weak installer artifacts (score < 6) with empty platform should prefer platform home."""
-    from mmrelay.constants.config import DEFAULT_CONFIG_FILENAME
     from mmrelay.paths import get_home_dir
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -87,8 +87,10 @@ class TestPingPlugin(unittest.TestCase):
         self.assertFalse(self.plugin.get_mimic_mode())
 
     def test_get_mimic_mode_non_boolean_disabled(self):
-        self.plugin.config = {"mimic_mode": "false"}
-        self.assertFalse(self.plugin.get_mimic_mode())
+        for mimic_mode_value in ("false", "true", 1):
+            with self.subTest(mimic_mode_value=mimic_mode_value):
+                self.plugin.config = {"mimic_mode": mimic_mode_value}
+                self.assertFalse(self.plugin.get_mimic_mode())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     def test_handle_meshtastic_message_missing_myinfo(self, mock_connect):
@@ -524,7 +526,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_mimic_ping_in_sentence(self, mock_sleep, mock_connect):
+    def test_mimic_ping_in_sentence_ignored(self, mock_sleep, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -540,8 +542,8 @@ class TestPingPluginMimicMode(unittest.TestCase):
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-            self.assertTrue(result)
-            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
 
         asyncio.run(run_test())
 

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -86,6 +86,10 @@ class TestPingPlugin(unittest.TestCase):
         self.plugin.config = {"mimic_mode": False}
         self.assertFalse(self.plugin.get_mimic_mode())
 
+    def test_get_mimic_mode_non_boolean_disabled(self):
+        self.plugin.config = {"mimic_mode": "false"}
+        self.assertFalse(self.plugin.get_mimic_mode())
+
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     def test_handle_meshtastic_message_missing_myinfo(self, mock_connect):
         mock_client = MagicMock()
@@ -265,6 +269,30 @@ class TestPingPlugin(unittest.TestCase):
 
         packet = {
             "decoded": {"text": "!!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_explicit_ping_with_trailing_punctuation_ignored_by_default(
+        self, mock_connect
+    ):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping?"},
             "channel": 0,
             "fromId": "!12345678",
             "to": BROADCAST_NUM,

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -335,7 +335,8 @@ class TestPingPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    def test_explicit_ping_works_with_mimic_mode_false(self, mock_connect):
+    @patch("asyncio.sleep")
+    def test_explicit_ping_works_with_mimic_mode_false(self, mock_sleep, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -353,6 +354,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
 
         asyncio.run(run_test())

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -432,6 +432,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
 
         asyncio.run(run_test())

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -526,6 +526,29 @@ class TestPingPluginMimicMode(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
+    def test_mimic_case_and_punctuation_mixed(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "PiNg!?!"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="PoNg!?!", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
     def test_mimic_ping_in_sentence_ignored(self, mock_sleep, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -544,6 +567,36 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertFalse(result)
             mock_client.sendText.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_ping_prose_variants_ignored(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        async def run_test():
+            for message in (
+                "please ping",
+                "can you ping?",
+                "ping now",
+                "before ping after",
+            ):
+                with self.subTest(message=message):
+                    packet = {
+                        "decoded": {"text": message},
+                        "channel": 0,
+                        "fromId": "!12345678",
+                        "to": BROADCAST_NUM,
+                    }
+                    result = await self.plugin.handle_meshtastic_message(
+                        packet, "formatted_message", "TestNode", "TestMesh"
+                    )
+                    self.assertFalse(result)
+                    mock_client.sendText.assert_not_called()
+                    mock_client.sendText.reset_mock()
 
         asyncio.run(run_test())
 

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -409,6 +409,65 @@ class TestPingPlugin(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_match_case_empty_source(self):
+        """Empty source returns empty string (line 40)."""
+        self.assertEqual(match_case("", "pong"), "")
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_handle_meshtastic_message_non_text_portnum(self, mock_connect):
+        """Non-text portnum should be rejected (line 99)."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"portnum": "TELEMETRY_APP", "text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    def test_get_matrix_commands_none_name(self):
+        """get_matrix_commands returns [] when plugin_name is None (line 192)."""
+        self.plugin.plugin_name = None
+        self.assertEqual(self.plugin.get_matrix_commands(), [])
+
+    def test_get_mesh_commands_none_name(self):
+        """get_mesh_commands returns [] when plugin_name is None (line 203)."""
+        self.plugin.plugin_name = None
+        self.assertEqual(self.plugin.get_mesh_commands(), [])
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_handle_meshtastic_message_no_client(self, mock_connect):
+        """Missing meshtastic client should return True (line 128-129)."""
+        mock_connect.return_value = None
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.logger.warning.assert_called_once_with(
+                "Meshtastic client unavailable; skipping ping"
+            )
+
+        asyncio.run(run_test())
+
 
 class TestPingPluginMimicMode(unittest.TestCase):
     def setUp(self):

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -106,7 +106,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -132,7 +132,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -160,7 +160,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": 123456789,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -168,6 +168,7 @@ class TestPingPlugin(unittest.TestCase):
             self.plugin.is_channel_enabled.assert_called_once_with(
                 1, is_direct_message=True
             )
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(
                 text="pong", destinationId="!12345678"
             )
@@ -188,11 +189,12 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
 
         asyncio.run(run_test())
@@ -210,7 +212,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -232,7 +234,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -254,7 +256,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -276,7 +278,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -300,7 +302,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -323,7 +325,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -346,7 +348,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -368,7 +370,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -391,7 +393,7 @@ class TestPingPlugin(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -423,7 +425,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -446,11 +448,12 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
 
         asyncio.run(run_test())
@@ -469,11 +472,12 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="Pong", channelIndex=0)
 
         asyncio.run(run_test())
@@ -492,11 +496,12 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="!pong!", channelIndex=0)
 
         asyncio.run(run_test())
@@ -515,11 +520,12 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
 
         asyncio.run(run_test())
@@ -538,11 +544,12 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="PoNg!?!", channelIndex=0)
 
         asyncio.run(run_test())
@@ -560,7 +567,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -575,7 +582,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
 
-        async def run_test():
+        async def run_test() -> None:
             for message in (
                 "please ping",
                 "can you ping?",
@@ -612,7 +619,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             "to": 123456789,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -620,6 +627,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             self.plugin.is_channel_enabled.assert_called_once_with(
                 1, is_direct_message=True
             )
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(
                 text="pong", destinationId="!12345678"
             )
@@ -638,7 +646,7 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
         room = MagicMock()
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -652,7 +660,7 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
         room.room_id = "!test:matrix.org"
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_room_message(room, event, "bot: !ping")
             self.assertTrue(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -673,7 +681,7 @@ class TestPingPluginEdgeCases(unittest.TestCase):
     def test_handle_meshtastic_message_no_decoded(self):
         packet = {"channel": 0, "fromId": "!12345678", "to": BROADCAST_NUM}
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -689,7 +697,7 @@ class TestPingPluginEdgeCases(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
@@ -711,15 +719,15 @@ class TestPingPluginEdgeCases(unittest.TestCase):
             "to": BROADCAST_NUM,
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
 
         asyncio.run(run_test())
-        mock_sleep.assert_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -66,7 +66,7 @@ class TestPingPlugin(unittest.TestCase):
     def test_description_property(self):
         self.assertEqual(
             self.plugin.description,
-            "Check connectivity with the relay or respond to pings over the mesh",
+            "Check connectivity with the relay; optional mimic mode responds to mesh pings",
         )
 
     def test_get_matrix_commands(self):
@@ -105,6 +105,10 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertTrue(result)
+            self.plugin.logger.warning.assert_called_once_with(
+                "Meshtastic client myInfo unavailable; skipping ping"
+            )
+            mock_client.sendText.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -217,6 +221,50 @@ class TestPingPlugin(unittest.TestCase):
 
         packet = {
             "decoded": {"text": "how far does the ping go?"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_explicit_ping_in_prose_ignored_by_default(self, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "please !ping now"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_double_bang_ping_ignored_by_default(self, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!!ping"},
             "channel": 0,
             "fromId": "!12345678",
             "to": BROADCAST_NUM,

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -4,7 +4,8 @@ Test suite for the MMRelay ping plugin.
 
 Tests the ping/pong functionality including:
 - Case matching utility function
-- Ping detection with various punctuation patterns
+- Explicit !ping command (default behavior)
+- mimic_mode for conversational matching of bare "ping"
 - Direct message vs broadcast handling
 - Response delay and message routing
 - Matrix room message handling
@@ -17,7 +18,6 @@ import sys
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-# Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from meshtastic.mesh_interface import BROADCAST_NUM
@@ -27,107 +27,170 @@ from mmrelay.plugins.ping_plugin import Plugin, match_case
 
 
 class TestMatchCase(unittest.TestCase):
-    """Test cases for the match_case utility function."""
-
     def test_match_case_all_lowercase(self):
-        """Test match_case with all lowercase source."""
         result = match_case("ping", "pong")
         self.assertEqual(result, "pong")
 
     def test_match_case_all_uppercase(self):
-        """
-        Tests that match_case converts the target string to all uppercase when the source string is all uppercase.
-        """
         result = match_case("PING", "pong")
         self.assertEqual(result, "PONG")
 
     def test_match_case_mixed_case(self):
-        """
-        Test that match_case adjusts the target string to match a mixed case source string.
-        """
         result = match_case("PiNg", "pong")
         self.assertEqual(result, "PoNg")
 
     def test_match_case_first_letter_uppercase(self):
-        """
-        Tests that match_case returns a target string with its first letter capitalized to match a source string with an initial uppercase letter.
-        """
         result = match_case("Ping", "pong")
         self.assertEqual(result, "Pong")
 
     def test_match_case_different_lengths(self):
-        """
-        Test that match_case returns a target string adjusted to the source's length and case when the strings have different lengths.
-        """
         result = match_case("Pi", "pong")
         self.assertEqual(result, "Po")
 
     def test_match_case_empty_strings(self):
-        """
-        Test that match_case returns an empty string when the source string is empty.
-        """
         result = match_case("", "pong")
         self.assertEqual(result, "")
 
 
 class TestPingPlugin(unittest.TestCase):
-    """Test cases for the ping plugin."""
-
     def setUp(self):
-        """
-        Initializes the Plugin instance and mocks its dependencies for isolated testing.
-        """
         self.plugin = Plugin()
         self.plugin.logger = MagicMock()
-
-        # Mock the is_channel_enabled method
         self.plugin.is_channel_enabled = MagicMock(return_value=True)
-
-        # Mock the get_response_delay method
         self.plugin.get_response_delay = MagicMock(return_value=1.0)
-
-        # Mock Matrix client methods
         self.plugin.send_matrix_message = AsyncMock()
 
     def test_plugin_name(self):
-        """
-        Verify that the plugin's name attribute is set to "ping".
-        """
         self.assertEqual(self.plugin.plugin_name, "ping")
 
     def test_description_property(self):
-        """
-        Verify that the plugin's description property returns the expected string.
-        """
-        description = self.plugin.description
         self.assertEqual(
-            description,
+            self.plugin.description,
             "Check connectivity with the relay or respond to pings over the mesh",
         )
 
     def test_get_matrix_commands(self):
-        """
-        Test that the plugin's get_matrix_commands method returns a list containing the "ping" command.
-        """
-        commands = self.plugin.get_matrix_commands()
-        self.assertEqual(commands, ["ping"])
+        self.assertEqual(self.plugin.get_matrix_commands(), ["ping"])
 
     def test_get_mesh_commands(self):
-        """
-        Test that the plugin's get_mesh_commands method returns a list containing the "ping" command.
-        """
-        commands = self.plugin.get_mesh_commands()
-        self.assertEqual(commands, ["ping"])
+        self.assertEqual(self.plugin.get_mesh_commands(), ["ping"])
+
+    def test_get_mimic_mode_default(self):
+        self.assertFalse(self.plugin.get_mimic_mode())
+
+    def test_get_mimic_mode_true(self):
+        self.plugin.config = {"mimic_mode": True}
+        self.assertTrue(self.plugin.get_mimic_mode())
+
+    def test_get_mimic_mode_false(self):
+        self.plugin.config = {"mimic_mode": False}
+        self.assertFalse(self.plugin.get_mimic_mode())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     def test_handle_meshtastic_message_missing_myinfo(self, mock_connect):
-        """
-        Ensure the handler exits cleanly when myInfo is missing.
-        """
-
         mock_client = MagicMock()
         mock_client.myInfo = None
         mock_client.nodes = {}
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_explicit_ping_broadcast(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.is_channel_enabled.assert_called_once_with(
+                0, is_direct_message=False
+            )
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            self.plugin.logger.info.assert_called_once()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_explicit_ping_direct_message(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 1,
+            "fromId": "!12345678",
+            "to": 123456789,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.is_channel_enabled.assert_called_once_with(
+                1, is_direct_message=True
+            )
+            mock_client.sendText.assert_called_once_with(
+                text="pong", destinationId="!12345678"
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_explicit_ping_case_matching(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!PING"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_bare_ping_ignored_by_default(self, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
 
         packet = {
@@ -138,240 +201,84 @@ class TestPingPlugin(unittest.TestCase):
         }
 
         async def run_test():
-            """
-            Verify that handle_meshtastic_message does not process a packet when the Meshtastic client lacks `myInfo`.
-
-            This test awaits plugin.handle_meshtastic_message with the provided `packet` and asserts that it returns `False`, indicating no handling occurred for a client with missing `myInfo`.
-            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-            self.assertTrue(result)
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
 
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_handle_meshtastic_message_simple_ping_broadcast(
-        self, mock_sleep, mock_connect
-    ):
-        """
-        Test that a simple "ping" broadcast message is correctly handled by the plugin.
-
-        Verifies that the plugin checks channel enablement, waits for the configured response delay, sends a "pong" broadcast response on the same channel, logs the processing, and returns True to indicate the message was handled.
-        """
-        # Mock meshtastic client
+    def test_ping_in_sentence_ignored_by_default(self, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
 
         packet = {
-            "decoded": {"text": "ping"},
+            "decoded": {"text": "how far does the ping go?"},
             "channel": 0,
             "fromId": "!12345678",
-            "to": BROADCAST_NUM,  # BROADCAST_NUM
+            "to": BROADCAST_NUM,
         }
 
         async def run_test():
-            """
-            Asynchronously tests that the plugin correctly handles a Meshtastic broadcast ping message.
-
-            Verifies that the plugin checks channel enablement, waits for the configured response delay, sends a broadcast "pong" response, and logs the processing. Asserts that the message handling result is True.
-            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
 
-            self.assertTrue(result)
+        asyncio.run(run_test())
 
-            # Should check channel enablement for broadcast
-            self.plugin.is_channel_enabled.assert_called_once_with(
-                0, is_direct_message=False
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_bare_ping_ignored_mimic_mode_false(self, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"mimic_mode": False}
+
+        packet = {
+            "decoded": {"text": "ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
             )
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
 
-            # Should wait for response delay
-            mock_sleep.assert_called_once_with(1.0)
+        asyncio.run(run_test())
 
-            # Should send broadcast response
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_explicit_ping_works_with_mimic_mode_false(self, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"mimic_mode": False}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
             mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
 
-            # Should log processing
-            self.plugin.logger.info.assert_called_once()
-
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_handle_meshtastic_message_ping_direct_message(
-        self, mock_sleep, mock_connect
-    ):
-        """
-        Test that the plugin correctly handles a "ping" message received as a direct Meshtastic message.
-
-        Verifies that the plugin checks channel enablement for direct messages, sends a direct "pong" response to the sender, and returns True to indicate the message was handled.
-        """
-        # Mock meshtastic client
-        mock_client = MagicMock()
-        mock_client.myInfo.my_node_num = 123456789
-        mock_connect.return_value = mock_client
-
-        packet = {
-            "decoded": {"text": "ping"},
-            "channel": 1,
-            "fromId": "!12345678",
-            "to": 123456789,  # Direct to relay
-        }
-
-        async def run_test():
-            """
-            Asynchronously tests that the plugin correctly handles a direct "ping" Meshtastic message.
-
-            Verifies that the plugin checks channel enablement for direct messages, sends a direct "pong" response to the sender, and returns True to indicate the message was handled.
-            """
-            result = await self.plugin.handle_meshtastic_message(
-                packet, "formatted_message", "TestNode", "TestMesh"
-            )
-
-            self.assertTrue(result)
-
-            # Should check channel enablement for direct message
-            self.plugin.is_channel_enabled.assert_called_once_with(
-                1, is_direct_message=True
-            )
-
-            # Should send direct message response
-            mock_client.sendText.assert_called_once_with(
-                text="pong", destinationId="!12345678"
-            )
-
-        asyncio.run(run_test())
-
-    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_handle_meshtastic_message_ping_with_punctuation(
-        self, mock_sleep, mock_connect
-    ):
-        """
-        Test that a Meshtastic "ping" message with punctuation receives a "pong" response preserving the original punctuation.
-
-        Verifies that the plugin responds to a ping message containing punctuation (e.g., "!ping!") by sending a pong message with matching punctuation (e.g., "!pong!"), and confirms the response is sent on the correct channel.
-        """
-        # Mock meshtastic client
-        mock_client = MagicMock()
-        mock_client.myInfo.my_node_num = 123456789
-        mock_connect.return_value = mock_client
-
-        packet = {
-            "decoded": {"text": "!ping!"},
-            "channel": 0,
-            "fromId": "!12345678",
-            "to": BROADCAST_NUM,  # BROADCAST_NUM
-        }
-
-        async def run_test():
-            """
-            Runs an asynchronous test to verify that the plugin responds to a Meshtastic ping message with a correctly punctuated pong response.
-
-            Returns:
-                bool: True if the plugin handled the message as expected.
-            """
-            result = await self.plugin.handle_meshtastic_message(
-                packet, "formatted_message", "TestNode", "TestMesh"
-            )
-
-            self.assertTrue(result)
-
-            # Should preserve punctuation in response
-            mock_client.sendText.assert_called_once_with(text="!pong!", channelIndex=0)
-
-        asyncio.run(run_test())
-
-    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_handle_meshtastic_message_ping_excessive_punctuation(
-        self, mock_sleep, mock_connect
-    ):
-        """
-        Test that the plugin responds with "Pong..." when handling a Meshtastic ping message containing excessive punctuation.
-
-        Verifies that when a ping message with more than five punctuation characters is received, the plugin sends a "Pong..." response on the same channel.
-        """
-        # Mock meshtastic client
-        mock_client = MagicMock()
-        mock_client.myInfo.my_node_num = 123456789
-        mock_connect.return_value = mock_client
-
-        packet = {
-            "decoded": {"text": "!!!ping!!!"},
-            "channel": 0,
-            "fromId": "!12345678",
-            "to": BROADCAST_NUM,  # BROADCAST_NUM
-        }
-
-        async def run_test():
-            """
-            Runs an asynchronous test to verify that the plugin responds with "Pong..." when handling a ping message containing excessive punctuation.
-
-            Returns:
-                bool: True if the plugin handled the message as expected.
-            """
-            result = await self.plugin.handle_meshtastic_message(
-                packet, "formatted_message", "TestNode", "TestMesh"
-            )
-
-            self.assertTrue(result)
-
-            # Should use "Pong..." for excessive punctuation (>5 chars)
-            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
-
-        asyncio.run(run_test())
-
-    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_handle_meshtastic_message_ping_case_matching(
-        self, mock_sleep, mock_connect
-    ):
-        """
-        Tests that the plugin responds to a Meshtastic "PING" message with a "PONG" reply that matches the original message's case.
-        """
-        # Mock meshtastic client
-        mock_client = MagicMock()
-        mock_client.myInfo.my_node_num = 123456789
-        mock_connect.return_value = mock_client
-
-        packet = {
-            "decoded": {"text": "PING"},
-            "channel": 0,
-            "fromId": "!12345678",
-            "to": BROADCAST_NUM,  # BROADCAST_NUM
-        }
-
-        async def run_test():
-            """
-            Runs an asynchronous test to verify that the plugin responds to a Meshtastic "ping" message with a correctly cased "PONG" response.
-
-            Returns:
-                bool: True if the plugin handled the message as expected.
-            """
-            result = await self.plugin.handle_meshtastic_message(
-                packet, "formatted_message", "TestNode", "TestMesh"
-            )
-
-            self.assertTrue(result)
-
-            # Should match case of original ping
-            mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
-
-        asyncio.run(run_test())
-
-    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    def test_handle_meshtastic_message_no_ping(self, mock_connect):
-        """
-        Test that the plugin does not respond to Meshtastic messages that do not contain a ping command.
-
-        Verifies that no message is sent and the handler returns False when the incoming message lacks a ping trigger.
-        """
-        # Mock meshtastic client
+    def test_no_ping_no_response(self, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -384,37 +291,52 @@ class TestPingPlugin(unittest.TestCase):
         }
 
         async def run_test():
-            """
-            Asynchronously runs a test to verify that no response is sent when handling a Meshtastic message that should not trigger a reply.
-
-            Returns:
-                None
-            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-
             self.assertFalse(result)
-
-            # Should not send any message
             mock_client.sendText.assert_not_called()
 
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    def test_handle_meshtastic_message_channel_disabled(self, mock_connect):
-        """
-        Test that no response is sent when handling a ping message on a disabled channel.
-
-        Verifies that the plugin does not respond to a "ping" Meshtastic message if the channel is disabled, and that no message is sent.
-        """
-        # Mock meshtastic client
+    def test_channel_disabled(self, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
-
-        # Mock channel as disabled
         self.plugin.is_channel_enabled = MagicMock(return_value=False)
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
+
+        asyncio.run(run_test())
+
+
+class TestPingPluginMimicMode(unittest.TestCase):
+    def setUp(self):
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        self.plugin.is_channel_enabled = MagicMock(return_value=True)
+        self.plugin.get_response_delay = MagicMock(return_value=1.0)
+        self.plugin.config = {"mimic_mode": True}
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_bare_ping(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
 
         packet = {
             "decoded": {"text": "ping"},
@@ -424,39 +346,170 @@ class TestPingPlugin(unittest.TestCase):
         }
 
         async def run_test():
-            """
-            Asynchronously runs a test to verify that no response is sent when handling a Meshtastic message that should not trigger a reply.
-
-            Returns:
-                None
-            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-
-            self.assertFalse(result)
-
-            # Should not send any message
-            mock_client.sendText.assert_not_called()
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
 
         asyncio.run(run_test())
 
-    def test_handle_room_message_no_match(self):
-        """
-        Test that handle_room_message returns False and does not send a message when the event does not match the plugin's criteria.
-        """
-        self.plugin.matches = MagicMock(return_value=False)
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_case_matching_upper(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
 
+        packet = {
+            "decoded": {"text": "PING"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_case_matching_title(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "Ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="Pong", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_punctuation_preserved(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping!"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="!pong!", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_excessive_punctuation_fallback(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!!!ping!!!"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_ping_in_sentence(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "how far does the ping go?"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_direct_message(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "ping"},
+            "channel": 1,
+            "fromId": "!12345678",
+            "to": 123456789,
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.is_channel_enabled.assert_called_once_with(
+                1, is_direct_message=True
+            )
+            mock_client.sendText.assert_called_once_with(
+                text="pong", destinationId="!12345678"
+            )
+
+        asyncio.run(run_test())
+
+
+class TestPingPluginMatrixHandling(unittest.TestCase):
+    def setUp(self):
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        self.plugin.send_matrix_message = AsyncMock()
+
+    def test_handle_room_message_no_match(self):
+        self.plugin.matches = MagicMock(return_value=False)
         room = MagicMock()
         event = MagicMock()
 
         async def run_test():
-            """
-            Asynchronously tests that no Matrix message is sent when the event does not match the plugin's criteria.
-
-            Returns:
-                bool: False, indicating the message was not handled.
-            """
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
@@ -465,23 +518,13 @@ class TestPingPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_handle_room_message_ping_match(self):
-        """
-        Tests that handle_room_message sends a "pong!" response when a ping command is detected in a Matrix room message.
-        """
         self.plugin.matches = MagicMock(return_value=True)
-
         room = MagicMock()
         room.room_id = "!test:matrix.org"
         event = MagicMock()
 
         async def run_test():
-            """
-            Runs an asynchronous test to verify that the plugin responds to a ping command in a Matrix room message.
-
-            Asserts that the plugin correctly matches the event, sends a "pong!" response to the specified Matrix room, and returns True.
-            """
             result = await self.plugin.handle_room_message(room, event, "bot: !ping")
-
             self.assertTrue(result)
             self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_called_once_with(
@@ -490,35 +533,26 @@ class TestPingPlugin(unittest.TestCase):
 
         asyncio.run(run_test())
 
-    def test_handle_meshtastic_message_no_decoded(self):
-        """
-        Test that the plugin does not handle a Meshtastic packet missing the "decoded" field.
 
-        Verifies that when the "decoded" field is absent from the packet, the handler returns False, indicating the message was not processed.
-        """
+class TestPingPluginEdgeCases(unittest.TestCase):
+    def setUp(self):
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        self.plugin.is_channel_enabled = MagicMock(return_value=True)
+        self.plugin.get_response_delay = MagicMock(return_value=1.0)
+
+    def test_handle_meshtastic_message_no_decoded(self):
         packet = {"channel": 0, "fromId": "!12345678", "to": BROADCAST_NUM}
 
         async def run_test():
-            """
-            Runs an asynchronous test to verify that the plugin does not handle a given Meshtastic message.
-
-            Returns:
-                bool: False, indicating the message was not handled by the plugin.
-            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-
             self.assertFalse(result)
 
         asyncio.run(run_test())
 
     def test_handle_meshtastic_message_no_text(self):
-        """
-        Test that the plugin does not handle a Meshtastic packet missing the "text" field in the "decoded" section.
-
-        Verifies that no response is sent and the handler returns False.
-        """
         packet = {
             "decoded": {"portnum": TEXT_MESSAGE_APP},
             "channel": 0,
@@ -527,31 +561,22 @@ class TestPingPlugin(unittest.TestCase):
         }
 
         async def run_test():
-            """
-            Runs an asynchronous test to verify that the plugin does not handle a given Meshtastic message.
-
-            Returns:
-                bool: False, indicating the message was not handled by the plugin.
-            """
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-
             self.assertFalse(result)
 
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_handle_meshtastic_message_broadcast_num(self, mock_sleep, mock_connect):
-        """Test handle_meshtastic_message with BROADCAST_NUM."""
-
+    def test_broadcast_num_explicit(self, mock_sleep, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
 
         packet = {
-            "decoded": {"portnum": TEXT_MESSAGE_APP, "text": "ping"},
+            "decoded": {"portnum": TEXT_MESSAGE_APP, "text": "!ping"},
             "channel": 0,
             "fromId": "!12345678",
             "to": BROADCAST_NUM,
@@ -561,12 +586,11 @@ class TestPingPlugin(unittest.TestCase):
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-            self.assertTrue(result)  # Should handle broadcast ping
-            # For broadcast messages, plugin sends Meshtastic reply, not Matrix message
+            self.assertTrue(result)
             mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
 
         asyncio.run(run_test())
-        mock_sleep.assert_called()  # ensure delay path exercised if applicable
+        mock_sleep.assert_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -732,6 +732,31 @@ class TestPingPluginEdgeCases(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_direct_message_missing_fromId(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 1,
+            "to": 123456789,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_client.sendText.assert_not_called()
+            self.plugin.logger.warning.assert_called_once_with(
+                "Direct message missing fromId; cannot reply"
+            )
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -548,8 +548,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_mimic_ping_in_sentence_ignored(self, mock_sleep, mock_connect):
+    def test_mimic_ping_in_sentence_ignored(self, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -571,8 +570,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_mimic_ping_prose_variants_ignored(self, mock_sleep, mock_connect):
+    def test_mimic_ping_prose_variants_ignored(self, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from meshtastic.mesh_interface import BROADCAST_NUM
 
-from mmrelay.constants.formats import TEXT_MESSAGE_APP
+from mmrelay.constants.formats import DEFAULT_CHANNEL, TEXT_MESSAGE_APP
 from mmrelay.plugins.ping_plugin import Plugin, match_case
 
 
@@ -91,6 +91,11 @@ class TestPingPlugin(unittest.TestCase):
             with self.subTest(mimic_mode_value=mimic_mode_value):
                 self.plugin.config = {"mimic_mode": mimic_mode_value}
                 self.assertFalse(self.plugin.get_mimic_mode())
+        self.plugin.logger.warning.assert_called_once_with(
+            "Invalid ping.mimic_mode value %r; expected boolean. Defaulting to false.",
+            "false",
+        )
+        self.assertTrue(self.plugin._invalid_mimic_mode_warned)
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     def test_handle_meshtastic_message_missing_myinfo(self, mock_connect):
@@ -759,15 +764,15 @@ class TestPingPluginEdgeCases(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    def test_packet_addressed_to_other_node_ignored(self, mock_connect):
+    def test_packet_targeted_to_other_node_ignored(self, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
 
         packet = {
             "decoded": {"text": "!ping"},
-            "channel": 0,
-            "fromId": "!99999999",
+            "channel": 1,
+            "fromId": "!12345678",
             "to": 987654321,
         }
 
@@ -776,7 +781,38 @@ class TestPingPluginEdgeCases(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
+            self.plugin.is_channel_enabled.assert_not_called()
             mock_client.sendText.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_channel_none_coalesces_to_default_channel(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": None,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.is_channel_enabled.assert_called_once_with(
+                DEFAULT_CHANNEL, is_direct_message=False
+            )
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(
+                text="pong",
+                channelIndex=DEFAULT_CHANNEL,
+            )
 
         asyncio.run(run_test())
 

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -733,8 +733,7 @@ class TestPingPluginEdgeCases(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
-    @patch("asyncio.sleep")
-    def test_direct_message_missing_fromId(self, mock_sleep, mock_connect):
+    def test_direct_message_missing_fromId(self, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -746,14 +745,38 @@ class TestPingPluginEdgeCases(unittest.TestCase):
         }
 
         async def run_test() -> None:
+            with patch("asyncio.sleep") as mock_sleep:
+                result = await self.plugin.handle_meshtastic_message(
+                    packet, "formatted_message", "TestNode", "TestMesh"
+                )
+                self.assertTrue(result)
+                mock_sleep.assert_not_called()
+                mock_client.sendText.assert_not_called()
+                self.plugin.logger.warning.assert_called_once_with(
+                    "Direct message missing fromId; cannot reply"
+                )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_packet_addressed_to_other_node_ignored(self, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!99999999",
+            "to": 987654321,
+        }
+
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-            self.assertTrue(result)
+            self.assertFalse(result)
             mock_client.sendText.assert_not_called()
-            self.plugin.logger.warning.assert_called_once_with(
-                "Direct message missing fromId; cannot reply"
-            )
 
         asyncio.run(run_test())
 

--- a/tests/test_setup_utils_edge_cases.py
+++ b/tests/test_setup_utils_edge_cases.py
@@ -491,5 +491,399 @@ ExecStart=%h/meshtastic-matrix-relay/.pyenv/bin/python %h/meshtastic-matrix-rela
                     self.assertIn("--config %h/.mmrelay/config.yaml", written_content)
 
 
+class TestGetResolvedExecStartEmpty(unittest.TestCase):
+    """Test get_resolved_exec_start with empty suffix (line 161)."""
+
+    @patch("mmrelay.setup_utils.get_resolved_exec_cmd", return_value="mmrelay")
+    def test_empty_suffix(self, mock_cmd):
+        """Empty suffix should produce ExecStart without args."""
+        from mmrelay.setup_utils import get_resolved_exec_start
+
+        result = get_resolved_exec_start(args_suffix="   ")
+        self.assertEqual(result, "ExecStart=mmrelay")
+
+
+class TestServiceNeedsUpdateEdgeCases(unittest.TestCase):
+    """Test service_needs_update edge cases for uncovered branches."""
+
+    def _make_service_content(self, exec_start, environment=None, unit_section=None):
+        lines = ["[Unit]"]
+        if unit_section:
+            lines.extend(unit_section)
+        lines.append("Description=Test")
+        lines.append("[Service]")
+        lines.append("Type=simple")
+        lines.append(exec_start)
+        if environment:
+            for env in environment:
+                lines.append(env)
+        lines.append("[Install]")
+        lines.append("WantedBy=default.target")
+        return "\n".join(lines)
+
+    def _full_service(self, exec_start, **kwargs):
+        defaults = {
+            "environment": [
+                "Environment=PATH=%h/.local/bin:%h/.local/pipx/venvs/mmrelay/bin:/usr/bin"
+            ],
+            "unit_section": [
+                "After=network-online.target time-sync.target",
+                "Wants=network-online.target time-sync.target",
+            ],
+        }
+        for k, v in defaults.items():
+            kwargs.setdefault(k, v)
+        return self._make_service_content(exec_start, **kwargs)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_missing_execstart_line(self, mock_path, mock_read):
+        """Service file missing ExecStart should need update (line 576)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = "[Unit]\nDescription=Test\n[Service]\nType=simple\n"
+        needs_update, reason = service_needs_update()
+        self.assertTrue(needs_update)
+        self.assertIn("missing ExecStart", reason)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_empty_execstart_value(self, mock_path, mock_read):
+        """Empty ExecStart value should need update (line 580)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._make_service_content(
+            "ExecStart=",
+            unit_section=[
+                "After=network.target time-sync.target",
+                "Wants=time-sync.target",
+            ],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertTrue(needs_update)
+        self.assertIn("empty ExecStart", reason)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_invalid_execstart_shlex(self, mock_path, mock_read):
+        """Invalid ExecStart (unbalanced quotes) should need update (line 591-592)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._make_service_content(
+            'ExecStart=/usr/bin/mmrelay "unbalanced',
+            unit_section=[
+                "After=network.target time-sync.target",
+                "Wants=time-sync.target",
+            ],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertTrue(needs_update)
+        self.assertIn("invalid ExecStart", reason)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_legacy_config_flag(self, mock_path, mock_read):
+        """Service with --config flag should need update (line 599)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._make_service_content(
+            "ExecStart=mmrelay --config /etc/config.yaml --home /test",
+            unit_section=[
+                "After=network.target time-sync.target",
+                "Wants=time-sync.target",
+            ],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertTrue(needs_update)
+        self.assertIn("legacy", reason)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_home_flag_with_dash_value(self, mock_path, mock_read):
+        """--home followed by a flag-like value should not count as home flag (line 612->615)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._make_service_content(
+            "ExecStart=mmrelay --home --other-flag",
+            unit_section=[
+                "After=network.target time-sync.target",
+                "Wants=time-sync.target",
+            ],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertTrue(needs_update)
+        self.assertIn("missing home", reason)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_home_equals_empty_value(self, mock_path, mock_read):
+        """--home= with empty value should not count, but MMRELAY_HOME env should work (line 619-620)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._full_service(
+            "ExecStart=/usr/bin/mmrelay --home= ",
+            environment=["Environment=MMRELAY_HOME=/test"],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertFalse(needs_update)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_empty_environment_line(self, mock_path, mock_read):
+        """Empty Environment= line should be handled (line 624->626, 627)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._full_service(
+            "ExecStart=/usr/bin/mmrelay --home /test",
+            environment=["Environment=", "Environment=MMRELAY_HOME=/test"],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertFalse(needs_update)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_env_launcher_with_double_dash(self, mock_path, mock_read):
+        """env launcher with -- separator should skip it (line 660)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._full_service(
+            "ExecStart=env -- mmrelay --home /test",
+        )
+        needs_update, reason = service_needs_update()
+        self.assertFalse(needs_update)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_env_launcher_with_flag(self, mock_path, mock_read):
+        """env launcher with -S flag should skip it (line 662)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._full_service(
+            "ExecStart=env -S mmrelay --home /test",
+        )
+        needs_update, reason = service_needs_update()
+        self.assertFalse(needs_update)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_env_without_equals(self, mock_path, mock_read):
+        """Environment line token without '=' should be skipped (line 636)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._full_service(
+            "ExecStart=/usr/bin/mmrelay --home /test",
+            environment=["Environment=NOEQUALS MMRELAY_HOME=/test"],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertFalse(needs_update)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_unrecognizable_launcher(self, mock_path, mock_read):
+        """Non-mmrelay, non-absolute launcher should be flagged (line 710)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._make_service_content(
+            "ExecStart=unknown_launcher --home /test",
+            unit_section=[
+                "After=network.target time-sync.target",
+                "Wants=time-sync.target",
+            ],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertTrue(needs_update)
+        self.assertIn("recognizable", reason)
+
+    @patch("mmrelay.setup_utils.read_service_file")
+    @patch("mmrelay.setup_utils.get_template_service_path", return_value=None)
+    def test_path_with_percent_h_entry(self, mock_path, mock_read):
+        """PATH with %h entry should normalize correctly (line 728)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        mock_read.return_value = self._make_service_content(
+            "ExecStart=env mmrelay --home /test",
+            environment=[
+                f"Environment=PATH=%h/.local/bin:%h/.local/pipx/venvs/mmrelay/bin:/usr/bin"
+            ],
+            unit_section=[
+                "After=network.target time-sync.target",
+                "Wants=time-sync.target",
+            ],
+        )
+        needs_update, reason = service_needs_update()
+        self.assertFalse(needs_update)
+
+    @patch("mmrelay.setup_utils.get_template_service_path")
+    def test_mtime_oserror(self, mock_get_path):
+        """OSError during stat check should trigger update (line 768-769)."""
+        from mmrelay.setup_utils import service_needs_update
+
+        with tempfile.NamedTemporaryFile(suffix=".service", delete=False) as f:
+            f.write(
+                b"[Unit]\nDescription=Test\nAfter=time-sync.target\nWants=time-sync.target\n"
+            )
+            f.write(
+                b"[Service]\nExecStart=/usr/bin/mmrelay --home /test\nType=simple\n"
+            )
+            f.write(b"[Install]\nWantedBy=default.target\n")
+            template_path = f.name
+
+        try:
+            mock_get_path.return_value = template_path
+
+            service_content = (
+                "[Unit]\nDescription=Test\nAfter=time-sync.target\nWants=time-sync.target\n"
+                "[Service]\nExecStart=/usr/bin/mmrelay --home /test\nType=simple\n"
+                "[Install]\nWantedBy=default.target\n"
+            )
+
+            with (
+                patch(
+                    "mmrelay.setup_utils.read_service_file",
+                    return_value=service_content,
+                ),
+                patch("os.path.exists", return_value=True),
+                patch("os.path.getmtime", side_effect=OSError("fail")),
+            ):
+                needs_update, reason = service_needs_update()
+                self.assertTrue(needs_update)
+                self.assertIn("Unable to stat", reason)
+        finally:
+            os.unlink(template_path)
+
+
+class TestCheckLingeringLoginctlNotFound(unittest.TestCase):
+    """Test check_lingering_enabled when loginctl is not found (line 833)."""
+
+    @patch("mmrelay.setup_utils.shutil.which", return_value=None)
+    @patch.dict(os.environ, {"USER": "testuser"}, clear=False)
+    def test_loginctl_not_found_returns_false(self, mock_which):
+        """check_lingering_enabled should return False when loginctl is not found."""
+        result = check_lingering_enabled()
+        self.assertFalse(result)
+
+
+class TestInstallServiceErrorPaths(unittest.TestCase):
+    """Test install_service error paths for uncovered branches."""
+
+    @patch("mmrelay.setup_utils.is_service_active", return_value=False)
+    @patch("mmrelay.setup_utils.start_service", return_value=False)
+    @patch("mmrelay.setup_utils.is_service_enabled", return_value=False)
+    @patch("mmrelay.setup_utils.check_lingering_enabled", return_value=True)
+    @patch("mmrelay.setup_utils.check_loginctl_available", return_value=False)
+    @patch("mmrelay.setup_utils.reload_daemon", return_value=True)
+    @patch("mmrelay.setup_utils.create_service_file", return_value=True)
+    @patch("mmrelay.setup_utils.service_needs_update", return_value=(True, "test"))
+    @patch("mmrelay.setup_utils.read_service_file", return_value=None)
+    @patch("mmrelay.setup_utils.show_service_status")
+    @patch("mmrelay.setup_utils.wait_for_service_start")
+    @patch("builtins.input", side_effect=["y", "y"])
+    def test_start_service_fails_warns(
+        self,
+        mock_input,
+        mock_wait,
+        mock_show,
+        mock_read,
+        mock_needs,
+        mock_create,
+        mock_reload,
+        mock_loginctl,
+        mock_linger,
+        mock_enabled,
+        mock_start,
+        mock_active,
+    ):
+        """install_service should log warning when start_service fails (line 1038)."""
+        with patch("mmrelay.setup_utils.log_service_commands"):
+            with patch("mmrelay.setup_utils.subprocess.run"):
+                result = install_service()
+        self.assertTrue(result)
+
+    @patch("mmrelay.setup_utils.is_service_active", return_value=False)
+    @patch("mmrelay.setup_utils.start_service", return_value=True)
+    @patch("mmrelay.setup_utils.is_service_enabled", return_value=False)
+    @patch("mmrelay.setup_utils.check_lingering_enabled", return_value=True)
+    @patch("mmrelay.setup_utils.check_loginctl_available", return_value=False)
+    @patch("mmrelay.setup_utils.reload_daemon", return_value=True)
+    @patch("mmrelay.setup_utils.create_service_file", return_value=True)
+    @patch("mmrelay.setup_utils.service_needs_update", return_value=(True, "test"))
+    @patch("mmrelay.setup_utils.read_service_file", return_value=None)
+    @patch("mmrelay.setup_utils.show_service_status")
+    @patch("mmrelay.setup_utils.wait_for_service_start")
+    @patch("builtins.input", side_effect=["y", "y"])
+    @patch("mmrelay.setup_utils.subprocess.run")
+    def test_enable_service_called_process_error(
+        self,
+        mock_run,
+        mock_input,
+        mock_wait,
+        mock_show,
+        mock_read,
+        mock_needs,
+        mock_create,
+        mock_reload,
+        mock_loginctl,
+        mock_linger,
+        mock_enabled,
+        mock_start,
+        mock_active,
+    ):
+        """install_service should handle CalledProcessError during enable (line 988-989)."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "enable")
+        with patch("mmrelay.setup_utils.log_service_commands"):
+            result = install_service()
+        self.assertTrue(result)
+
+    @patch("mmrelay.setup_utils.is_service_active", return_value=False)
+    @patch("mmrelay.setup_utils.start_service", return_value=True)
+    @patch("mmrelay.setup_utils.is_service_enabled", return_value=False)
+    @patch("mmrelay.setup_utils.check_lingering_enabled", return_value=True)
+    @patch("mmrelay.setup_utils.check_loginctl_available", return_value=False)
+    @patch("mmrelay.setup_utils.reload_daemon", return_value=True)
+    @patch("mmrelay.setup_utils.create_service_file", return_value=True)
+    @patch("mmrelay.setup_utils.service_needs_update", return_value=(True, "test"))
+    @patch("mmrelay.setup_utils.read_service_file", return_value=None)
+    @patch("mmrelay.setup_utils.show_service_status")
+    @patch("mmrelay.setup_utils.wait_for_service_start")
+    @patch("builtins.input", side_effect=["y", "y"])
+    @patch("mmrelay.setup_utils.subprocess.run")
+    def test_enable_service_oserror(
+        self,
+        mock_run,
+        mock_input,
+        mock_wait,
+        mock_show,
+        mock_read,
+        mock_needs,
+        mock_create,
+        mock_reload,
+        mock_loginctl,
+        mock_linger,
+        mock_enabled,
+        mock_start,
+        mock_active,
+    ):
+        """install_service should handle OSError during enable (line 990-991)."""
+        mock_run.side_effect = OSError("fail")
+        with patch("mmrelay.setup_utils.log_service_commands"):
+            result = install_service()
+        self.assertTrue(result)
+
+
+class TestStartServiceOSError(unittest.TestCase):
+    """Test start_service OSError path (line 1073-1075)."""
+
+    @patch(
+        "mmrelay.setup_utils.subprocess.run",
+        side_effect=OSError("No such file"),
+    )
+    def test_start_service_os_error(self, mock_run):
+        """start_service should return False on OSError."""
+        from mmrelay.setup_utils import start_service
+
+        result = start_service()
+        self.assertFalse(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_setup_utils_edge_cases.py
+++ b/tests/test_setup_utils_edge_cases.py
@@ -703,7 +703,7 @@ class TestServiceNeedsUpdateEdgeCases(unittest.TestCase):
         mock_read.return_value = self._make_service_content(
             "ExecStart=env mmrelay --home /test",
             environment=[
-                f"Environment=PATH=%h/.local/bin:%h/.local/pipx/venvs/mmrelay/bin:/usr/bin"
+                "Environment=PATH=%h/.local/bin:%h/.local/pipx/venvs/mmrelay/bin:/usr/bin"
             ],
             unit_section=[
                 "After=network.target time-sync.target",

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -305,7 +305,7 @@ class TestTelemetryPlugin(unittest.TestCase):
                     "time": 1642248000,
                     "deviceMetrics": {"batteryLevel": 80},
                 },
-            },
+            }
         }
 
         async def run_test():
@@ -318,6 +318,116 @@ class TestTelemetryPlugin(unittest.TestCase):
             self.plugin.set_node_data.assert_not_called()
 
         import asyncio
+
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_non_dict_decoded(self):
+        """Non-dict decoded should return False immediately."""
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                {"decoded": "not_a_dict"}, "f", "l", "m"
+            )
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_no_decoded(self):
+        """Packet with no decoded key should return False."""
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message({}, "f", "l", "m")
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_non_finite_time(self):
+        """Non-finite telemetry time should fall back to rxTime."""
+        packet = {
+            "fromId": "!node1",
+            "rxTime": 9999,
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "telemetry": {
+                    "time": float("inf"),
+                    "deviceMetrics": {"batteryLevel": 50},
+                },
+            },
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
+            self.assertFalse(result)
+            stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
+            self.assertEqual(stored[0]["time"], 9999)
+
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_string_time(self):
+        """String telemetry time should fall back to rxTime."""
+        packet = {
+            "fromId": "!node1",
+            "rxTime": 5555,
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "telemetry": {
+                    "time": "not_a_number",
+                    "deviceMetrics": {"batteryLevel": 60},
+                },
+            },
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
+            self.assertFalse(result)
+            stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
+            self.assertEqual(stored[0]["time"], 5555)
+
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_existing_data_list(self):
+        """Should append to existing list of telemetry data."""
+        self.plugin.get_node_data.return_value = [{"time": 100, "batteryLevel": 70}]
+
+        packet = {
+            "fromId": "!node1",
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "telemetry": {
+                    "time": 200,
+                    "deviceMetrics": {"batteryLevel": 80},
+                },
+            },
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
+            self.assertFalse(result)
+            stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
+            self.assertEqual(len(stored), 2)
+
+        asyncio.run(run_test())
+
+    def test_handle_meshtastic_message_existing_data_non_list(self):
+        """Should wrap non-list existing data into a list and append."""
+        self.plugin.get_node_data.return_value = {"time": 100, "batteryLevel": 70}
+
+        packet = {
+            "fromId": "!node1",
+            "decoded": {
+                "portnum": "TELEMETRY_APP",
+                "telemetry": {
+                    "time": 200,
+                    "deviceMetrics": {"batteryLevel": 80},
+                },
+            },
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
+            self.assertFalse(result)
+            stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
+            self.assertEqual(len(stored), 2)
 
         asyncio.run(run_test())
 
@@ -545,6 +655,153 @@ class TestTelemetryPlugin(unittest.TestCase):
                     self.assertIn("voltage", title_call)
 
                 asyncio.run(run_test())
+
+    def test_handle_room_message_matrix_unavailable(self):
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+            patch("mmrelay.matrix_utils.connect_matrix", return_value=None),
+        ):
+
+            async def run_test():
+                room = MagicMock()
+                room.room_id = "!r"
+                event = MagicMock()
+                event.body = "!batteryLevel"
+                event.source = {"content": {"formatted_body": ""}}
+                result = await self.plugin.handle_room_message(
+                    room, event, "!batteryLevel"
+                )
+                self.assertFalse(result)
+
+            asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    @patch("mmrelay.matrix_utils.send_image")
+    def test_handle_room_message_node_no_data(self, mock_send, mock_connect):
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_node_data.return_value = None
+        self.plugin.send_matrix_message = AsyncMock()
+
+        mock_matrix_client = MagicMock()
+        mock_connect.return_value = mock_matrix_client
+
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+        ):
+
+            async def run_test():
+                room = MagicMock()
+                room.room_id = "!r"
+                event = MagicMock()
+                event.body = "!batteryLevel NodeX"
+                event.source = {"content": {"formatted_body": ""}}
+                result = await self.plugin.handle_room_message(
+                    room, event, "!batteryLevel NodeX"
+                )
+                self.assertTrue(result)
+                self.plugin.send_matrix_message.assert_awaited_once()
+                self.assertIn(
+                    "No telemetry data",
+                    self.plugin.send_matrix_message.call_args.args[1],
+                )
+
+            asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    @patch("mmrelay.matrix_utils.send_image")
+    def test_handle_room_message_all_nodes_data(self, mock_send, mock_connect):
+        import json
+
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        now_ts = datetime.now().timestamp()
+        self.plugin.get_data.return_value = [
+            (json.dumps([{"time": now_ts, "batteryLevel": 80}]),)
+        ]
+
+        mock_matrix_client = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+            patch("mmrelay.plugins.telemetry_plugin.plt.xticks"),
+            patch("mmrelay.plugins.telemetry_plugin.plt.subplots") as mock_subplots,
+            patch("mmrelay.plugins.telemetry_plugin.Image") as mock_image_class,
+        ):
+            mock_fig = MagicMock()
+            mock_ax = MagicMock()
+            mock_subplots.return_value = (mock_fig, mock_ax)
+            mock_img = MagicMock()
+            mock_img.mode = "RGBA"
+            mock_image_class.open.return_value.__enter__ = MagicMock(
+                return_value=mock_img
+            )
+            mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
+
+            async def run_test():
+                room = MagicMock()
+                room.room_id = "!r"
+                event = MagicMock()
+                event.body = "!batteryLevel"
+                event.source = {"content": {"formatted_body": ""}}
+                result = await self.plugin.handle_room_message(
+                    room, event, "!batteryLevel"
+                )
+                self.assertTrue(result)
+
+            asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    @patch("mmrelay.matrix_utils.send_image")
+    def test_handle_room_message_image_upload_error(self, mock_send, mock_connect):
+        from mmrelay.matrix_utils import ImageUploadError
+
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_data.return_value = []
+
+        mock_matrix_client = MagicMock()
+        mock_matrix_client.room_send = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+        mock_send.side_effect = ImageUploadError("fail")
+
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+            patch("mmrelay.plugins.telemetry_plugin.plt.xticks"),
+            patch("mmrelay.plugins.telemetry_plugin.plt.subplots") as mock_subplots,
+            patch("mmrelay.plugins.telemetry_plugin.Image") as mock_image_class,
+        ):
+            mock_fig = MagicMock()
+            mock_ax = MagicMock()
+            mock_subplots.return_value = (mock_fig, mock_ax)
+            mock_img = MagicMock()
+            mock_img.mode = "RGBA"
+            mock_image_class.open.return_value.__enter__ = MagicMock(
+                return_value=mock_img
+            )
+            mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
+
+            async def run_test():
+                room = MagicMock()
+                room.room_id = "!r"
+                event = MagicMock()
+                event.body = "!batteryLevel"
+                event.source = {"content": {"formatted_body": ""}}
+                result = await self.plugin.handle_room_message(
+                    room, event, "!batteryLevel"
+                )
+                self.assertTrue(result)
+                mock_matrix_client.room_send.assert_awaited_once()
+
+            asyncio.run(run_test())
 
 
 if __name__ == "__main__":

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -12,6 +12,7 @@ Tests the weather forecast functionality including:
 - Error handling for API failures
 """
 
+import asyncio
 import copy
 import os
 import sys
@@ -1303,6 +1304,277 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         result = await plugin.handle_meshtastic_message(
             mock_packet, "!weather", "Tester", "mesh"
         )
+        self.assertTrue(result)
+
+    def test_generate_forecast_daily_mode(self):
+        """Test daily forecast mode generates multi-day output."""
+        daily_data = {
+            "current_weather": {
+                "temperature": 20.0,
+                "weathercode": 0,
+                "is_day": 1,
+                "time": "2023-08-20T10:00",
+            },
+            "hourly": {
+                "time": [],
+                "temperature_2m": [],
+                "precipitation_probability": [],
+            },
+            "daily": {
+                "weathercode": [0, 1, 2],
+                "temperature_2m_max": [25.0, 27.0, 22.0],
+                "temperature_2m_min": [15.0, 17.0, 12.0],
+                "time": ["2023-08-20", "2023-08-21", "2023-08-22"],
+            },
+        }
+
+        with patch("requests.get") as mock_get:
+            mock_get.return_value = _make_ok_response(daily_data)
+            result = self.plugin.generate_forecast(
+                TEST_LAT_NYC, TEST_LON_NYC, mode="daily"
+            )
+            self.assertIn("25.0°C/15.0°C", result)
+            self.assertIn("|", result)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_generate_forecast_invalid_units_fallback(self, mock_get):
+        """Invalid units in config should fall back to metric."""
+        mock_get.return_value = _make_ok_response(self.sample_weather_data)
+        self.plugin.config = {"units": "kelvin"}
+        result = self.plugin.generate_forecast(TEST_LAT_NYC, TEST_LON_NYC)
+        self.assertIn("°C", result)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_generate_forecast_daily_no_data(self, mock_get):
+        """Daily forecast with no data returns unavailable message."""
+        daily_data = {
+            "current_weather": {
+                "temperature": 20,
+                "weathercode": 0,
+                "is_day": 1,
+                "time": "2023-08-20T10:00",
+            },
+            "hourly": {
+                "time": [],
+                "temperature_2m": [],
+                "precipitation_probability": [],
+            },
+            "daily": {
+                "weathercode": [],
+                "temperature_2m_max": [],
+                "temperature_2m_min": [],
+                "time": [],
+            },
+        }
+        mock_get.return_value = _make_ok_response(daily_data)
+        result = self.plugin.generate_forecast(TEST_LAT_NYC, TEST_LON_NYC, mode="daily")
+        self.assertEqual(result, "Weather data temporarily unavailable.")
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_generate_forecast_daily_with_none_data(self, mock_get):
+        """Daily forecast with None values shows Data unavailable."""
+        daily_data = {
+            "current_weather": {
+                "temperature": 20,
+                "weathercode": 0,
+                "is_day": 1,
+                "time": "2023-08-20T10:00",
+            },
+            "hourly": {
+                "time": [],
+                "temperature_2m": [],
+                "precipitation_probability": [],
+            },
+            "daily": {
+                "weathercode": [None],
+                "temperature_2m_max": [None],
+                "temperature_2m_min": [None],
+                "time": ["2023-08-20"],
+            },
+        }
+        mock_get.return_value = _make_ok_response(daily_data)
+        result = self.plugin.generate_forecast(TEST_LAT_NYC, TEST_LON_NYC, mode="daily")
+        self.assertIn("Data unavailable", result)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_geocode_location_success(self, mock_get):
+        """Successful geocoding should return coordinates."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [{"latitude": 41.8781, "longitude": -87.6298}]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = self.plugin._geocode_location("Chicago")
+        self.assertAlmostEqual(result[0], 41.8781)
+        self.assertAlmostEqual(result[1], -87.6298)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_geocode_location_empty_results(self, mock_get):
+        """Geocoding with empty results should return None."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = self.plugin._geocode_location("NowhereXYZ")
+        self.assertIsNone(result)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_geocode_location_malformed_response(self, mock_get):
+        """Geocoding with malformed response should return None."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = self.plugin._geocode_location("Chicago")
+        self.assertIsNone(result)
+
+    def test_geocode_location_empty_query(self):
+        """Empty query should return None."""
+        result = self.plugin._geocode_location("")
+        self.assertIsNone(result)
+
+    def test_parse_mesh_command_non_string(self):
+        """Non-string message should return None."""
+        cmd, args = self.plugin._parse_mesh_command(12345)
+        self.assertIsNone(cmd)
+        self.assertIsNone(args)
+
+    def test_parse_location_override_empty(self):
+        """Empty arg_text should return None."""
+        self.assertIsNone(self.plugin._parse_location_override(""))
+
+    def test_determine_mesh_location_no_positions(self):
+        """Should return None when no nodes have positions."""
+        mock_client = MagicMock()
+        mock_client.nodes = {"n1": {}, "n2": {"position": {}}}
+        self.assertIsNone(self.plugin._determine_mesh_location(mock_client))
+
+    def test_determine_mesh_location_with_positions(self):
+        """Should return average position from nodes."""
+        mock_client = MagicMock()
+        mock_client.nodes = {
+            "n1": {"position": {"latitude": 10.0, "longitude": 10.0}},
+            "n2": {"position": {"latitude": 20.0, "longitude": 20.0}},
+        }
+        result = self.plugin._determine_mesh_location(mock_client)
+        self.assertAlmostEqual(result[0], 15.0)
+
+    def test_resolve_location_from_args_empty(self):
+        """Empty arg_text returns None."""
+        result = asyncio.run(self.plugin._resolve_location_from_args(""))
+        self.assertIsNone(result)
+
+    def test_resolve_location_from_args_none(self):
+        """None arg_text returns None."""
+        result = asyncio.run(self.plugin._resolve_location_from_args(None))
+        self.assertIsNone(result)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_resolve_location_from_args_geocode(self, mock_get):
+        """Should geocode free-form text."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "results": [{"latitude": 40.7, "longitude": -74.0}]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = asyncio.run(self.plugin._resolve_location_from_args("NYC"))
+        self.assertAlmostEqual(result[0], 40.7)
+
+    def test_trim_to_max_bytes(self):
+        """Short strings should pass through unchanged."""
+        result = Plugin._trim_to_max_bytes("hello")
+        self.assertEqual(result, "hello")
+
+    def test_weather_code_day_prefix(self):
+        """DAY: prefix should return day text when is_day=True."""
+        result = Plugin._weather_code_to_text(1, 1)
+        self.assertIn("Mainly clear", _normalize_emoji(result))
+
+    def test_weather_code_both_prefix(self):
+        """BOTH: prefix should return text regardless of is_day."""
+        result = Plugin._weather_code_to_text(51, 0)
+        self.assertIn("Light drizzle", _normalize_emoji(result))
+
+    def test_weather_code_day_night_fallback(self):
+        """DAY-only entry without NIGHT part should fall back to day text at night."""
+        from mmrelay.constants.plugins import WEATHER_CODE_TEXT_MAPPING
+
+        for code, text in WEATHER_CODE_TEXT_MAPPING.items():
+            if text.startswith("DAY:") and "|NIGHT:" not in text:
+                result = Plugin._weather_code_to_text(code, 0)
+                self.assertNotIn("DAY:", result)
+                break
+
+    async def test_handle_room_message_no_match(self):
+        """Should return False when event doesn't match."""
+        self.plugin.matches = MagicMock(return_value=False)
+        result = await self.plugin.handle_room_message(
+            MagicMock(room_id="!r"), MagicMock(), "!help"
+        )
+        self.assertFalse(result)
+
+    async def test_handle_room_message_no_coords_no_mesh(self):
+        """Should send 'Cannot determine location' when no coords available."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_require_bot_mention = MagicMock(return_value=False)
+        self.plugin.send_matrix_message = AsyncMock()
+
+        mock_event = MagicMock()
+        mock_event.body = "!weather"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        with patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None):
+            result = await self.plugin.handle_room_message(
+                MagicMock(room_id="!r"), mock_event, "!weather"
+            )
+        self.assertTrue(result)
+        self.assertIn(
+            "Cannot determine location",
+            self.plugin.send_matrix_message.call_args.args[1],
+        )
+
+    async def test_handle_room_message_mesh_location_fallback(self):
+        """Should use mesh location when no coords in args."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_require_bot_mention = MagicMock(return_value=False)
+        self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
+
+        mock_client = MagicMock()
+        mock_client.nodes = {
+            "n1": {"position": {"latitude": 10.0, "longitude": 20.0}},
+        }
+
+        mock_event = MagicMock()
+        mock_event.body = "!weather"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        with patch(
+            "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+        ):
+            result = await self.plugin.handle_room_message(
+                MagicMock(room_id="!r"), mock_event, "!weather"
+            )
+        self.assertTrue(result)
+        self.plugin.generate_forecast.assert_called_once()
+
+    async def test_handle_meshtastic_meshtastic_unavailable(self):
+        """Should return True when meshtastic client is unavailable."""
+        packet = {
+            "decoded": {"portnum": PORTNUM_TEXT_MESSAGE_APP, "text": "!weather"},
+            "channel": 0,
+        }
+
+        with patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None):
+            result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
         self.assertTrue(result)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR strengthens relay startup correctness by introducing explicit startup-drain completion coordination and ensuring readiness is only published once the system is fully initialized and stable. It eliminates several race conditions around startup, shutdown, and reconnect paths, and aligns readiness signaling with actual operational state.

It also refines the ping plugin with stricter command matching and an optional `mimic_mode` configuration, improving predictability while allowing controlled conversational behavior when explicitly enabled.

------------------------------------------------------------------------

## Key Changes

### Startup sequencing and readiness correctness

-   **Startup-drain completion coordination**
    -   Introduced a guarded startup-drain completion event with a
        public accessor.
    -   All connect, rollback, timer, and reconnect paths now
        consistently signal through this event.
-   **Race-safe readiness publication**
    -   Readiness is published only after:
        -   startup-drain completion is confirmed
        -   Matrix sync is active (not failed)
        -   shutdown has not been requested
    -   Ready file writes are offloaded using `asyncio.to_thread`.
    -   Post-write rechecks prevent publishing readiness if state
        changes mid-write.
-   **Timer and deadline correctness**
    -   Startup-drain completion is only signaled for the active
        timer/deadline generation.
    -   Deadline state is cleared consistently on failure paths.
    -   Prevents stale timers from incorrectly signaling completion.
-   **Consistent startup logging**
    -   "Relay startup complete" now reflects true readiness.
    -   Log ordering aligns with actual system state.
    -   Minor formatting and consistency improvements.

------------------------------------------------------------------------

### Ping plugin improvements

-   **Configurable mimic mode**
    -   `plugins.ping.mimic_mode` (default: false)
    -   When enabled, responds to bare ping-style mesh messages.
    -   Matching is strict (no substring/prose triggering).
-   **Stricter default behavior**
    -   Default remains explicit `!ping` only.
    -   Regex matching updated to require full command matches.
-   **Robust message handling**
    -   Validates `fromId` before replying to direct messages.
    -   Preserves punctuation and case for mimic responses.
    -   Emits a single warning for invalid config values.

------------------------------------------------------------------------

### Tests and CI

-   **Expanded startup-drain coverage**
    -   Added tests for:
        -   readiness gating
        -   startup-drain event transitions
        -   reconnect and rollback paths
        -   None-event (safe no-op) behavior
-   **Test isolation improvements**
    -   Startup-drain timers are cancel-and-joined in fixtures.
    -   Shared module state is fully reset between tests.
-   **Ping plugin test coverage**
    -   Enforces strict matching semantics and mimic-mode boundaries.
    -   Timing behavior is consistently mocked and asserted.
-   **CI updates**
    -   File logging explicitly enabled for integration tests.
    -   Readiness checks now rely on "Relay startup complete" in file
        logs.
    -   Artifact reporting includes file-log outputs.

------------------------------------------------------------------------

## Fixes

-   Prevents premature readiness publication when:
    -   Matrix sync fails during startup
    -   shutdown is requested mid-startup
    -   startup-drain timers are replaced or fail to initialize
-   Ensures startup-drain completion signaling:
    -   is generation-safe (no stale timer signaling)
    -   clears deadline state consistently
    -   unblocks waiters across all connect/rollback paths
-   Eliminates race conditions in:
    -   timer scheduling and failure handling
    -   readiness publication
    -   reconnect/bootstrap transitions

------------------------------------------------------------------------

## Behavior Changes

-   **Ping command behavior**
    -   Default: only explicit `!ping`

    -   Optional conversational behavior via:

        ``` yaml
        plugins:
          ping:
            mimic_mode: true
        ```
-   **Readiness semantics**
    -   "Relay startup complete" now indicates true readiness
    -   Monitoring/CI should rely on this marker (file logs supported)
    -   A short delay is expected while startup-drain completes

------------------------------------------------------------------------

## Notes

This PR focuses on startup correctness, determinism, and operational reliability. The ping plugin changes align behavior with expectations while preserving flexibility through configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->