### PR TITLE
refactor(plugins): centralize mesh command parsing and simplify ping handling

### DIFF
--- a/src/mmrelay/constants/messages.py
+++ b/src/mmrelay/constants/messages.py
@@ -28,7 +28,7 @@ DISPLAY_NAME_DEFAULT_LENGTH: Final[int] = 5  # Default display name truncation
 
 # Ping plugin messages
 PING_FALLBACK_RESPONSE: Final[str] = "Pong..."
-PING_MATRIX_RESPONSE: Final[str] = "pong!"
+PING_RESPONSE: Final[str] = "pong!"
 
 # Help plugin messages
 MSG_NO_SUCH_COMMAND: Final[str] = "No such command: {command}"

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -891,6 +891,60 @@ class BasePlugin(ABC):
             return ""
         return args.strip()
 
+    def parse_mesh_bang_command(
+        self, text: str, commands: Iterable[str]
+    ) -> tuple[str, str] | None:
+        """
+        Parse a mesh command that starts with `!` and return the matched command plus args.
+
+        Command matching is case-insensitive, but the returned command uses the canonical
+        command spelling provided in `commands` (first occurrence wins). Commands may be
+        passed with or without a leading `!`.
+
+        Parameters:
+            text (str): Incoming mesh message text.
+            commands (Iterable[str]): Supported command names.
+
+        Returns:
+            tuple[str, str] | None: `(command, args)` with trimmed args (possibly empty),
+                or `None` if the message does not start with a supported `!command`.
+        """
+        if not isinstance(text, str):
+            return None
+
+        command_lookup: dict[str, str] = {}
+        normalized_commands: list[str] = []
+        for candidate in commands:
+            if not isinstance(candidate, str):
+                continue
+            normalized = candidate.strip()
+            if not normalized:
+                continue
+            if normalized.startswith("!"):
+                normalized = normalized[1:]
+            if not normalized:
+                continue
+
+            key = normalized.casefold()
+            if key in command_lookup:
+                continue
+            command_lookup[key] = normalized
+            normalized_commands.append(normalized)
+
+        if not normalized_commands:
+            return None
+
+        cmd_pattern = "|".join(re.escape(cmd) for cmd in normalized_commands)
+        pattern = rf"^\s*!(?P<cmd>{cmd_pattern})\b(?:\s+(?P<args>.*))?$"
+        match = re.match(pattern, text, flags=re.IGNORECASE)
+        if not match:
+            return None
+
+        matched_cmd = match.group("cmd")
+        canonical_command = command_lookup.get(matched_cmd.casefold(), matched_cmd)
+        args = (match.group("args") or "").strip()
+        return canonical_command, args
+
     def get_require_bot_mention(self) -> bool:
         """
         Determine whether this plugin requires the bot to be mentioned.

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -892,18 +892,21 @@ class BasePlugin(ABC):
         return args.strip()
 
     def parse_mesh_bang_command(
-        self, text: str, commands: Iterable[str]
+        self, text: str, commands: Iterable[str], *, allow_anywhere: bool = False
     ) -> tuple[str, str] | None:
         """
-        Parse a mesh command that starts with `!` and return the matched command plus args.
+        Parse a mesh command prefixed with `!` and return the matched command plus args.
 
-        Command matching is case-insensitive, but the returned command uses the canonical
-        command spelling provided in `commands` (first occurrence wins). Commands may be
-        passed with or without a leading `!`.
+        Command matching is case-insensitive, but the returned command uses the
+        canonical command spelling provided in `commands` (first occurrence wins).
+        Commands may be passed with or without a leading `!`.
 
         Parameters:
             text (str): Incoming mesh message text.
             commands (Iterable[str]): Supported command names.
+            allow_anywhere (bool): When `False` (default), command matching must
+                occur at the start of the message (ignoring leading whitespace).
+                When `True`, the command may appear anywhere in the message.
 
         Returns:
             tuple[str, str] | None: `(command, args)` with trimmed args (possibly empty),
@@ -935,7 +938,10 @@ class BasePlugin(ABC):
             return None
 
         cmd_pattern = "|".join(re.escape(cmd) for cmd in normalized_commands)
-        pattern = rf"^\s*!(?P<cmd>{cmd_pattern})\b(?:\s+(?P<args>.*))?$"
+        if allow_anywhere:
+            pattern = rf"^.*?!(?P<cmd>{cmd_pattern})\b(?:\s+(?P<args>.*))?$"
+        else:
+            pattern = rf"^\s*!(?P<cmd>{cmd_pattern})\b(?:\s+(?P<args>.*))?$"
         match = re.match(pattern, text, flags=re.IGNORECASE)
         if not match:
             return None

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -939,10 +939,11 @@ class BasePlugin(ABC):
 
         cmd_pattern = "|".join(re.escape(cmd) for cmd in normalized_commands)
         if allow_anywhere:
-            pattern = rf"^.*?!(?P<cmd>{cmd_pattern})\b(?:\s+(?P<args>.*))?$"
+            pattern = rf"(?:(?<=\s)|^)!(?P<cmd>{cmd_pattern})\b(?:\s+(?P<args>.*))?$"
+            match = re.search(pattern, text, flags=re.IGNORECASE)
         else:
             pattern = rf"^\s*!(?P<cmd>{cmd_pattern})\b(?:\s+(?P<args>.*))?$"
-        match = re.match(pattern, text, flags=re.IGNORECASE)
+            match = re.match(pattern, text, flags=re.IGNORECASE)
         if not match:
             return None
 

--- a/src/mmrelay/plugins/drop_plugin.py
+++ b/src/mmrelay/plugins/drop_plugin.py
@@ -12,7 +12,7 @@ from nio import (
 
 from mmrelay.constants.database import DEFAULT_DISTANCE_KM_FALLBACK, DEFAULT_RADIUS_KM
 from mmrelay.constants.formats import TEXT_MESSAGE_APP
-from mmrelay.constants.plugins import DROP_COMMAND_REGEX, SPECIAL_NODE_MESSAGES
+from mmrelay.constants.plugins import SPECIAL_NODE_MESSAGES
 from mmrelay.meshtastic_utils import connect_meshtastic
 from mmrelay.plugins.base_plugin import BasePlugin
 
@@ -129,11 +129,15 @@ class Plugin(BasePlugin):
         ):
             text = packet["decoded"].get("text") or ""
 
-            match = DROP_COMMAND_REGEX.search(text)
-            if not match:
+            parsed_drop = self.parse_mesh_bang_command(
+                text, ("drop",), allow_anywhere=True
+            )
+            if parsed_drop is None:
                 return False
 
-            drop_message = match.group(1)
+            _, drop_message = parsed_drop
+            if not drop_message:
+                return False
 
             dropping_from_id: str | None = packet.get("fromId")
             if not dropping_from_id:

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -105,16 +105,27 @@ class Plugin(BasePlugin):
         mimic_mode = self.get_mimic_mode()
 
         if mimic_mode:
-            match = PING_COMMAND_REGEX.fullmatch(message)
+            first_word = message.split(maxsplit=1)[0] if message else ""
+            match = PING_COMMAND_REGEX.fullmatch(first_word)
             if not match:
                 return False
             pre_punc = match.group(1)
             matched_text = match.group(2)
             post_punc = match.group(3)
+            base_response = match_case(matched_text, "pong")
+            reply_message = (
+                PING_FALLBACK_RESPONSE
+                if (
+                    len(pre_punc) > MAX_PUNCTUATION_LENGTH
+                    or len(post_punc) > MAX_PUNCTUATION_LENGTH
+                )
+                else pre_punc + base_response + post_punc
+            )
         else:
             explicit_match = PING_EXPLICIT_COMMAND_REGEX.fullmatch(message)
             if not explicit_match:
                 return False
+            reply_message = PING_RESPONSE
 
         from mmrelay.meshtastic_utils import connect_meshtastic
 
@@ -151,19 +162,6 @@ class Plugin(BasePlugin):
             channel,
             self.plugin_name,
         )
-
-        if mimic_mode:
-            total_punc_length = len(pre_punc) + len(post_punc)
-
-            base_response = match_case(matched_text, "pong")
-
-            reply_message = (
-                PING_FALLBACK_RESPONSE
-                if total_punc_length > MAX_PUNCTUATION_LENGTH
-                else pre_punc + base_response + post_punc
-            )
-        else:
-            reply_message = PING_RESPONSE
 
         await asyncio.sleep(self.get_response_delay())
 

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -105,9 +105,7 @@ class Plugin(BasePlugin):
         mimic_mode = self.get_mimic_mode()
 
         if mimic_mode:
-            words = message.split(maxsplit=1)
-            first_word = words[0] if words else ""
-            match = PING_COMMAND_REGEX.fullmatch(first_word)
+            match = PING_COMMAND_REGEX.fullmatch(message)
             if not match:
                 return False
             pre_punc = match.group(1)

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -105,7 +105,8 @@ class Plugin(BasePlugin):
         mimic_mode = self.get_mimic_mode()
 
         if mimic_mode:
-            first_word = message.split(maxsplit=1)[0] if message else ""
+            words = message.split(maxsplit=1)
+            first_word = words[0] if words else ""
             match = PING_COMMAND_REGEX.fullmatch(first_word)
             if not match:
                 return False

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -14,7 +14,7 @@ from nio import (
 from mmrelay.constants.formats import DEFAULT_CHANNEL, TEXT_MESSAGE_APP
 from mmrelay.constants.messages import (
     PING_FALLBACK_RESPONSE,
-    PING_MATRIX_RESPONSE,
+    PING_RESPONSE,
     PORTNUM_TEXT_MESSAGE_APP,
 )
 from mmrelay.constants.plugins import (
@@ -115,9 +115,6 @@ class Plugin(BasePlugin):
             explicit_match = PING_EXPLICIT_COMMAND_REGEX.fullmatch(message)
             if not explicit_match:
                 return False
-            matched_text = explicit_match.group(1)
-            pre_punc = ""
-            post_punc = ""
 
         from mmrelay.meshtastic_utils import connect_meshtastic
 
@@ -155,15 +152,18 @@ class Plugin(BasePlugin):
             self.plugin_name,
         )
 
-        total_punc_length = len(pre_punc) + len(post_punc)
+        if mimic_mode:
+            total_punc_length = len(pre_punc) + len(post_punc)
 
-        base_response = match_case(matched_text, "pong")
+            base_response = match_case(matched_text, "pong")
 
-        reply_message = (
-            PING_FALLBACK_RESPONSE
-            if total_punc_length > MAX_PUNCTUATION_LENGTH
-            else pre_punc + base_response + post_punc
-        )
+            reply_message = (
+                PING_FALLBACK_RESPONSE
+                if total_punc_length > MAX_PUNCTUATION_LENGTH
+                else pre_punc + base_response + post_punc
+            )
+        else:
+            reply_message = PING_RESPONSE
 
         await asyncio.sleep(self.get_response_delay())
 
@@ -225,5 +225,5 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        await self.send_matrix_message(room.room_id, PING_MATRIX_RESPONSE)
+        await self.send_matrix_message(room.room_id, PING_RESPONSE)
         return True

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -759,16 +759,11 @@ class Plugin(BasePlugin):
         Returns:
             tuple[str | None, str | None]: `(command, args)` where `command` is the matched command in lowercase and `args` is the trimmed argument string. Returns `(None, None)` if `message` is not a string or does not contain a supported command.
         """
-        if not isinstance(message, str):
+        parsed = self.parse_mesh_bang_command(message, self.mesh_commands)
+        if parsed is None:
             return None, None
-        cmd_pattern = "|".join(re.escape(cmd) for cmd in self.mesh_commands)
-        pattern = rf"^\s*!(?P<cmd>{cmd_pattern})(?:\s+(?P<args>.*))?$"
-        match = re.match(pattern, message, flags=re.IGNORECASE)
-        if not match:
-            return None, None
-        cmd = match.group("cmd").lower()
-        args = match.group("args") or ""
-        return cmd, args.strip()
+        cmd, args = parsed
+        return cmd.lower(), args
 
     def _parse_location_override(self, arg_text: str) -> tuple[float, float] | None:
         """

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1587,6 +1587,14 @@ class TestBasePlugin(unittest.TestCase):
             plugin.parse_mesh_bang_command("please use !weather 90210", ("weather",))
         )
 
+    def test_parse_mesh_bang_command_allow_anywhere(self):
+        """parse_mesh_bang_command should support embedded matching when requested."""
+        plugin = MockPlugin()
+        result = plugin.parse_mesh_bang_command(
+            "please use !weather 90210", ("weather",), allow_anywhere=True
+        )
+        self.assertEqual(result, ("weather", "90210"))
+
     def test_parse_mesh_bang_command_non_string_or_empty_commands(self):
         """parse_mesh_bang_command should return None for invalid inputs."""
         plugin = MockPlugin()

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1564,6 +1564,35 @@ class TestBasePlugin(unittest.TestCase):
             result = plugin.extract_command_args("test_plugin", "!other_cmd")
             self.assertIsNone(result)
 
+    def test_parse_mesh_bang_command_with_args(self):
+        """parse_mesh_bang_command should parse command and trailing args."""
+        plugin = MockPlugin()
+        result = plugin.parse_mesh_bang_command(
+            "   !weather  90210  ", ("weather", "hourly")
+        )
+        self.assertEqual(result, ("weather", "90210"))
+
+    def test_parse_mesh_bang_command_case_insensitive_and_canonical(self):
+        """parse_mesh_bang_command should return canonical command spelling."""
+        plugin = MockPlugin()
+        result = plugin.parse_mesh_bang_command(
+            "!BATTERYLEVEL node123", ("batteryLevel", "voltage")
+        )
+        self.assertEqual(result, ("batteryLevel", "node123"))
+
+    def test_parse_mesh_bang_command_no_match(self):
+        """parse_mesh_bang_command should return None when no command matches."""
+        plugin = MockPlugin()
+        self.assertIsNone(
+            plugin.parse_mesh_bang_command("please use !weather 90210", ("weather",))
+        )
+
+    def test_parse_mesh_bang_command_non_string_or_empty_commands(self):
+        """parse_mesh_bang_command should return None for invalid inputs."""
+        plugin = MockPlugin()
+        self.assertIsNone(plugin.parse_mesh_bang_command(12345, ("weather",)))
+        self.assertIsNone(plugin.parse_mesh_bang_command("!weather", ()))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_drop_plugin.py
+++ b/tests/test_drop_plugin.py
@@ -172,7 +172,7 @@ class TestDropPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "longname", "meshnet_name"
             )

--- a/tests/test_drop_plugin.py
+++ b/tests/test_drop_plugin.py
@@ -158,6 +158,37 @@ class TestDropPlugin(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.plugins.drop_plugin.connect_meshtastic")
+    def test_handle_meshtastic_message_drop_embedded_command_valid(self, mock_connect):
+        """
+        Test that an embedded "!drop" command remains supported for backward compatibility.
+        """
+        mock_connect.return_value = self.mock_meshtastic_client
+
+        packet = {
+            "fromId": "!12345678",
+            "decoded": {
+                "portnum": TEXT_MESSAGE_APP,
+                "text": "please process !drop Embedded message",
+            },
+        }
+
+        async def run_test():
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "longname", "meshnet_name"
+            )
+
+            self.assertTrue(result)
+            self.plugin.store_node_data.assert_called_once()
+            call_args = self.plugin.store_node_data.call_args
+            self.assertEqual(call_args[0][0], "!NODE_MSGS!")
+            stored_data = call_args[0][1]
+            self.assertEqual(stored_data["text"], "Embedded message")
+            self.assertEqual(stored_data["originator"], "!12345678")
+            self.assertEqual(stored_data["location"], (TEST_LAT_NYC, TEST_LON_NYC))
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.plugins.drop_plugin.connect_meshtastic")
     def test_handle_meshtastic_message_drop_no_position(self, mock_connect):
         """
         Test that dropping a message from a node without position data logs a debug message and does not store the message, but returns True.

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -584,7 +584,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_mimic_excessive_punctuation_fallback(self, mock_sleep, mock_connect):
+    def test_mimic_balanced_wrapper_punctuation_preserved(
+        self, mock_sleep, mock_connect
+    ):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -602,7 +604,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
+            mock_client.sendText.assert_called_once_with(
+                text="!!!pong!!!", channelIndex=0
+            )
 
         asyncio.run(run_test())
 
@@ -662,7 +666,6 @@ class TestPingPluginMimicMode(unittest.TestCase):
             for message in (
                 "please ping",
                 "can you ping?",
-                "ping now",
                 "before ping after",
             ):
                 with self.subTest(message=message):
@@ -678,6 +681,86 @@ class TestPingPluginMimicMode(unittest.TestCase):
                     self.assertFalse(result)
                     mock_client.sendText.assert_not_called()
                     mock_client.sendText.reset_mock()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_first_word_ping_with_trailing_text_matches(
+        self, mock_sleep, mock_connect
+    ):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "ping now"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_first_word_wrapped_ping_with_trailing_text_preserved(
+        self, mock_sleep, mock_connect
+    ):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!!!!!PInG?!!!! status"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(
+                text="!!!!!POnG?!!!!", channelIndex=0
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_first_word_one_side_exceeds_max_uses_fallback(
+        self, mock_sleep, mock_connect
+    ):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!!!!!!PING? status"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
 
         asyncio.run(run_test())
 

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -512,6 +512,37 @@ class TestPingPluginMimicMode(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
+    def test_mimic_mode_explicit_ping_uses_mimic_response(
+        self, mock_sleep, mock_connect
+    ):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        async def run_test() -> None:
+            for message, expected_response in (("!ping", "!pong"), ("!PING", "!PONG")):
+                with self.subTest(message=message, expected_response=expected_response):
+                    packet = {
+                        "decoded": {"text": message},
+                        "channel": 0,
+                        "fromId": "!12345678",
+                        "to": BROADCAST_NUM,
+                    }
+                    result = await self.plugin.handle_meshtastic_message(
+                        packet, "formatted_message", "TestNode", "TestMesh"
+                    )
+                    self.assertTrue(result)
+                    mock_sleep.assert_called_once_with(1.0)
+                    mock_client.sendText.assert_called_once_with(
+                        text=expected_response, channelIndex=0
+                    )
+                    mock_sleep.reset_mock()
+                    mock_client.sendText.reset_mock()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
     def test_mimic_case_matching_upper(self, mock_sleep, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -666,6 +666,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             for message in (
                 "please ping",
                 "can you ping?",
+                "ping me",
                 "before ping after",
             ):
                 with self.subTest(message=message):
@@ -708,7 +709,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_mimic_first_word_ping_with_trailing_text_matches(
+    def test_mimic_first_word_ping_with_trailing_text_ignored(
         self, mock_sleep, mock_connect
     ):
         mock_client = MagicMock()
@@ -726,15 +727,15 @@ class TestPingPluginMimicMode(unittest.TestCase):
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-            self.assertTrue(result)
-            mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            self.assertFalse(result)
+            mock_sleep.assert_not_called()
+            mock_client.sendText.assert_not_called()
 
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_mimic_first_word_wrapped_ping_with_trailing_text_preserved(
+    def test_mimic_first_word_wrapped_ping_with_trailing_text_ignored(
         self, mock_sleep, mock_connect
     ):
         mock_client = MagicMock()
@@ -752,25 +753,21 @@ class TestPingPluginMimicMode(unittest.TestCase):
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
-            self.assertTrue(result)
-            mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text="!!!!!POnG?!!!!", channelIndex=0
-            )
+            self.assertFalse(result)
+            mock_sleep.assert_not_called()
+            mock_client.sendText.assert_not_called()
 
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_mimic_first_word_one_side_exceeds_max_uses_fallback(
-        self, mock_sleep, mock_connect
-    ):
+    def test_mimic_one_side_exceeds_max_uses_fallback(self, mock_sleep, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
 
         packet = {
-            "decoded": {"text": "!!!!!!PING? status"},
+            "decoded": {"text": "!!!!!!PING?"},
             "channel": 0,
             "fromId": "!12345678",
             "to": BROADCAST_NUM,

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -612,6 +612,58 @@ class TestPingPluginMimicMode(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
+    def test_mimic_one_side_at_limit_preserved(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!!!!!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(
+                text="!!!!!pong", channelIndex=0
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_both_sides_at_limit_preserved(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "!!!!!Ping?????"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(
+                text="!!!!!Pong?????", channelIndex=0
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
     def test_mimic_case_and_punctuation_mixed(self, mock_sleep, mock_connect):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
@@ -768,6 +820,30 @@ class TestPingPluginMimicMode(unittest.TestCase):
 
         packet = {
             "decoded": {"text": "!!!!!!PING?"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            mock_sleep.assert_called_once_with(1.0)
+            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_mimic_post_side_exceeds_max_uses_fallback(self, mock_sleep, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "??pIng!!!!!!"},
             "channel": 0,
             "fromId": "!12345678",
             "to": BROADCAST_NUM,

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -23,6 +23,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from meshtastic.mesh_interface import BROADCAST_NUM
 
 from mmrelay.constants.formats import DEFAULT_CHANNEL, TEXT_MESSAGE_APP
+from mmrelay.constants.messages import PING_RESPONSE
 from mmrelay.plugins.ping_plugin import Plugin, match_case
 
 
@@ -146,7 +147,9 @@ class TestPingPlugin(unittest.TestCase):
                 0, is_direct_message=False
             )
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            mock_client.sendText.assert_called_once_with(
+                text=PING_RESPONSE, channelIndex=0
+            )
             self.plugin.logger.info.assert_called_once()
 
         asyncio.run(run_test())
@@ -175,14 +178,16 @@ class TestPingPlugin(unittest.TestCase):
             )
             mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(
-                text="pong", destinationId="!12345678"
+                text=PING_RESPONSE, destinationId="!12345678"
             )
 
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_explicit_ping_case_matching(self, mock_sleep, mock_connect):
+    def test_explicit_ping_case_insensitive_normalized_response(
+        self, mock_sleep, mock_connect
+    ):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -200,7 +205,9 @@ class TestPingPlugin(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
+            mock_client.sendText.assert_called_once_with(
+                text=PING_RESPONSE, channelIndex=0
+            )
 
         asyncio.run(run_test())
 
@@ -360,7 +367,9 @@ class TestPingPlugin(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            mock_client.sendText.assert_called_once_with(
+                text=PING_RESPONSE, channelIndex=0
+            )
 
         asyncio.run(run_test())
 
@@ -732,7 +741,7 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
             self.assertTrue(result)
             self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_called_once_with(
-                "!test:matrix.org", "pong!"
+                "!test:matrix.org", PING_RESPONSE
             )
 
         asyncio.run(run_test())
@@ -792,7 +801,9 @@ class TestPingPluginEdgeCases(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            mock_client.sendText.assert_called_once_with(
+                text=PING_RESPONSE, channelIndex=0
+            )
 
         asyncio.run(run_test())
 
@@ -869,7 +880,7 @@ class TestPingPluginEdgeCases(unittest.TestCase):
             )
             mock_sleep.assert_called_once_with(1.0)
             mock_client.sendText.assert_called_once_with(
-                text="pong",
+                text=PING_RESPONSE,
                 channelIndex=DEFAULT_CHANNEL,
             )
 

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -685,6 +685,28 @@ class TestPingPluginMimicMode(unittest.TestCase):
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_mimic_whitespace_only_ignored(self, mock_connect):
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+
+        packet = {
+            "decoded": {"text": "     "},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertFalse(result)
+            mock_client.sendText.assert_not_called()
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
     def test_mimic_first_word_ping_with_trailing_text_matches(
         self, mock_sleep, mock_connect


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR centralizes parsing of mesh "!command" messages by adding BasePlugin.parse_mesh_bang_command(...), simplifies and corrects ping handling (especially mimic-mode matching/response construction), updates plugins to use the centralized parser, and expands tests. Most changes are refactors to remove inline/legacy regex and consolidate logic; there is a small behavior fix in ping handling related to matching and punctuation preservation.

## Key Changes

Features

- Added BasePlugin.parse_mesh_bang_command(text, commands, allow_anywhere=False)
  - Accepts string input and an iterable of commands.
  - Normalizes commands case-insensitively, returns the canonical command spelling and trimmed args.
  - allow_anywhere=True enables detection of embedded `!command` tokens (not only at start).

Fixes

- Ping mimic-mode matching revised:
  - Uses full-message regex matching for mimic mode (replacing prior first-word-only matching). Trailing prose (for example, `ping now`) does not match and is ignored.
  - Preserves punctuation and case from matched mimic-mode input when within configured limits; falls back to a unified literal fallback when either punctuation side exceeds the configured max.
  - In mimic mode, explicit forms like `!ping`/`!PING` also use mimic semantics (`!pong`/`!PONG`) for consistent transport-independent behavior within that mode.
- Consolidated ping reply constant: renamed PING_MATRIX_RESPONSE → PING_RESPONSE (value unchanged) and non-mimic replies use this constant.

Refactors

- Weather plugin now delegates mesh command parsing to BasePlugin.parse_mesh_bang_command instead of building local regex alternations.
- Drop plugin replaced legacy DROP_COMMAND_REGEX logic with parse_mesh_bang_command(..., allow_anywhere=True); simplified control flow and rejects empty/falsy drop payloads.
- Removed legacy regex parsing across updated plugins and centralized command parsing logic.
- Simplified ping response construction: clearer, separated paths for mimic vs non-mimic responses, shared PING_RESPONSE usage, and unified reply path for Matrix/mesh replies.
- Tests extended/updated:
  - New unit tests for parse_mesh_bang_command covering whitespace tolerance, case-insensitivity, embedded matches, and invalid inputs.
  - Updated/expanded ping tests for mimic-mode edge cases (punctuation wrappers, mixed case, limits, ignored prose), and updated expectations to use PING_RESPONSE.
  - Added drop plugin test for embedded `!drop` handling and assertions on stored payload.

Breaking changes / migration

- None expected. The renamed ping constant preserves its string value; plugins/tests were updated accordingly and no migration steps are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->