### PR TITLE
Fix coroutine resource leak in reconnect scheduling

### DIFF
--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -167,11 +167,16 @@ def _reset_ble_degraded_state_after_disconnect(
 def _schedule_reconnect_after_disconnect() -> None:
     if facade.event_loop and not facade.event_loop.is_closed():
         facade.reconnecting = True
+        reconnect_coro = facade.reconnect()
         try:
             facade.reconnect_task = facade.asyncio.run_coroutine_threadsafe(
-                facade.reconnect(), facade.event_loop
+                reconnect_coro,
+                facade.event_loop,
             )
         except RuntimeError:
+            # If scheduling fails, close the unscheduled coroutine to avoid
+            # unawaited-coroutine warnings during teardown/error paths.
+            reconnect_coro.close()
             facade.reconnecting = False
             facade.logger.error(
                 "Failed to schedule reconnect; event loop became unavailable"

--- a/tests/test_meshtastic_events.py
+++ b/tests/test_meshtastic_events.py
@@ -168,6 +168,51 @@ class TestOnLostMeshtasticConnection:
         assert mu.reconnect_task is scheduled_reconnect_task
         mu.reconnecting = False
 
+    def test_reconnect_schedule_runtime_error_closes_coroutine(self):
+        import mmrelay.meshtastic.events as events
+
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = MagicMock()
+        mu._relay_active_client_id = None
+        mu.meshtastic_iface = None
+        mu._ble_future = None
+        mu._ble_future_address = None
+        mu._ble_executor_degraded_addresses = set()
+
+        mock_loop = MagicMock()
+        mock_loop.is_closed.return_value = False
+        mu.event_loop = mock_loop
+
+        reconnect_coro = MagicMock()
+
+        with (
+            patch.object(events.facade, "_disconnect_ble_interface"),
+            patch.object(events.facade, "reset_executor_degraded_state"),
+            patch.object(
+                events.facade,
+                "reconnect",
+                new=MagicMock(return_value=reconnect_coro),
+            ),
+            patch.object(
+                events.facade.asyncio,
+                "run_coroutine_threadsafe",
+                side_effect=RuntimeError("loop unavailable"),
+            ) as mock_schedule,
+            patch.object(events.facade.logger, "error") as mock_logger_error,
+        ):
+            events.on_lost_meshtastic_connection()
+
+        assert mu.reconnecting is False
+        reconnect_coro.close.assert_called_once()
+        mock_schedule.assert_called_once_with(reconnect_coro, mock_loop)
+        assert any(
+            call.args
+            and call.args[0]
+            == "Failed to schedule reconnect; event loop became unavailable"
+            for call in mock_logger_error.call_args_list
+        )
+
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestOnMeshtasticMessage:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request addresses a resource management issue in the Meshtastic event handling code. When the event loop becomes unavailable during reconnect scheduling, the previously created coroutine is now properly closed to prevent unawaited-coroutine warnings. This fix ensures cleaner teardown behavior and improves error visibility through logging.

## Changes

**Fixes:**
- In `_schedule_reconnect_after_disconnect`, the reconnect coroutine is now created once before attempting to schedule it, allowing for proper cleanup if scheduling fails
- Added error handling to close the coroutine and log the error when `asyncio.run_coroutine_threadsafe` raises `RuntimeError`
- Maintains the `facade.reconnecting` flag state during error conditions

**Tests:**
- Added `test_reconnect_schedule_runtime_error_closes_coroutine` to verify the coroutine is properly closed when event loop scheduling fails
- Test confirms proper error logging and correct flag state during the failure scenario

<!-- end of auto-generated comment: release notes by coderabbit.ai -->