### PR TITLE
Fix docs inconsistencies; update ready-file location and image version to 1.3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *$py.class
 src/mmrelay.egg-info
 .opencode/
+.codex
 /build/
 /.ci-artifacts/
 coderabbit_actionable_items.md

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -50,6 +50,9 @@ lint:
       paths:
         - src/mmrelay/tools/sample_config.yaml
         - src/mmrelay/plugins/map_plugin.py
+    - linters: [dotenv-linter]
+      paths:
+        - src/mmrelay/tools/sample.env
     - linters: [prettier, yamllint]
       paths:
         - src/mmrelay/tools/k8s/*.yaml

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -33,8 +33,8 @@ lint:
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
-    - prettier@3.8.1
-    - ruff@0.15.9
+    - prettier@3.8.2
+    - ruff@0.15.10
     - trufflehog@3.94.3
     - yamllint@1.38.0
   definitions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ENV PYTHONUNBUFFERED=1
 ENV MPLCONFIGDIR=/tmp/matplotlib
 ENV PATH=/usr/local/bin:/usr/bin:/bin
 ENV MMRELAY_HOME=/data
-ENV MMRELAY_READY_FILE=/run/mmrelay/ready
+ENV MMRELAY_READY_FILE=/tmp/mmrelay-ready
 
 # Switch to non-root user
 USER mmrelay
@@ -74,7 +74,7 @@ USER mmrelay
 # Health check - verifies ready-file freshness.
 # The ready file is created when the app is running and healthy.
 # Users who don't want ready-file health checks should omit HEALTHCHECK entirely.
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD find "$MMRELAY_READY_FILE" -mmin -2 | grep -q .
 
 # Default command

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY pyproject.toml MANIFEST.in setup.py README.md LICENSE ./
 COPY src/ ./src/
 
 # Install dependencies and application package with E2EE support
+# hadolint ignore=DL3013
 RUN python -m pip install --no-cache-dir --timeout=300 --retries=3 ".[e2e]"
 
 # Runtime stage

--- a/deploy/helm/mmrelay/Chart.yaml
+++ b/deploy/helm/mmrelay/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mmrelay
 description: A Helm chart for MMRelay - Meshtastic to Matrix relay
 type: application
-version: 1.3.0
-appVersion: 1.3.0
+version: 1.3.3
+appVersion: 1.3.3
 keywords:
   - meshtastic
   - matrix

--- a/deploy/helm/mmrelay/templates/deployment.yaml
+++ b/deploy/helm/mmrelay/templates/deployment.yaml
@@ -188,8 +188,6 @@ spec:
               mountPath: {{ .Values.mmrelayHome | quote }}
             - name: tmp
               mountPath: /tmp
-            - name: run
-              mountPath: /run/mmrelay
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -216,8 +214,6 @@ spec:
           emptyDir: {}
           {{- end }}
         - name: tmp
-          emptyDir: {}
-        - name: run
           emptyDir: {}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/mmrelay/templates/deployment.yaml
+++ b/deploy/helm/mmrelay/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         checkov.io/skip1: "CKV_K8S_43=Chart allows tag/digest pinning via values.yaml"
         checkov.io/skip2: "CKV_K8S_35=Matrix auth uses env vars to bootstrap credentials.json on the PVC."
-        checkov.io/skip3: "CKV_K8S_15=Default uses image.tag=1.3.3; pin via image.digest for production."
+        checkov.io/skip3: "CKV_K8S_15=Default uses image.tag={{ .Values.image.tag }}; pin via image.digest for production."
         checkov.io/skip4: "CKV2_K8S_6=NetworkPolicy is provided in networkpolicy.yaml; enable via networkPolicy.enabled in values.yaml."
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/mmrelay/templates/deployment.yaml
+++ b/deploy/helm/mmrelay/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         checkov.io/skip1: "CKV_K8S_43=Chart allows tag/digest pinning via values.yaml"
         checkov.io/skip2: "CKV_K8S_35=Matrix auth uses env vars to bootstrap credentials.json on the PVC."
-        checkov.io/skip3: "CKV_K8S_15=Default uses image.tag=1.3.0; pin via image.digest for production."
+        checkov.io/skip3: "CKV_K8S_15=Default uses image.tag=1.3.3; pin via image.digest for production."
         checkov.io/skip4: "CKV2_K8S_6=NetworkPolicy is provided in networkpolicy.yaml; enable via networkPolicy.enabled in values.yaml."
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/mmrelay/values.yaml
+++ b/deploy/helm/mmrelay/values.yaml
@@ -15,7 +15,7 @@ mmrelayHome: /data
 configPath: /data/config.yaml
 # Liveness probe expects this ready file to be updated at least every 2 minutes
 # (see livenessProbe find -mmin -2). Adjust the probe or update cadence if needed.
-readyFile: /run/mmrelay/ready
+readyFile: /tmp/mmrelay-ready
 
 # Config injection
 # The init container copies config.yaml from this Secret/ConfigMap to the PVC.

--- a/deploy/helm/mmrelay/values.yaml
+++ b/deploy/helm/mmrelay/values.yaml
@@ -3,7 +3,7 @@
 # Image configuration
 image:
   repository: ghcr.io/jeremiah-k/mmrelay
-  tag: 1.3.0
+  tag: 1.3.3
   pullPolicy: IfNotPresent
   # If set, overrides tag (format: sha256:abc123...)
   digest: ""

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -136,7 +136,7 @@ spec:
               command:
                 - sh
                 - -c
-                - test -f /tmp/mmrelay-ready
+                - test -f "$MMRELAY_READY_FILE"
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 2
@@ -146,7 +146,7 @@ spec:
               command:
                 - sh
                 - -c
-                - test -f /tmp/mmrelay-ready
+                - test -f "$MMRELAY_READY_FILE"
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 60

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -165,8 +165,6 @@ spec:
               mountPath: /data
             - name: tmp
               mountPath: /tmp
-            - name: run
-              mountPath: /run/mmrelay
       volumes:
         # Config source (Secret containing config.yaml) - used by init container only
         - name: config-source
@@ -180,6 +178,4 @@ spec:
           persistentVolumeClaim:
             claimName: mmrelay-data
         - name: tmp
-          emptyDir: {}
-        - name: run
           emptyDir: {}

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -91,7 +91,7 @@ spec:
             - name: MPLCONFIGDIR
               value: /tmp/matplotlib
             - name: MMRELAY_READY_FILE
-              value: /run/mmrelay/ready
+              value: /tmp/mmrelay-ready
             - name: MMRELAY_HOME
               value: /data
           envFrom:
@@ -136,7 +136,7 @@ spec:
               command:
                 - sh
                 - -c
-                - test -f /run/mmrelay/ready
+                - test -f /tmp/mmrelay-ready
             initialDelaySeconds: 0
             periodSeconds: 10
             timeoutSeconds: 2
@@ -146,7 +146,7 @@ spec:
               command:
                 - sh
                 - -c
-                - test -f /run/mmrelay/ready
+                - test -f /tmp/mmrelay-ready
             periodSeconds: 5
             timeoutSeconds: 2
             failureThreshold: 60

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   - name: ghcr.io/jeremiah-k/mmrelay
     # Pin to a stable release by default for predictable deployments.
     # Use overlays/digest for immutable production pinning.
-    newTag: 1.3.0
+    newTag: 1.3.3

--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -328,7 +328,6 @@ Use environment variables **only** when:
 | `MMRELAY_DATABASE_PATH`                      | `database.path`                      | string  | SQLite database path                                                                                                 |
 | `MMRELAY_HOME`                               | _(path override)_                    | string  | Override application home directory (default: `~/.mmrelay`)                                                          |
 | `MMRELAY_LOG_PATH`                           | _(path override)_                    | string  | Override log file path (default: `<home>/logs/mmrelay.log`)                                                          |
-| `MMRELAY_CREDENTIALS_PATH`                   | `credentials_path`                   | string  | Override credentials.json file path (default: `<home>/matrix/credentials.json`)                                      |
 
 ## Tips for Advanced Configuration
 

--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -268,7 +268,7 @@ The `MMRELAY_MATRIX_*` variables (HOMESERVER, BOT_USER_ID, PASSWORD, ACCESS_TOKE
 
 #### System Configuration
 
-- **`MMRELAY_LOGGING_LEVEL`**: Log level (`debug`, `info`, `warning`, `error`)
+- **`MMRELAY_LOGGING_LEVEL`**: Log level (`debug`, `info`, `warning`, `error`, `critical`)
 - **`MMRELAY_LOG_FILE`**: Path to log file (enables file logging when set; for Docker use a path under `/data/logs/...` to persist)
 - **`MMRELAY_DATABASE_PATH`**: Path to SQLite database file
 
@@ -323,7 +323,7 @@ Use environment variables **only** when:
 | `MMRELAY_MESHTASTIC_MESHNET_NAME`            | `meshtastic.meshnet_name`            | string  | Display name for mesh                                                                                                |
 | `MMRELAY_MESHTASTIC_MESSAGE_DELAY`           | `meshtastic.message_delay`           | float   | Delay between messages in seconds (minimum: 2.0)                                                                     |
 | `MMRELAY_MESHTASTIC_NODEDB_REFRESH_INTERVAL` | `meshtastic.nodedb_refresh_interval` | float   | Refresh interval for cached long/short node-name tables from NodeDB (default: `15.0`; `0` disables periodic refresh) |
-| `MMRELAY_LOGGING_LEVEL`                      | `logging.level`                      | string  | Log level (`debug`, `info`, `warning`, `error`)                                                                      |
+| `MMRELAY_LOGGING_LEVEL`                      | `logging.level`                      | string  | Log level (`debug`, `info`, `warning`, `error`, `critical`)                                                          |
 | `MMRELAY_LOG_FILE`                           | `logging.filename`                   | string  | Log file path (enables file logging when set)                                                                        |
 | `MMRELAY_DATABASE_PATH`                      | `database.path`                      | string  | SQLite database path                                                                                                 |
 | `MMRELAY_HOME`                               | _(path override)_                    | string  | Override application home directory (default: `~/.mmrelay`)                                                          |

--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -268,7 +268,7 @@ The `MMRELAY_MATRIX_*` variables (HOMESERVER, BOT_USER_ID, PASSWORD, ACCESS_TOKE
 
 #### System Configuration
 
-- **`MMRELAY_LOGGING_LEVEL`**: Log level (`debug`, `info`, `warning`, `error`, `critical`)
+- **`MMRELAY_LOGGING_LEVEL`**: Log level (`debug`, `info`, `warning`, `error`)
 - **`MMRELAY_LOG_FILE`**: Path to log file (enables file logging when set; for Docker use a path under `/data/logs/...` to persist)
 - **`MMRELAY_DATABASE_PATH`**: Path to SQLite database file
 
@@ -310,6 +310,10 @@ Use environment variables **only** when:
 
 | Environment Variable                         | Config.yaml Path                     | Type    | Description                                                                                                          |
 | -------------------------------------------- | ------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `MMRELAY_MATRIX_HOMESERVER`                  | `matrix.homeserver`                  | string  | Matrix homeserver URL                                                                                                |
+| `MMRELAY_MATRIX_BOT_USER_ID`                 | `matrix.bot_user_id`                 | string  | Matrix bot user ID                                                                                                   |
+| `MMRELAY_MATRIX_PASSWORD`                    | `matrix.password`                    | string  | Matrix password (prefer `mmrelay auth login`)                                                                        |
+| `MMRELAY_MATRIX_ACCESS_TOKEN`                | `matrix.access_token`                | string  | Matrix access token (prefer `mmrelay auth login`)                                                                    |
 | `MMRELAY_MESHTASTIC_CONNECTION_TYPE`         | `meshtastic.connection_type`         | string  | Connection method (`tcp`, `serial`, `ble`)                                                                           |
 | `MMRELAY_MESHTASTIC_HOST`                    | `meshtastic.host`                    | string  | TCP host address                                                                                                     |
 | `MMRELAY_MESHTASTIC_PORT`                    | `meshtastic.port`                    | integer | TCP port (default: 4403)                                                                                             |
@@ -319,9 +323,12 @@ Use environment variables **only** when:
 | `MMRELAY_MESHTASTIC_MESHNET_NAME`            | `meshtastic.meshnet_name`            | string  | Display name for mesh                                                                                                |
 | `MMRELAY_MESHTASTIC_MESSAGE_DELAY`           | `meshtastic.message_delay`           | float   | Delay between messages in seconds (minimum: 2.0)                                                                     |
 | `MMRELAY_MESHTASTIC_NODEDB_REFRESH_INTERVAL` | `meshtastic.nodedb_refresh_interval` | float   | Refresh interval for cached long/short node-name tables from NodeDB (default: `15.0`; `0` disables periodic refresh) |
-| `MMRELAY_LOGGING_LEVEL`                      | `logging.level`                      | string  | Log level (`debug`, `info`, `warning`, `error`, `critical`)                                                          |
-| `MMRELAY_LOG_FILE`                           | `logging.filename`                   | string  | Log file path                                                                                                        |
+| `MMRELAY_LOGGING_LEVEL`                      | `logging.level`                      | string  | Log level (`debug`, `info`, `warning`, `error`)                                                                      |
+| `MMRELAY_LOG_FILE`                           | `logging.filename`                   | string  | Log file path (enables file logging when set)                                                                        |
 | `MMRELAY_DATABASE_PATH`                      | `database.path`                      | string  | SQLite database path                                                                                                 |
+| `MMRELAY_HOME`                               | _(path override)_                    | string  | Override application home directory (default: `~/.mmrelay`)                                                          |
+| `MMRELAY_LOG_PATH`                           | _(path override)_                    | string  | Override log file path (default: `<home>/logs/mmrelay.log`)                                                          |
+| `MMRELAY_CREDENTIALS_PATH`                   | `credentials_path`                   | string  | Override credentials.json file path (default: `<home>/matrix/credentials.json`)                                      |
 
 ## Tips for Advanced Configuration
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -509,7 +509,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "find $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} -mmin -2 | grep -q .",
+          "test -f $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} && find $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} -mmin -2 | grep -q .",
         ]
       interval: 30s
       timeout: 5s

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -234,6 +234,12 @@ MMRelay checks for authentication in this order:
 - `make build-nocache` - Build Docker image from source with --no-cache for fresh builds
 - `make rebuild` - Stop, rebuild with --no-cache, and restart container (for updates)
 
+### Update and Diagnostic Commands
+
+- `make update-compose` - Update docker-compose.yaml with latest sample
+- `make doctor` - Run diagnostics inside the container
+- `make paths` - Show runtime paths inside the container
+
 ### Manual Docker Commands
 
 If not using make commands:
@@ -417,7 +423,7 @@ For upgrade/migration procedures and deprecation timeline details, see the [Migr
 
 - Check logs: `docker compose logs mmrelay`
 - Verify config syntax (host):
-  `mmrelay config check --config ~/.mmrelay/config.yaml`
+  `mmrelay --config ~/.mmrelay/config.yaml config check`
 - Verify config syntax (container):
   `docker compose exec mmrelay mmrelay config check`
 - Ensure all required config fields are set
@@ -493,18 +499,22 @@ services:
       - MMRELAY_READY_FILE=/tmp/mmrelay-ready
     volumes:
       # Use MMRELAY_HOST_HOME for host paths (not MMRELAY_HOME to avoid conflict)
-      # For SELinux systems (RHEL/CentOS/Fedora), add :Z flag to prevent permission denied errors
-      - ${MMRELAY_HOST_HOME:-$HOME}/.mmrelay:/data:Z
-      # For non-SELinux systems, you can use:
-      # - ${MMRELAY_HOST_HOME:-$HOME}/.mmrelay:/data
+      # For non-SELinux systems (most common):
+      - ${MMRELAY_HOST_HOME:-$HOME}/.mmrelay:/data
+      # For SELinux systems (RHEL/CentOS/Fedora), add :Z flag to prevent permission denied errors:
+      # - ${MMRELAY_HOST_HOME:-$HOME}/.mmrelay:/data:Z
 
-    # Lightweight readiness check
+    # Readiness check (checks readiness file freshness periodically updated by app)
     healthcheck:
-      test: ["CMD-SHELL", "test -f $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready}"]
+      test:
+        [
+          "CMD-SHELL",
+          "find $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} -mmin -2 | grep -q .",
+        ]
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      start_period: 60s
 ```
 
 ### Step 4: Start the container

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -57,7 +57,7 @@ helm install mmrelay ./deploy/helm/mmrelay \
 # Optional but recommended: pin image tag explicitly for repeatable runs
 helm upgrade --install mmrelay ./deploy/helm/mmrelay \
   --namespace mmrelay \
-  --set image.tag=1.3.0
+  --set image.tag=1.3.3
 ```
 
 ### 6. Verify Deployment
@@ -76,7 +76,7 @@ The Helm chart is highly configurable. Key options include:
 ```yaml
 image:
   repository: ghcr.io/jeremiah-k/mmrelay
-  tag: 1.3.0
+  tag: 1.3.3
   pullPolicy: IfNotPresent
   # Pin by digest for production (immutable)
   digest: ""
@@ -88,7 +88,7 @@ image:
 
 ```bash
 helm upgrade mmrelay ./deploy/helm/mmrelay \
-  --set image.tag=1.3.0 \
+  --set image.tag=1.3.3 \
   --namespace mmrelay
 ```
 
@@ -486,7 +486,7 @@ If upgrading from 1.2.x or earlier, follow `docs/MIGRATION_1.3.md` first.
 ```bash
 helm upgrade mmrelay ./deploy/helm/mmrelay \
   --namespace mmrelay \
-  --set image.tag=1.3.0
+  --set image.tag=1.3.3
 ```
 
 ### Rolling Restart

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -315,7 +315,7 @@ probes:
     failureThreshold: 3
 ```
 
-- **Readiness**: Checks for ready file at `/run/mmrelay/ready` (cheap, fast)
+- **Readiness**: Checks for ready file at `/tmp/mmrelay-ready` (cheap, fast)
 - **Startup**: Allows up to 5 minutes for initialization (60 failures × 5s = 300s)
 - **Liveness**: Checks the ready file for recent updates
 
@@ -447,9 +447,8 @@ The chart uses fixed runtime paths (consistent with container design):
 
 - **MMRELAY_HOME**: `/data` (PVC mount)
 - **Config Path**: `/data/config.yaml` (from Secret/ConfigMap)
-- **Ready File**: `/run/mmrelay/ready` (for probes)
+- **Ready File**: `/tmp/mmrelay-ready` (for probes, under /tmp emptyDir)
 - **Tmp**: `/tmp` (emptyDir)
-- **Run**: `/run/mmrelay` (emptyDir)
 
 All persistent data lives under `/data`:
 
@@ -596,7 +595,7 @@ Check:
 ### Ready File Missing
 
 ```bash
-kubectl exec -n mmrelay <pod-name> -- ls -l /run/mmrelay
+kubectl exec -n mmrelay <pod-name> -- ls -l /tmp/mmrelay-ready
 kubectl logs -n mmrelay <pod-name> --tail=50
 ```
 

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -234,6 +234,34 @@ extraVolumeMounts:
 
 This direct Secret mount is only safe if you treat `credentials.json` as immutable. MMRelay may update credentials after discovery, so if you need those updates persisted, copy the file into the PVC instead of mounting the Secret path directly.
 
+One practical pattern is to mount the Secret at a temporary path, copy it into
+`/data/matrix/credentials.json` once, then remove the temporary mount on the
+next Helm upgrade:
+
+```yaml
+extraVolumes:
+  - name: credentials-bootstrap
+    secret:
+      secretName: mmrelay-credentials
+      items:
+        - key: credentials.json
+          path: credentials.json
+
+extraVolumeMounts:
+  - name: credentials-bootstrap
+    mountPath: /tmp/bootstrap-credentials/credentials.json
+    subPath: credentials.json
+    readOnly: true
+```
+
+```bash
+kubectl exec -n mmrelay deploy/mmrelay -- sh -c \
+  'cp /tmp/bootstrap-credentials/credentials.json /data/matrix/credentials.json && chmod 600 /data/matrix/credentials.json'
+```
+
+After the file is on the PVC, remove the temporary Secret mount from your Helm
+values so future credential updates persist normally.
+
 If you previously used bootstrap auth, delete the old `mmrelay-matrix-auth` Secret after switching to pre-existing credentials to avoid confusion or conflicts:
 
 ```bash

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -173,38 +173,9 @@ config:
 
 ### Credentials Injection
 
-MMRelay can use a pre-created `credentials.json` from a Secret (recommended for credential rotation):
+MMRelay authenticates with Matrix using environment variables that bootstrap `credentials.json` on the PVC. This is handled by the `matrixAuth` values section.
 
-```yaml
-credentials:
-  enabled: true
-  secretName: mmrelay-credentials
-  key: credentials.json
-  create: false
-  data: ""
-```
-
-Create the credentials Secret:
-
-```bash
-kubectl create secret generic mmrelay-credentials \
-  --from-file=credentials.json=./credentials.json \
-  --namespace mmrelay
-```
-
-#### Optional: Helm-created credentials (explicit opt-in)
-
-```yaml
-credentials:
-  enabled: true
-  secretName: mmrelay-credentials
-  key: credentials.json
-  create: true
-  data: |
-    { "homeserver": "https://matrix.org", "user_id": "@bot:matrix.org", "access_token": "..." }
-```
-
-#### Bootstrap Mode (Alternative)
+#### Bootstrap Mode (Default)
 
 For initial deployment without existing credentials, use Matrix auth environment variables:
 
@@ -235,6 +206,38 @@ Rate-limit safety for repeat tests:
 
 - Do not repeatedly recreate namespace/PVC + `mmrelay-matrix-auth` unless required.
 - Reuse the same PVC between test iterations when possible to avoid repeated Matrix login bootstrap.
+
+#### Pre-existing credentials.json (Manual)
+
+If you already have a `credentials.json` (e.g., from `mmrelay auth login`), you can mount it directly by creating a Secret and adding custom volume mounts via `extraVolumes` and `extraVolumeMounts`:
+
+```bash
+kubectl create secret generic mmrelay-credentials \
+  --from-file=credentials.json=./credentials.json \
+  --namespace mmrelay
+```
+
+```yaml
+extraVolumes:
+  - name: credentials
+    secret:
+      secretName: mmrelay-credentials
+      items:
+        - key: credentials.json
+          path: credentials.json
+
+extraVolumeMounts:
+  - name: credentials
+    mountPath: /data/matrix/credentials.json
+    subPath: credentials.json
+    readOnly: true
+```
+
+After mounting a pre-existing `credentials.json`, disable the bootstrap Secret to avoid conflicts:
+
+```bash
+kubectl delete secret mmrelay-matrix-auth -n mmrelay
+```
 
 ### Persistence
 
@@ -425,7 +428,7 @@ denies all ingress and allows all egress by default.
 
 ```yaml
 networkPolicy:
-  enabled: true
+  enabled: false # Set to true to enable
 ```
 
 ### No Horizontal Pod Autoscaler (HPA)
@@ -658,9 +661,9 @@ config:
   source: secret
   name: mmrelay-config-external
 
-credentials:
+matrixAuth:
   enabled: true
-  secretName: mmrelay-credentials-external
+  secretName: mmrelay-matrix-auth-external
 ```
 
 External secret manager creates Secrets with these names.

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -175,9 +175,10 @@ config:
 
 MMRelay authenticates with Matrix using environment variables that bootstrap `credentials.json` on the PVC. This is handled by the `matrixAuth` values section.
 
-#### Bootstrap Mode (Default)
+#### Bootstrap Mode (Optional)
 
-For initial deployment without existing credentials, use Matrix auth environment variables:
+For initial deployment without existing credentials, enable bootstrap by
+setting `matrixAuth.enabled: true` and use Matrix auth environment variables:
 
 ```yaml
 matrixAuth:

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -209,7 +209,7 @@ Rate-limit safety for repeat tests:
 
 #### Pre-existing credentials.json (Manual)
 
-If you already have a `credentials.json` (e.g., from `mmrelay auth login`), you can mount it directly by creating a Secret and adding custom volume mounts via `extraVolumes` and `extraVolumeMounts`:
+If you already have a `credentials.json` (e.g., from `mmrelay auth login`), disable `matrixAuth.enabled` and mount it by creating a Secret and adding custom volume mounts via `extraVolumes` and `extraVolumeMounts`:
 
 ```bash
 kubectl create secret generic mmrelay-credentials \
@@ -230,10 +230,11 @@ extraVolumeMounts:
   - name: credentials
     mountPath: /data/matrix/credentials.json
     subPath: credentials.json
-    readOnly: true
 ```
 
-After mounting a pre-existing `credentials.json`, disable the bootstrap Secret to avoid conflicts:
+This direct Secret mount is only safe if you treat `credentials.json` as immutable. MMRelay may update credentials after discovery, so if you need those updates persisted, copy the file into the PVC instead of mounting the Secret path directly.
+
+If you previously used bootstrap auth, delete the old `mmrelay-matrix-auth` Secret after switching to pre-existing credentials to avoid confusion or conflicts:
 
 ```bash
 kubectl delete secret mmrelay-matrix-auth -n mmrelay

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -78,14 +78,8 @@ This interactive command will:
 - Create secure credentials and save to `~/.mmrelay/matrix/credentials.json`
 - Set up encryption keys for secure communication (Linux/macOS)
 - Works for regular Matrix communication on all platforms
-- **Use modern OIDC authentication** compatible with Matrix 2.0 and MAS (Matrix Authentication Service)
-
-**Why use `mmrelay auth login`?**
-
-- **Future-proof**: Compatible with Matrix Authentication Service (MAS) used by matrix.org and other modern homeservers.
-- **Token rotation**: Automatically handles token refresh, preventing authentication expiration.
 - **Required for E2EE**: Essential for encrypted room support.
-- **Secure**: Uses proper OIDC flows instead of long-lived access tokens.
+- **Secure**: Stores credentials in a dedicated credentials file instead of embedding tokens in config.yaml.
 
 **Platform Notes**:
 
@@ -111,7 +105,7 @@ Start the relay with a single command:
 mmrelay
 ```
 
-By default, MMRelay uses `~/.mmrelay` as the home directory for all runtime data on Linux/macOS. On Windows, it uses the platform-specific application data directory (e.g., `%APPDATA%/mmrelay`).
+By default, MMRelay uses `~/.mmrelay` as the home directory for all runtime data on Linux/macOS. On Windows, it uses the platform-specific application data directory (e.g., `%LOCALAPPDATA%/mmrelay`).
 
 ### Command-Line Options
 
@@ -126,6 +120,7 @@ mmrelay --config /path/to/config.yaml --home /path/to/mmrelay-home
 - `--config PATH` - Specify a custom configuration file location
 - `--home PATH` - Set the home directory for all runtime data (credentials, logs, database, plugins)
 - `--log-level {error,warning,info,debug}` - Set the logging verbosity
+- `--logfile PATH` - Specify a custom log file location
 - `--version` - Show version information and exit
 - `--help` - Display help message
 
@@ -155,6 +150,18 @@ mmrelay service install
 
 # Set up Matrix E2EE authentication (for encrypted rooms)
 mmrelay auth login
+
+# Check Matrix authentication status
+mmrelay auth status
+
+# Log out and clear Matrix session data
+mmrelay auth logout
+
+# Show path configuration and diagnostics
+mmrelay paths
+
+# Diagnose path configuration and migration status
+mmrelay doctor
 ```
 
 ## Running as a Service

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -120,7 +120,6 @@ mmrelay --config /path/to/config.yaml --home /path/to/mmrelay-home
 - `--config PATH` - Specify a custom configuration file location
 - `--home PATH` - Set the home directory for all runtime data (credentials, logs, database, plugins)
 - `--log-level {error,warning,info,debug}` - Set the logging verbosity
-- `--logfile PATH` - Specify a custom log file location
 - `--version` - Show version information and exit
 - `--help` - Display help message
 

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -184,7 +184,7 @@ For most users, keep the default Secret-based flow to avoid extra configuration 
              path: config.yaml
      ```
 
-   - The `volumeMounts` in the init container and main container do not need to change (they reference `config-source` and `data`)
+   - The init container mounts `config-source` and `data`; the main container mounts `data` and `tmp`
 
 **Important**: Only enable one pattern at a time (Secret OR ConfigMap), not both.
 
@@ -774,9 +774,19 @@ Serial requires host device access and node pinning. Start with the most restric
         - 20 # device group (often dialout)
     ```
 
-5.  If `supplementalGroups` is insufficient, try adding capabilities. Only use `runAsUser: 0` / `runAsGroup: 0` as a **last resort** — this runs the container as root and significantly increases the attack surface:
+5.  If `supplementalGroups` is insufficient, try adding capabilities before falling back to root. Keep `allowPrivilegeEscalation: false` and use the smallest capability set that works for your cluster policy:
 
-    > **Warning**: Running as root (`runAsUser: 0`) should only be used if supplemental groups and capabilities both fail. It is not recommended for production.
+    ```yaml
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+          - DAC_OVERRIDE
+    ```
+
+6.  If capabilities still do not work, try running as root with `runAsUser: 0` and `runAsGroup: 0`:
+
+    > **Warning**: Running as root should only be used after supplemental groups and capabilities both fail. It is not recommended for production.
 
     ```yaml
     securityContext:
@@ -785,7 +795,7 @@ Serial requires host device access and node pinning. Start with the most restric
       allowPrivilegeEscalation: false
     ```
 
-If you still get permission errors, try adding capabilities. Only use `privileged: true` as a last resort.
+7.  If you still get permission errors, use `privileged: true` as a last resort only.
 
 ### BLE
 

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -565,7 +565,7 @@ If you need to reset the PVC:
 
 The following paths recreate themselves automatically on startup:
 
-- `/run/mmrelay/`: Runtime directory (contains the ready file)
+- `/tmp/mmrelay-ready`: Ready file (auto-created, checked by probes)
 - Caches: Temporary data cached in memory or temporary files
 - Logs: New log files are created on startup (old logs are retained in `/data/logs/`)
 
@@ -577,7 +577,7 @@ The PVC is the **single source of truth** for persistent data:
 
 - `/data` (PVC): **Authoritative** - persistent, backed up
 - `/data/config.yaml`: **Persistent after first startup** - copied by the init container from Secret/ConfigMap onto the PVC; subsequent pod restarts use the PVC copy
-- `/run/mmrelay`: **Not persistent** - recreated on each pod start
+- `/tmp/mmrelay-ready`: **Not persistent** - recreated on each pod start
 - `/tmp`: **Not persistent** - temporary storage
 
 When debugging or troubleshooting, always verify the contents of `/data` on the PVC.
@@ -590,21 +590,21 @@ MMRelay uses Kubernetes startup, readiness, and liveness probes to ensure the po
 
 **Readiness probe** (period: 10s, timeout: 2s, failureThreshold: 3):
 
-- Checks if the ready file exists at `/run/mmrelay/ready`
+- Checks if the ready file exists at `/tmp/mmrelay-ready`
 - Cheap and stable check that determines service routing
 - The pod is marked "Ready" when the ready file exists
 - Traffic is only sent to ready pods
 
 **Startup probe** (period: 5s, timeout: 2s, failureThreshold: 60):
 
-- Also checks for the ready file at `/run/mmrelay/ready`
+- Also checks for the ready file at `/tmp/mmrelay-ready`
 - Allows up to 5 minutes for initialization (60 failures × 5s = 300s)
 - Prevents the liveness probe from killing the pod during slow startup
 - Once the startup probe succeeds, the liveness probe takes over
 
 **Liveness probe** (period: 60s, timeout: 20s, failureThreshold: 3):
 
-- Checks that the ready file at `/run/mmrelay/ready` has been modified within the last 2 minutes
+- Checks that the ready file at `/tmp/mmrelay-ready` has been modified within the last 2 minutes
 - Verifies the application is still actively updating the ready file (not frozen/deadlocked)
 - If the probe fails repeatedly, Kubernetes will restart the pod
 - The longer period and timeout reduce false positives for transient issues
@@ -633,7 +633,7 @@ If a pod is not ready or keeps restarting:
 2. Verify the ready file exists:
 
    ```bash
-   kubectl exec -n mmrelay <pod-name> -- ls -l /run/mmrelay
+   kubectl exec -n mmrelay <pod-name> -- ls -l /tmp/mmrelay-ready
    ```
 
 3. Run doctor inside the pod:
@@ -794,8 +794,8 @@ Because environments differ widely, treat BLE support in Kubernetes as experimen
 
 ## Notes
 
-- Ready file: The ready file feature is enabled by default via `MMRELAY_READY_FILE=/run/mmrelay/ready` in the deployment:
-  - Readiness and startup probes check for the marker file at `/run/mmrelay/ready`
-  - Liveness probe verifies the ready file at `/run/mmrelay/ready` was modified within the last 2 minutes
+- Ready file: The ready file feature is enabled by default via `MMRELAY_READY_FILE=/tmp/mmrelay-ready` in the deployment:
+  - Readiness and startup probes check for the marker file at `/tmp/mmrelay-ready`
+  - Liveness probe verifies the ready file at `/tmp/mmrelay-ready` was modified within the last 2 minutes
   - Heartbeat interval is configurable via `MMRELAY_READY_HEARTBEAT_SECONDS` (default: 60s)
 - NetworkPolicy: The default NetworkPolicy allows all egress; restrict CIDRs as needed for production. The default policy includes rules for both IPv4 (`0.0.0.0/0`) and IPv6 (`::/0`) egress.

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -17,7 +17,7 @@ proceed with the Quick Start below.
 
 ## Image Selection
 
-The base Kubernetes manifest uses `kustomize` images transform to set the container image tag. By default, the base configuration uses the `latest` tag. For 1.3.x, set a specific tag such as `1.3.0`.
+The base Kubernetes manifest uses `kustomize` images transform to set the container image tag. The default `kustomization.yaml` pins to a specific stable release tag (e.g., `1.3.0`). Edit `kustomization.yaml` to change the tag for your target release.
 
 ### Setting a specific image tag
 
@@ -119,7 +119,7 @@ kubectl create secret generic mmrelay-config \
 kubectl apply -k ./deploy/k8s
 
 # Check status
-kubectl get pods -n mmrelay -l app.kubernetes.io/name=mmrelay
+kubectl get pods -n mmrelay -l app=mmrelay
 kubectl logs -n mmrelay -f deployment/mmrelay
 ```
 
@@ -172,10 +172,17 @@ For most users, keep the default Secret-based flow to avoid extra configuration 
      --namespace mmrelay
    ```
 
-2. Uncomment the ConfigMap volume and volumeMount in `deployment.yaml`:
-   - In the `volumes` section, uncomment the ConfigMap volume
-   - In `spec.template.spec.containers[0].volumeMounts`, uncomment the ConfigMap mount
-   - Comment out the Secret volume and mount
+2. Edit `deployment.yaml` to replace the Secret volume with a ConfigMap volume:
+   - In the `volumes` section, change the `config-source` volume from `secret` to `configMap`:
+     ```yaml
+     - name: config-source
+       configMap:
+         name: mmrelay-config
+         items:
+           - key: config.yaml
+             path: config.yaml
+     ```
+   - The `volumeMounts` in the init container and main container do not need to change (they reference `config-source` and `data`)
 
 **Important**: Only enable one pattern at a time (Secret OR ConfigMap), not both.
 
@@ -206,9 +213,23 @@ kubectl create secret generic mmrelay-credentials \
 
 #### Enable credentials Secret in deployment
 
-1. Uncomment the credentials Secret volume in `deployment.yaml`:
-   - In the `volumes` section, uncomment the credentials Secret volume
-   - In `spec.template.spec.containers[0].volumeMounts`, uncomment the credentials mount
+1. Add a credentials Secret volume to `deployment.yaml`:
+   - In the `volumes` section, add:
+     ```yaml
+     - name: credentials
+       secret:
+         secretName: mmrelay-credentials
+         items:
+           - key: credentials.json
+             path: credentials.json
+     ```
+   - In `spec.template.spec.containers[0].volumeMounts`, add:
+     ```yaml
+     - name: credentials
+       mountPath: /data/matrix/credentials.json
+       subPath: credentials.json
+       readOnly: true
+     ```
 
 2. Delete the optional `mmrelay-matrix-auth` Secret (if used):
 
@@ -218,7 +239,7 @@ kubectl create secret generic mmrelay-credentials \
 
 3. Restart the pod:
    ```bash
-   kubectl delete pod -n mmrelay -l app.kubernetes.io/name=mmrelay
+   kubectl delete pod -n mmrelay -l app=mmrelay
    ```
 
 The pod will start using the mounted `credentials.json` instead of bootstrapping from environment variables.
@@ -244,7 +265,7 @@ To rotate credentials:
 
 3. Restart the pod:
    ```bash
-   kubectl delete pod -n mmrelay -l app.kubernetes.io/name=mmrelay
+   kubectl delete pod -n mmrelay -l app=mmrelay
    ```
 
 The new credentials will be loaded on the next startup.
@@ -326,7 +347,7 @@ Create a backup to local storage:
 
 ```bash
 # Get the pod name
-POD_NAME=$(kubectl get pods -n mmrelay -l app.kubernetes.io/name=mmrelay -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(kubectl get pods -n mmrelay -l app=mmrelay -o jsonpath='{.items[0].metadata.name}')
 
 # Copy /data to local directory
 kubectl exec -n mmrelay $POD_NAME -- tar czf - /data > mmrelay-backup-$(date +%Y%m%d).tar.gz
@@ -679,7 +700,7 @@ After deployment, verify your configuration:
 
 ```bash
 # Get the pod name
-POD_NAME=$(kubectl get pods -n mmrelay -l app.kubernetes.io/name=mmrelay -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(kubectl get pods -n mmrelay -l app=mmrelay -o jsonpath='{.items[0].metadata.name}')
 
 # Run diagnostics
 kubectl exec -n mmrelay $POD_NAME -- mmrelay doctor
@@ -748,9 +769,9 @@ Serial requires host device access and node pinning. Start with the most restric
         - 20 # device group (often dialout)
     ```
 
-5.  Use a minimal security context (least privilege first):
+5.  If `supplementalGroups` is insufficient, try adding capabilities. Only use `runAsUser: 0` / `runAsGroup: 0` as a **last resort** — this runs the container as root and significantly increases the attack surface:
 
-    Update `spec.template.spec.containers[0].securityContext`:
+    > **Warning**: Running as root (`runAsUser: 0`) should only be used if supplemental groups and capabilities both fail. It is not recommended for production.
 
     ```yaml
     securityContext:

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -174,6 +174,7 @@ For most users, keep the default Secret-based flow to avoid extra configuration 
 
 2. Edit `deployment.yaml` to replace the Secret volume with a ConfigMap volume:
    - In the `volumes` section, change the `config-source` volume from `secret` to `configMap`:
+
      ```yaml
      - name: config-source
        configMap:
@@ -182,6 +183,7 @@ For most users, keep the default Secret-based flow to avoid extra configuration 
            - key: config.yaml
              path: config.yaml
      ```
+
    - The `volumeMounts` in the init container and main container do not need to change (they reference `config-source` and `data`)
 
 **Important**: Only enable one pattern at a time (Secret OR ConfigMap), not both.
@@ -215,6 +217,7 @@ kubectl create secret generic mmrelay-credentials \
 
 1. Add a credentials Secret volume to `deployment.yaml`:
    - In the `volumes` section, add:
+
      ```yaml
      - name: credentials
        secret:
@@ -223,7 +226,9 @@ kubectl create secret generic mmrelay-credentials \
            - key: credentials.json
              path: credentials.json
      ```
+
    - In `spec.template.spec.containers[0].volumeMounts`, add:
+
      ```yaml
      - name: credentials
        mountPath: /data/matrix/credentials.json

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -17,7 +17,7 @@ proceed with the Quick Start below.
 
 ## Image Selection
 
-The base Kubernetes manifest uses `kustomize` images transform to set the container image tag. The default `kustomization.yaml` pins to a specific stable release tag (e.g., `1.3.0`). Edit `kustomization.yaml` to change the tag for your target release.
+The base Kubernetes manifest uses `kustomize` images transform to set the container image tag. The default `kustomization.yaml` pins to a specific stable release tag (e.g., `1.3.3`). Edit `kustomization.yaml` to change the tag for your target release.
 
 ### Setting a specific image tag
 
@@ -26,7 +26,7 @@ Edit `deploy/k8s/kustomization.yaml` to set a specific tag:
 ```yaml
 images:
   - name: ghcr.io/jeremiah-k/mmrelay
-    newTag: 1.3.0 # Change to your desired version
+    newTag: 1.3.3 # Change to your desired version
 ```
 
 Alternatively, use `kustomize edit` from the command line:
@@ -79,7 +79,7 @@ curl -fLo ./deploy/k8s/overlays/digest/kustomization.yaml "${BASE_URL}/overlays/
 
 # Set a specific image tag (recommended; avoid floating latest in production/tests)
 ${EDITOR:-vi} ./deploy/k8s/kustomization.yaml
-# Set newTag to 1.3.0 (or your target release tag)
+# Set newTag to 1.3.3 (or your target release tag)
 # If you change the namespace, update the --namespace/-n flags below
 
 # Ensure the namespace exists

--- a/docs/WHATS_NEW_1.2.md
+++ b/docs/WHATS_NEW_1.2.md
@@ -79,6 +79,10 @@ matrix:
 - **Full Test Suite CI**: CI covers Python 3.10-3.12; runtime supports Python 3.10+
 - **Component Coverage**: Dedicated coverage tracking for major feature areas
 
+### Migration Note
+
+MMRelay 1.2 requires Python 3.10 or newer. If you are still on Python 3.8 or 3.9, upgrade Python before upgrading MMRelay to 1.2.
+
 ### Documentation & Developer Experience
 
 - **Docker Guide Restructure**: Clearer deployment paths and comprehensive examples
@@ -97,12 +101,12 @@ pipx install --upgrade 'mmrelay[e2e]'
 mmrelay auth login
 ```
 
-### Backward Compatibility
+### Compatibility Notes
 
-- **Existing Configurations**: All 1.1.4 configurations continue to work unchanged
+- **Existing Configurations**: Most 1.1.4 settings continue to work after the runtime Python upgrade
 - **Gradual Migration**: Add new features (E2EE, HTML formatting, enhanced Docker support) as desired
-- **No Breaking Changes**: Seamless upgrade experience
+- **Python Upgrade Required**: Python 3.8 and 3.9 users must upgrade their runtime before installing MMRelay 1.2
 
 ---
 
-**MMRelay 1.2** brings secure end-to-end encryption, modern authentication, and enhanced deployment options while maintaining full backward compatibility with existing setups.
+**MMRelay 1.2** brings secure end-to-end encryption, modern authentication, and enhanced deployment options for Python 3.10+ environments.

--- a/docs/WHATS_NEW_1.2.md
+++ b/docs/WHATS_NEW_1.2.md
@@ -2,6 +2,11 @@
 
 MMRelay 1.2 introduces Matrix End-to-End Encryption support, enhanced authentication management, and improved Docker deployment capabilities. This release focuses on security, reliability, and ease of deployment for users upgrading from 1.1.4.
 
+## ⬆️ Upgrade Note
+
+MMRelay 1.2 requires Python 3.10 or newer. Upgrade to Python 3.10+ before
+upgrading to MMRelay 1.2.
+
 ## 🔐 Matrix End-to-End Encryption (E2EE) Support
 
 **The flagship feature of 1.2** - Full Matrix E2EE support enabling secure communication in encrypted Matrix rooms.
@@ -79,10 +84,6 @@ matrix:
 - **Full Test Suite CI**: CI covers Python 3.10-3.12; runtime supports Python 3.10+
 - **Component Coverage**: Dedicated coverage tracking for major feature areas
 
-### Migration Note
-
-MMRelay 1.2 requires Python 3.10 or newer. If you are still on Python 3.8 or 3.9, upgrade Python before upgrading MMRelay to 1.2.
-
 ### Documentation & Developer Experience
 
 - **Docker Guide Restructure**: Clearer deployment paths and comprehensive examples
@@ -103,9 +104,9 @@ mmrelay auth login
 
 ### Compatibility Notes
 
-- **Existing Configurations**: Most 1.1.4 settings continue to work after the runtime Python upgrade
+- **Existing Configurations**: Most 1.1.4 settings continue to work after you upgrade to Python 3.10+
 - **Gradual Migration**: Add new features (E2EE, HTML formatting, enhanced Docker support) as desired
-- **Python Upgrade Required**: Python 3.8 and 3.9 users must upgrade their runtime before installing MMRelay 1.2
+- **Python Upgrade Required**: Python 3.8 and 3.9 users must upgrade to Python 3.10+ before upgrading to MMRelay 1.2
 
 ---
 

--- a/docs/WHATS_NEW_1.2.md
+++ b/docs/WHATS_NEW_1.2.md
@@ -40,9 +40,9 @@ matrix:
 
 ### Improved Authentication Flow
 
-- **OIDC Compatibility**: `mmrelay auth login` now uses modern OIDC flows compatible with Matrix 2.0
-- **MAS Support**: Compatible with Matrix Authentication Service used by matrix.org
-- **Token Rotation**: Automatic handling of token refresh, preventing authentication expiration
+- **Credentials Management**: `mmrelay auth login` creates persistent credentials stored in `~/.mmrelay/matrix/credentials.json`
+- **Persistent Device ID**: Maintains a consistent device identity across restarts for E2EE
+- **Interactive Setup**: Guided prompts for homeserver, username, and password
 
 ## 🎨 Matrix HTML Formatting Support
 
@@ -76,7 +76,7 @@ matrix:
 ### Testing Enhancements
 
 - **Improved Test Coverage**: Significant increase from ~70% to 90%+ total coverage
-- **Full Test Suite CI**: CI covers Python 3.10-3.12; runtime supports Python 3.9+
+- **Full Test Suite CI**: CI covers Python 3.10-3.12; runtime supports Python 3.10+
 - **Component Coverage**: Dedicated coverage tracking for major feature areas
 
 ### Documentation & Developer Experience

--- a/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
+++ b/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
@@ -1,0 +1,753 @@
+# Remove `credentials_path` and `store_path` Configurability
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the ability for users to configure custom `credentials_path` and `store_path` locations via config keys or the `MMRELAY_CREDENTIALS_PATH` env var. These paths will always be derived from `MMRELAY_HOME`, which already provides full control over data location.
+
+**Architecture:** Currently the code checks a 3-level resolution chain for `credentials_path` (env var → top-level config → `matrix.credentials_path`) and a 2-level chain for `store_path` (`matrix.encryption.store_path` → `matrix.e2ee.store_path`). All of these will be removed. The default paths (`<MMRELAY_HOME>/matrix/credentials.json` and `<MMRELAY_HOME>/matrix/store/`) already handle every deployment scenario via `MMRELAY_HOME`. The `InvalidCredentialsPathTypeError` exception class will be removed. The `get_explicit_credentials_path()` function will be removed. All callers will be simplified to use only the default path functions.
+
+**Tech Stack:** Python 3.10+, pytest, asyncio
+
+---
+
+## Background
+
+### Why These Are Unnecessary
+
+Every deployment method already controls data paths via `MMRELAY_HOME`:
+
+| Deployment     | How it works                                                                                                    |
+| -------------- | --------------------------------------------------------------------------------------------------------------- |
+| Local pip/pipx | Default `~/.mmrelay` → credentials at `~/.mmrelay/matrix/credentials.json`, store at `~/.mmrelay/matrix/store/` |
+| Docker         | `MMRELAY_HOME=/data` env var → credentials at `/data/matrix/credentials.json`, store at `/data/matrix/store/`   |
+| Kubernetes     | Same — PVC mount + `MMRELAY_HOME` env var                                                                       |
+| Helm           | `matrixAuth` handles credentials; `MMRELAY_HOME` handles all paths                                              |
+
+No Helm chart, K8s manifest, or Docker compose file references `credentials_path` or `store_path`. The "Tip (Kubernetes): set credentials_path to a writable PVC location" in the sample config was misleading — `MMRELAY_HOME` already solves this.
+
+### Why `credentials_path` Shouldn't Be Top-Level
+
+Credentials are a Matrix concept. The code supports checking both `config["credentials_path"]` (top-level) and `config["matrix"]["credentials_path"]` (nested), which is confusing. Since we're removing configurability entirely, this becomes moot — but it's worth noting as part of the rationale.
+
+### The INNO_SETUP_GUIDE Exception
+
+`docs/dev/INNO_SETUP_GUIDE.md:382` shows the Windows installer generating `store_path` in config. This is a dev/internal doc with an example, not actual installer code. It should be updated to remove the `store_path` line, but the installer script itself (`scripts/mmrelay.iss`) should be checked too.
+
+---
+
+## Files Affected
+
+### Source files to modify:
+
+- `src/mmrelay/config.py` — Remove `get_explicit_credentials_path()`, `InvalidCredentialsPathTypeError`, `_resolve_credentials_path()`, simplify `save_credentials()`, `load_credentials()`, `get_credentials_search_paths()`
+- `src/mmrelay/paths.py` — No changes needed (default path functions are correct)
+- `src/mmrelay/matrix_utils.py` — Remove re-exports of deleted functions, update `MatrixAuthInfo` dataclass
+- `src/mmrelay/matrix/credentials.py` — Simplify `_resolve_credentials_save_path()`, remove `credentials_path` from auth resolution
+- `src/mmrelay/matrix/sync_bootstrap.py` — Simplify login flow, remove `credentials_path` tracking
+- `src/mmrelay/matrix/auth.py` — Remove `credentials_path` from `restore_e2ee_session()`, remove `store_path` config reading from `_configure_e2ee()`
+- `src/mmrelay/cli.py` — Remove `_validate_credentials_json()` references to explicit path, remove `store_path` reading from `_validate_e2ee_config()`
+- `src/mmrelay/cli_utils.py` — Remove `store_path` override handling in `_cleanup_local_session_data()`
+- `src/mmrelay/constants/messages.py` — Remove or keep `LEGACY_CREDENTIALS_WARNING_MSG` (still used for legacy _location_ warnings, not path config)
+- `src/mmrelay/tools/sample_config.yaml` — Remove `credentials_path` references in comments (lines 18-19, 29)
+
+### Test files to modify:
+
+- `tests/test_config_edge_cases.py` — Remove/update ~15 tests for `get_explicit_credentials_path`, `InvalidCredentialsPathTypeError`, `_resolve_credentials_path`, `MMRELAY_CREDENTIALS_PATH` env var
+- `tests/test_config.py` — Remove/update ~8 tests for explicit path saving, `MMRELAY_CREDENTIALS_PATH` env var
+- `tests/test_matrix_utils_auth_credentials.py` — Remove/update tests for explicit credentials path
+- `tests/test_matrix_utils_credentials_resolve.py` — Update tests that pass config with `credentials_path`
+- `tests/test_matrix_utils_connect_credentials.py` — Remove `test_connect_matrix_explicit_credentials_path_is_used`, update `InvalidCredentialsPathTypeError` test
+- `tests/test_matrix_auth_discovery.py` — Update tests that save to `credentials_path`
+- `tests/test_matrix_utils_sync_bootstrap_login.py` — Update tests patching `save_credentials` with `credentials_path`
+- `tests/test_matrix_utils_auth_e2ee.py` — Remove/update `test_connect_matrix_e2ee_store_path_from_config`, `test_connect_matrix_e2ee_store_path_precedence_encryption`, `test_connect_matrix_e2ee_store_path_uses_e2ee_section`, keep `test_connect_matrix_e2ee_store_path_default`
+- `tests/test_matrix_utils_connect_e2ee.py` — Update E2EE connect tests
+- `tests/test_cli.py` — Remove/update `_validate_e2ee_config` tests with `store_path`
+- `tests/test_cli_utils.py` — Remove/update `test_cleanup_config_override_store_path`
+- `tests/test_e2ee_utils.py` — Update fixtures that include `credentials_path`
+- `tests/test_matrix_utils_auth_login.py` — Update login tests
+- `tests/test_matrix_utils_auth_logout.py` — Update logout tests
+- `tests/test_cli_paths.py` — Verify still correct
+- `tests/test_paths.py` — Verify still correct
+- `tests/test_paths_coverage.py` — Verify still correct
+- `tests/test_auth_flow_fixes.py` — Update `test_windows_credentials_path_handling`
+- `tests/test_async_patterns.py` — Update async credential loading tests
+- `tests/test_migrate.py` — Verify migration tests still pass (migration handles _legacy file locations_, not config overrides)
+- `tests/test_migrate_rollback_auto.py` — Verify rollback tests
+- `tests/test_cli_targeted.py` — Update if needed
+
+### Documentation files to modify:
+
+- `docs/ADVANCED_CONFIGURATION.md` — Remove `MMRELAY_CREDENTIALS_PATH` from env var table
+- `docs/E2EE.md` — Remove `store_path` reference at line 184
+- `docs/dev/INNO_SETUP_GUIDE.md` — Remove `store_path` from example at line 382
+
+---
+
+## Task 1: Remove `credentials_path` from `config.py`
+
+**Files:**
+
+- Modify: `src/mmrelay/config.py`
+
+This is the core change. All credentials path resolution collapses to: use `get_credentials_path()` from `paths.py` (which returns `<MMRELAY_HOME>/matrix/credentials.json`).
+
+- [ ] **Step 1: Remove `InvalidCredentialsPathTypeError`**
+
+Remove the class at lines 278-287:
+
+```python
+class InvalidCredentialsPathTypeError(TypeError):
+    """Raised when credentials_path is not a string."""
+    def __init__(self) -> None:
+        super().__init__("credentials_path must be a string")
+```
+
+- [ ] **Step 2: Remove `get_explicit_credentials_path()`**
+
+Remove the entire function at lines 290-323. This is the function that checks `MMRELAY_CREDENTIALS_PATH` env var → `config["credentials_path"]` → `config["matrix"]["credentials_path"]`.
+
+- [ ] **Step 3: Simplify `get_credentials_search_paths()`**
+
+At lines 182-250, the function accepts `explicit_path` parameter. Remove this parameter. The function should only build the candidate list from the default path (`get_credentials_path()`), config-adjacent dirs, `~/.mmrelay/credentials.json`, and legacy dirs. Remove any logic that handles explicit path overrides.
+
+Update the signature to:
+
+```python
+def get_credentials_search_paths(
+    *, config_paths: Iterable[str] | None = None,
+    include_base_data: bool = True,
+) -> list[str]:
+```
+
+Inside the function, remove the block that handles `explicit_path` (it's used as the first candidate). The first candidate should now always be the unified default path.
+
+- [ ] **Step 4: Simplify `get_candidate_credentials_paths()`**
+
+At lines 254-275, this is a backward-compatible alias. Remove the `explicit_path` parameter since the underlying function no longer accepts it. Update to:
+
+```python
+def get_candidate_credentials_paths(
+    *, config_paths: Iterable[str] | None = None,
+    include_base_data: bool = True,
+) -> list[str]:
+    return get_credentials_search_paths(
+        config_paths=config_paths,
+        include_base_data=include_base_data,
+    )
+```
+
+- [ ] **Step 5: Simplify `load_credentials()`**
+
+At lines 775-894, remove the `get_explicit_credentials_path()` call (line ~794). The function should use `get_credentials_search_paths()` without an explicit path override. The `config_override` parameter can remain for loading config from a specific source, but the credentials path is always the default.
+
+Remove:
+
+```python
+explicit_path = get_explicit_credentials_path(config_for_paths)
+```
+
+And the call to `get_credentials_search_paths` becomes:
+
+```python
+candidates = get_credentials_search_paths(
+    config_paths=config_path_candidates,
+    include_base_data=True,
+)
+```
+
+- [ ] **Step 6: Simplify `save_credentials()`**
+
+At lines 917-988, remove the `credentials_path` parameter and all resolution logic that checks env vars/config. The function should always save to `get_credentials_path()` (from `paths.py`).
+
+New signature:
+
+```python
+def save_credentials(credentials: dict[str, Any]) -> None:
+```
+
+The target path is always:
+
+```python
+target_path = get_credentials_path()
+```
+
+Keep the directory creation, JSON writing, and permission-setting logic. Remove the `_expand_path` and `path_module.normpath` calls since `get_credentials_path()` already returns a clean `Path`.
+
+- [ ] **Step 7: Remove `_resolve_credentials_path()`**
+
+Remove the entire function at lines 1362-1417. This was used by CLI tools to resolve the credentials path with config/env overrides. Callers should use `get_credentials_path()` directly.
+
+- [ ] **Step 8: Run targeted tests to verify nothing imports the removed symbols**
+
+Run: `python -c "from mmrelay.config import InvalidCredentialsPathTypeError"`
+Expected: ImportError (confirming removal)
+
+Run: `python -c "from mmrelay.config import get_explicit_credentials_path"`
+Expected: ImportError (confirming removal)
+
+Run: `python -c "from mmrelay.config import save_credentials, load_credentials, get_candidate_credentials_paths"`
+Expected: No error (these functions still exist)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/mmrelay/config.py
+git commit -m "refactor: remove credentials_path configurability from config.py
+
+Remove get_explicit_credentials_path(), InvalidCredentialsPathTypeError,
+_resolve_credentials_path(), and simplify save_credentials() and
+load_credentials() to always use the default path derived from MMRELAY_HOME."
+```
+
+---
+
+## Task 2: Remove `store_path` config reading from `matrix/auth.py`
+
+**Files:**
+
+- Modify: `src/mmrelay/matrix/auth.py`
+
+The `_configure_e2ee()` function (lines 19-158) reads `store_path` from `matrix.encryption.store_path` and `matrix.e2ee.store_path`. After this change, it will always use the default `get_e2ee_store_dir()`.
+
+- [ ] **Step 1: Simplify `_configure_e2ee()` store path resolution**
+
+In `_configure_e2ee()`, remove the config override logic at lines ~88-103:
+
+```python
+# REMOVE this block:
+store_override = None
+if isinstance(matrix_section, dict):
+    encryption_section = matrix_section.get("encryption")
+    e2ee_section = matrix_section.get("e2ee")
+    if isinstance(encryption_section, dict):
+        store_override = encryption_section.get("store_path")
+    if not store_override and isinstance(e2ee_section, dict):
+        store_override = e2ee_section.get("store_path")
+
+if isinstance(store_override, str) and store_override:
+    e2ee_store_path = os.path.expanduser(store_override)
+else:
+    e2ee_store_path = str(
+        await asyncio.to_thread(facade.get_e2ee_store_dir)
+    )
+```
+
+Replace with:
+
+```python
+e2ee_store_path = str(
+    await asyncio.to_thread(facade.get_e2ee_store_dir)
+)
+```
+
+This always uses the default path `<MMRELAY_HOME>/matrix/store`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/mmrelay/matrix/auth.py
+git commit -m "refactor: remove store_path config override from _configure_e2ee()"
+```
+
+---
+
+## Task 3: Update `matrix_utils.py` facade
+
+**Files:**
+
+- Modify: `src/mmrelay/matrix_utils.py`
+
+- [ ] **Step 1: Remove imports of deleted functions**
+
+At line ~61, remove `get_explicit_credentials_path` from the import:
+
+```python
+from mmrelay.config import (
+    async_load_credentials,
+    get_explicit_credentials_path,  # REMOVE THIS
+    save_credentials,
+)
+```
+
+At line ~116, remove `get_credentials_path` import if it was only used for re-export of the explicit path function (check first — it may still be used elsewhere in the facade).
+
+- [ ] **Step 2: Update `MatrixAuthInfo` dataclass**
+
+At lines ~304-311, the `credentials_path` field tracks where credentials were loaded from. After removing configurability, this is always `str(get_credentials_path())`. Remove the field from the dataclass:
+
+```python
+@dataclass
+class MatrixAuthInfo:
+    homeserver: str
+    access_token: str
+    user_id: str
+    device_id: Optional[str]
+    credentials: dict[str, Any] | None
+    # credentials_path removed — always default path
+```
+
+- [ ] **Step 3: Search for all references to `credentials_path` in this file and update them**
+
+Any code that reads `auth_info.credentials_path` or passes `credentials_path` to `save_credentials` needs updating. The `save_credentials` call sites should now use `save_credentials(credentials)` without a path argument.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mmrelay/matrix_utils.py
+git commit -m "refactor: remove credentials_path from facade and MatrixAuthInfo"
+```
+
+---
+
+## Task 4: Update `matrix/credentials.py`
+
+**Files:**
+
+- Modify: `src/mmrelay/matrix/credentials.py`
+
+- [ ] **Step 1: Simplify `_resolve_credentials_save_path()`**
+
+At lines 30-52, this function checks `get_explicit_credentials_path` then falls back to `get_credentials_path()`. Remove the explicit path check:
+
+```python
+def _resolve_credentials_save_path(config_data: dict[str, Any] | None) -> str | None:
+    return str(facade.get_credentials_path())
+```
+
+- [ ] **Step 2: Update `_resolve_and_load_credentials()`**
+
+This function (lines 91-364) populates `credentials_path` in the returned `MatrixAuthInfo`. Since `MatrixAuthInfo` no longer has that field, remove all assignments to `credentials_path` in the return statements. The function should no longer track where credentials came from — it just loads them from the default location.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mmrelay/matrix/credentials.py
+git commit -m "refactor: simplify credentials path resolution in credentials.py"
+```
+
+---
+
+## Task 5: Update `matrix/sync_bootstrap.py`
+
+**Files:**
+
+- Modify: `src/mmrelay/matrix/sync_bootstrap.py`
+
+- [ ] **Step 1: Simplify login flow**
+
+At lines ~718-749, remove the `credentials_path` tracking variable and the `_resolve_credentials_save_path` call. Replace with direct use of `facade.get_credentials_path()`.
+
+- [ ] **Step 2: Simplify save after login**
+
+At lines ~1017-1027, remove the `credentials_path` variable and pass `credentials` only to `save_credentials()`:
+
+```python
+await asyncio.to_thread(facade.save_credentials, credentials)
+facade.logger.info("Credentials saved to %s", facade.get_credentials_path())
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mmrelay/matrix/sync_bootstrap.py
+git commit -m "refactor: remove credentials_path tracking from sync_bootstrap"
+```
+
+---
+
+## Task 6: Update `matrix/auth.py` session restore
+
+**Files:**
+
+- Modify: `src/mmrelay/matrix/auth.py`
+
+- [ ] **Step 1: Update `restore_e2ee_session()`**
+
+At lines ~277, the function saves credentials back to `auth_info.credentials_path`:
+
+```python
+await asyncio.to_thread(
+    facade.save_credentials,
+    auth_info.credentials,
+    credentials_path=auth_info.credentials_path,
+)
+```
+
+Since `MatrixAuthInfo` no longer has `credentials_path` and `save_credentials` no longer takes a path arg, change to:
+
+```python
+await asyncio.to_thread(
+    facade.save_credentials,
+    auth_info.credentials,
+)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/mmrelay/matrix/auth.py
+git commit -m "refactor: simplify credentials save in restore_e2ee_session"
+```
+
+---
+
+## Task 7: Update `cli.py`
+
+**Files:**
+
+- Modify: `src/mmrelay/cli.py`
+
+- [ ] **Step 1: Update `_validate_credentials_json()`**
+
+At lines ~555-614, remove the import and call to `get_explicit_credentials_path` and `InvalidCredentialsPathTypeError`. Simplify to use `get_credentials_search_paths()` without explicit path.
+
+Remove:
+
+```python
+from mmrelay.config import (
+    InvalidCredentialsPathTypeError,  # REMOVE
+    get_explicit_credentials_path,     # REMOVE
+)
+```
+
+Remove the explicit path resolution:
+
+```python
+# REMOVE:
+try:
+    explicit_path = get_explicit_credentials_path(config or relay_config)
+except InvalidCredentialsPathTypeError:
+    _get_logger().error("Invalid credentials_path: %s", exc)
+    return False
+```
+
+Update the candidates call:
+
+```python
+candidates = get_credentials_search_paths(
+    config_paths=[config_path] if config_path else None,
+)
+```
+
+- [ ] **Step 2: Update `_validate_e2ee_config()`**
+
+At lines ~775-781, remove the `store_path` reading from config:
+
+```python
+# REMOVE:
+store_path = e2ee_config.get("store_path") or encryption_config.get("store_path")
+if store_path:
+    expanded_path = os.path.expanduser(store_path)
+    if not os.path.exists(expanded_path):
+        print(f"Info: E2EE store directory will be created: {expanded_path}")
+```
+
+- [ ] **Step 3: Update `_find_credentials_json_path()`**
+
+At lines ~878-897, same pattern as `_validate_credentials_json` — remove `get_explicit_credentials_path` usage.
+
+- [ ] **Step 4: Search for any remaining references**
+
+Search `cli.py` for `credentials_path`, `get_explicit_credentials_path`, `InvalidCredentialsPathTypeError`, `MMRELAY_CREDENTIALS_PATH`, `store_path`. Update or remove all remaining references.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/mmrelay/cli.py
+git commit -m "refactor: remove credentials_path and store_path config handling from CLI"
+```
+
+---
+
+## Task 8: Update `cli_utils.py`
+
+**Files:**
+
+- Modify: `src/mmrelay/cli_utils.py`
+
+- [ ] **Step 1: Simplify `_cleanup_local_session_data()`**
+
+At lines ~423-468, remove the code that reads `store_path` from config and adds it to the cleanup set:
+
+```python
+# REMOVE this block:
+for section in ("e2ee", "encryption"):
+    section_cfg = matrix_cfg.get(section, {})
+    override = os.path.expanduser(section_cfg.get("store_path", ""))
+    if override:
+        candidate_store_paths.add(override)
+```
+
+The function should only clean up the default store dir.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/mmrelay/cli_utils.py
+git commit -m "refactor: remove store_path override cleanup from cli_utils"
+```
+
+---
+
+## Task 9: Update `sample_config.yaml`
+
+**Files:**
+
+- Modify: `src/mmrelay/tools/sample_config.yaml`
+
+- [ ] **Step 1: Remove credentials_path references**
+
+Remove line 18-19 (the K8s tip):
+
+```yaml
+# REMOVE:
+# Tip (Kubernetes): set credentials_path to a writable PVC location
+# credentials_path: /data/matrix/credentials.json
+```
+
+Remove line 29 (legacy method example):
+
+```yaml
+# REMOVE:
+#credentials_path: /data/matrix/credentials.json
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/mmrelay/tools/sample_config.yaml
+git commit -m "docs: remove credentials_path from sample config"
+```
+
+---
+
+## Task 10: Update documentation
+
+**Files:**
+
+- Modify: `docs/ADVANCED_CONFIGURATION.md`
+- Modify: `docs/E2EE.md`
+- Modify: `docs/dev/INNO_SETUP_GUIDE.md`
+
+- [ ] **Step 1: Remove `MMRELAY_CREDENTIALS_PATH` from ADVANCED_CONFIGURATION.md**
+
+Find and remove the row for `MMRELAY_CREDENTIALS_PATH` in the environment variable mapping table (around line 331). Also remove any narrative text that describes configuring credentials_path.
+
+- [ ] **Step 2: Remove `store_path` from E2EE.md**
+
+At line ~184, remove:
+
+```yaml
+# store_path: ~/.mmrelay/matrix/store
+```
+
+And any surrounding text that presents it as a configurable option.
+
+- [ ] **Step 3: Update INNO_SETUP_GUIDE.md**
+
+At line 382, remove the `store_path` line from the Pascal example:
+
+```pascal
+// REMOVE this line:
+'    store_path: ''' + InstallDir + '\e2ee_store''' + #13#10;
+```
+
+The E2EE config should just be:
+
+```pascal
+config := config + 'matrix:' + #13#10 +
+          '  e2ee:' + #13#10 +
+          '    enabled: true' + #13#10;
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ADVANCED_CONFIGURATION.md docs/E2EE.md docs/dev/INNO_SETUP_GUIDE.md
+git commit -m "docs: remove credentials_path and store_path configurability documentation"
+```
+
+---
+
+## Task 11: Update test files (batch 1 — config tests)
+
+**Files:**
+
+- Modify: `tests/test_config_edge_cases.py`
+- Modify: `tests/test_config.py`
+- Modify: `tests/test_matrix_utils_auth_credentials.py`
+
+These tests heavily reference `get_explicit_credentials_path`, `InvalidCredentialsPathTypeError`, `MMRELAY_CREDENTIALS_PATH` env var, and `_resolve_credentials_path`.
+
+- [ ] **Step 1: Update `tests/test_config_edge_cases.py`**
+
+Remove or rewrite these tests:
+
+- `test_get_explicit_credentials_path_no_config` — DELETE (function removed)
+- `test_get_explicit_credentials_path_non_string` — DELETE (exception removed)
+- `test_get_explicit_credentials_path_matrix_section_non_string` — DELETE
+- `test_get_explicit_credentials_path_matrix_section_returns_path` — DELETE
+- `test_get_explicit_credentials_path_matrix_section_empty_returns_none` — DELETE
+- `test_resolve_credentials_path_relay_config` — DELETE (function removed)
+- `test_resolve_credentials_path_matrix_section` — DELETE
+- `test_resolve_credentials_path_default` — REWRITE to test `get_credentials_path()` from paths.py
+- `test_resolve_credentials_path_directory_appends_filename` — DELETE
+- `test_resolve_credentials_path_empty_dirname` — DELETE
+- `test_resolve_credentials_path_env_var` — DELETE (MMRELAY_CREDENTIALS_PATH removed)
+- `test_save_credentials_writes_to_file` — REWRITE to not use MMRELAY_CREDENTIALS_PATH env var
+- `test_load_credentials_path_error_returns_none` — REWRITE (no more explicit path)
+- `test_credentials_path_error_message` — DELETE (exception removed)
+- `test_get_e2ee_store_dir_*` — KEEP as-is (these test the default path, not config overrides)
+
+- [ ] **Step 2: Update `tests/test_config.py`**
+
+- `test_save_credentials_with_explicit_path` — DELETE (no more explicit path parameter)
+- `test_save_credentials_trailing_separator_treated_as_dir` — DELETE
+- `test_save_credentials_directory_as_path` — DELETE
+- `test_save_credentials_actual_directory_path` — DELETE
+- `test_save_credentials_altsep_path_detection` — DELETE
+- `test_save_credentials_empty_config_dir_uses_base_dir` — REWRITE (simpler path logic)
+- `test_save_credentials_verification` — REWRITE (no explicit path)
+- `test_save_credentials_windows_error_guidance` — KEEP or REWRITE (still handles Windows errors)
+- `test_load_credentials_*` — KEEP (tests loading from default locations)
+
+- [ ] **Step 3: Update `tests/test_matrix_utils_auth_credentials.py`**
+
+- `test_load_credentials_success` — REWRITE if it uses explicit path
+- `test_load_credentials_file_not_exists` — KEEP
+- `test_save_credentials` — REWRITE to not pass explicit path or use MMRELAY_CREDENTIALS_PATH env var
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_config_edge_cases.py tests/test_config.py tests/test_matrix_utils_auth_credentials.py
+git commit -m "test: update config tests for credentials_path removal"
+```
+
+---
+
+## Task 12: Update test files (batch 2 — matrix and CLI tests)
+
+**Files:**
+
+- Modify: `tests/test_matrix_utils_credentials_resolve.py`
+- Modify: `tests/test_matrix_utils_connect_credentials.py`
+- Modify: `tests/test_matrix_auth_discovery.py`
+- Modify: `tests/test_matrix_utils_sync_bootstrap_login.py`
+- Modify: `tests/test_matrix_utils_auth_e2ee.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_cli_utils.py`
+- Modify: `tests/test_e2ee_utils.py`
+- Modify: `tests/test_matrix_utils_auth_login.py`
+- Modify: `tests/test_matrix_utils_auth_logout.py`
+- Modify: `tests/test_auth_flow_fixes.py`
+- Modify: `tests/test_async_patterns.py`
+
+- [ ] **Step 1: Update `tests/test_matrix_utils_credentials_resolve.py`**
+
+All 14 tests in this file test `_resolve_and_load_credentials`. Remove any that test `credentials_path` as a parameter or return value. Update return value assertions to not check `credentials_path` field (it no longer exists on `MatrixAuthInfo`).
+
+- [ ] **Step 2: Update `tests/test_matrix_utils_connect_credentials.py`**
+
+- `test_connect_matrix_explicit_credentials_path_is_used` — DELETE
+- `test_connect_matrix_invalid_credentials_path_type_error_falls_back_to_config_auth` — DELETE (exception removed)
+- Update remaining tests that reference `credentials_path` in config dicts
+
+- [ ] **Step 3: Update `tests/test_matrix_auth_discovery.py`**
+
+All tests that call `save_credentials` with `credentials_path=` need updating to call `save_credentials(credentials)` only.
+
+- [ ] **Step 4: Update `tests/test_matrix_utils_sync_bootstrap_login.py`**
+
+- `test_login_matrix_bot_no_credentials_path` — REWRITE (no more credentials_path resolution)
+- Update all tests that patch `save_credentials` with `credentials_path` kwarg
+
+- [ ] **Step 5: Update `tests/test_matrix_utils_auth_e2ee.py`**
+
+- `test_connect_matrix_e2ee_store_path_from_config` — DELETE
+- `test_connect_matrix_e2ee_store_path_precedence_encryption` — DELETE
+- `test_connect_matrix_e2ee_store_path_uses_e2ee_section` — DELETE
+- `test_connect_matrix_e2ee_store_path_default` — KEEP (tests default behavior)
+- `test_connect_matrix_e2ee_store_missing_db_files_warns` — REWRITE if it sets store_path in config
+- `test_connect_matrix_e2ee_missing_sqlite_store` — REWRITE if needed
+- `test_login_matrix_bot_e2ee_store_path_created` — KEEP or REWRITE (tests dir creation, which still happens)
+
+- [ ] **Step 6: Update `tests/test_cli.py`**
+
+- `test_validate_e2ee_config_e2ee_enabled_with_store_path` — DELETE
+- `test_validate_e2ee_config_legacy_store_path` — DELETE
+- Update any tests that set `credentials_path` in mock config dicts
+
+- [ ] **Step 7: Update `tests/test_cli_utils.py`**
+
+- `test_cleanup_config_override_store_path` — DELETE
+
+- [ ] **Step 8: Update remaining test files**
+
+For `test_e2ee_utils.py`, `test_matrix_utils_auth_login.py`, `test_matrix_utils_auth_logout.py`, `test_auth_flow_fixes.py`, `test_async_patterns.py`:
+
+- Remove `credentials_path` from config dicts in test fixtures
+- Remove `credentials_path` from `MatrixAuthInfo` constructor calls
+- Remove `credentials_path=` keyword arguments to `save_credentials` calls
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tests/
+git commit -m "test: update matrix and CLI tests for credentials_path/store_path removal"
+```
+
+---
+
+## Task 13: Verify and run full test suite
+
+- [ ] **Step 1: Run full test suite with coverage**
+
+Run: `python -m pytest -v --cov --tb=short --timeout=60`
+Expected: All tests pass
+
+- [ ] **Step 2: Run lint checks**
+
+Run: `.trunk/trunk check --fix --all`
+Expected: No errors
+
+- [ ] **Step 3: Verify no references to removed symbols remain**
+
+Run: `grep -r "get_explicit_credentials_path\|InvalidCredentialsPathTypeError\|_resolve_credentials_path\|MMRELAY_CREDENTIALS_PATH" src/ tests/ --include="*.py"`
+Expected: No matches
+
+Run: `grep -r "store_path" src/mmrelay/ --include="*.py"`
+Expected: No matches (only `STORE_DIRNAME` constant and `get_e2ee_store_dir()` function should remain)
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: cleanup after credentials_path/store_path removal"
+```
+
+---
+
+## Summary of Removed Functionality
+
+| Removed                                          | Replacement                                     |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `MMRELAY_CREDENTIALS_PATH` env var               | `MMRELAY_HOME` controls all paths               |
+| `config["credentials_path"]` (top-level)         | Always `<MMRELAY_HOME>/matrix/credentials.json` |
+| `config["matrix"]["credentials_path"]`           | Always `<MMRELAY_HOME>/matrix/credentials.json` |
+| `config["matrix"]["e2ee"]["store_path"]`         | Always `<MMRELAY_HOME>/matrix/store/`           |
+| `config["matrix"]["encryption"]["store_path"]`   | Always `<MMRELAY_HOME>/matrix/store/`           |
+| `get_explicit_credentials_path()`                | `get_credentials_path()` from `paths.py`        |
+| `InvalidCredentialsPathTypeError`                | No longer needed                                |
+| `_resolve_credentials_path()`                    | `get_credentials_path()` from `paths.py`        |
+| `credentials_path` param on `save_credentials()` | Always saves to default                         |
+| `credentials_path` field on `MatrixAuthInfo`     | Always default path                             |
+
+## What Remains Unchanged
+
+- `get_credentials_path()` in `paths.py` — returns `<MMRELAY_HOME>/matrix/credentials.json`
+- `get_e2ee_store_dir()` in `paths.py` — returns `<MMRELAY_HOME>/matrix/store/`
+- `MMRELAY_HOME` env var — still controls the base directory for all data
+- `--home` CLI flag — still sets MMRELAY_HOME
+- Legacy location detection and migration — still works (detects files in old dirs, not config overrides)
+- All other config keys and env vars — unchanged

--- a/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
+++ b/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
@@ -8,6 +8,14 @@
 
 **Tech Stack:** Python 3.10+, pytest, asyncio
 
+## Versioning and Migration
+
+This is a breaking change and must be called out in the release notes and changelog. Users should remove any `credentials_path` or `store_path` config entries and rely on `MMRELAY_HOME` for path control instead.
+
+External integrations that read `MatrixAuthInfo.credentials_path` or pass `credentials_path` to `save_credentials()` will break and need to be updated before the release ships.
+
+Add migration guidance that Python 3.8/3.9 users must upgrade their runtime before moving to MMRelay 1.2, and include a short note in the changelog/release announcement so the upgrade path is explicit.
+
 ---
 
 ## Background
@@ -24,6 +32,16 @@ Every deployment method already controls data paths via `MMRELAY_HOME`:
 | Helm           | `matrixAuth` handles credentials; `MMRELAY_HOME` handles all paths                                              |
 
 No Helm chart, K8s manifest, or Docker compose file references `credentials_path` or `store_path`. The "Tip (Kubernetes): set credentials_path to a writable PVC location" in the sample config was misleading — `MMRELAY_HOME` already solves this.
+
+### Deprecation Warnings
+
+Add warnings when the following legacy config keys or environment variables are present but ignored:
+
+- top-level `credentials_path`
+- `matrix.credentials_path`
+- `matrix.e2ee.store_path`
+- `matrix.encryption.store_path`
+- `MMRELAY_CREDENTIALS_PATH`
 
 ### Why `credentials_path` Shouldn't Be Top-Level
 
@@ -716,8 +734,8 @@ Expected: No errors
 Run: `grep -r "get_explicit_credentials_path\|InvalidCredentialsPathTypeError\|_resolve_credentials_path\|MMRELAY_CREDENTIALS_PATH" src/ tests/ --include="*.py"`
 Expected: No matches
 
-Run: `grep -r "store_path" src/mmrelay/ --include="*.py"`
-Expected: No matches (only `STORE_DIRNAME` constant and `get_e2ee_store_dir()` function should remain)
+Run: `grep -r -n "store_path" src/mmrelay/ --include="*.py" | grep -E "config|credentials|section_cfg|override|store_path ="`
+Expected: Matches only legacy config-reading or assignment sites that should be removed
 
 - [ ] **Step 4: Final commit if any fixes needed**
 

--- a/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
+++ b/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
@@ -779,8 +779,11 @@ Expected: No errors
 
 - [ ] **Step 3: Verify no references to removed symbols remain**
 
-Run: `grep -r "get_explicit_credentials_path\|InvalidCredentialsPathTypeError\|_resolve_credentials_path\|MMRELAY_CREDENTIALS_PATH" src/ tests/ --include="*.py"`
+Run: `grep -r "get_explicit_credentials_path\|InvalidCredentialsPathTypeError\|_resolve_credentials_path" src/ tests/ --include="*.py"`
 Expected: No matches
+
+Run: `grep -r "MMRELAY_CREDENTIALS_PATH" src/ tests/ --include="*.py"`
+Expected: Matches only the centralized deprecation-warning path and related tests
 
 Run: `grep -r -nE 'get\("store_path"\)|section_cfg\.get\("store_path"\)|store_override' src/mmrelay/ --include="*.py"`
 Expected: No matches

--- a/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
+++ b/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
@@ -14,7 +14,7 @@ This is a breaking change and must be called out in the release notes and change
 
 External integrations that read `MatrixAuthInfo.credentials_path` or pass `credentials_path` to `save_credentials()` will break and need to be updated before the release ships.
 
-Add migration guidance that Python 3.8/3.9 users must upgrade their runtime before moving to MMRelay 1.2, and include a short note in the changelog/release announcement so the upgrade path is explicit.
+Add migration guidance that users must remove legacy path overrides before upgrading to the release that includes this breaking change, and include a short note in the changelog/release announcement so the upgrade path is explicit.
 
 ---
 
@@ -539,7 +539,55 @@ git commit -m "docs: remove credentials_path from sample config"
 
 ---
 
-## Task 10: Update documentation
+## Task 10: Add deprecation warnings for ignored legacy overrides
+
+**Files:**
+
+- Modify: `src/mmrelay/config.py`
+- Modify: `src/mmrelay/cli.py`
+- Modify: `tests/test_config_edge_cases.py`
+- Modify: `tests/test_cli.py`
+
+- [ ] **Step 1: Add centralized warning logic in `config.py`**
+
+Add a helper in `src/mmrelay/config.py` that checks parsed config data plus the
+`MMRELAY_CREDENTIALS_PATH` environment variable and logs warnings when ignored
+legacy path overrides are present:
+
+- top-level `credentials_path`
+- `matrix.credentials_path`
+- `matrix.e2ee.store_path`
+- `matrix.encryption.store_path`
+- `MMRELAY_CREDENTIALS_PATH`
+
+Call this helper from the main config-loading path so warnings are emitted once
+per load, not from every downstream auth or E2EE code path.
+
+- [ ] **Step 2: Keep warning scope narrow and migration-oriented**
+
+Warnings should explain that these keys/env vars are ignored, that
+`MMRELAY_HOME` is now the only supported path control, and that users should
+remove the legacy settings from their config or deployment manifests.
+
+- [ ] **Step 3: Update tests**
+
+Add or update tests in `tests/test_config_edge_cases.py` and `tests/test_cli.py`
+to verify:
+
+- warnings are emitted for each ignored legacy key/env var
+- warnings are not duplicated excessively during a single config load
+- config loading still succeeds after warning
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mmrelay/config.py src/mmrelay/cli.py tests/test_config_edge_cases.py tests/test_cli.py
+git commit -m "feat: warn on ignored credentials_path and store_path overrides"
+```
+
+---
+
+## Task 11: Update documentation
 
 **Files:**
 
@@ -587,7 +635,7 @@ git commit -m "docs: remove credentials_path and store_path configurability docu
 
 ---
 
-## Task 11: Update test files (batch 1 — config tests)
+## Task 12: Update test files (batch 1 — config tests)
 
 **Files:**
 
@@ -644,7 +692,7 @@ git commit -m "test: update config tests for credentials_path removal"
 
 ---
 
-## Task 12: Update test files (batch 2 — matrix and CLI tests)
+## Task 13: Update test files (batch 2 — matrix and CLI tests)
 
 **Files:**
 
@@ -717,7 +765,7 @@ git commit -m "test: update matrix and CLI tests for credentials_path/store_path
 
 ---
 
-## Task 13: Verify and run full test suite
+## Task 14: Verify and run full test suite
 
 - [ ] **Step 1: Run full test suite with coverage**
 
@@ -734,8 +782,12 @@ Expected: No errors
 Run: `grep -r "get_explicit_credentials_path\|InvalidCredentialsPathTypeError\|_resolve_credentials_path\|MMRELAY_CREDENTIALS_PATH" src/ tests/ --include="*.py"`
 Expected: No matches
 
-Run: `grep -r -n "store_path" src/mmrelay/ --include="*.py" | grep -E "config|credentials|section_cfg|override|store_path ="`
-Expected: Matches only legacy config-reading or assignment sites that should be removed
+Run: `grep -r -nE 'get\("store_path"\)|section_cfg\.get\("store_path"\)|store_override' src/mmrelay/ --include="*.py"`
+Expected: No matches
+
+This final grep only checks for config-based `store_path` override reads. Other
+runtime `store_path` identifiers may still remain where they refer to the
+default E2EE store path or AsyncClient kwargs.
 
 - [ ] **Step 4: Final commit if any fixes needed**
 

--- a/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
+++ b/docs/dev/2026-04-10-remove-credentials-store-path-configurability.md
@@ -55,7 +55,7 @@ Credentials are a Matrix concept. The code supports checking both `config["crede
 
 ## Files Affected
 
-### Source files to modify:
+### Source files to modify
 
 - `src/mmrelay/config.py` — Remove `get_explicit_credentials_path()`, `InvalidCredentialsPathTypeError`, `_resolve_credentials_path()`, simplify `save_credentials()`, `load_credentials()`, `get_credentials_search_paths()`
 - `src/mmrelay/paths.py` — No changes needed (default path functions are correct)
@@ -68,7 +68,7 @@ Credentials are a Matrix concept. The code supports checking both `config["crede
 - `src/mmrelay/constants/messages.py` — Remove or keep `LEGACY_CREDENTIALS_WARNING_MSG` (still used for legacy _location_ warnings, not path config)
 - `src/mmrelay/tools/sample_config.yaml` — Remove `credentials_path` references in comments (lines 18-19, 29)
 
-### Test files to modify:
+### Test files to modify
 
 - `tests/test_config_edge_cases.py` — Remove/update ~15 tests for `get_explicit_credentials_path`, `InvalidCredentialsPathTypeError`, `_resolve_credentials_path`, `MMRELAY_CREDENTIALS_PATH` env var
 - `tests/test_config.py` — Remove/update ~8 tests for explicit path saving, `MMRELAY_CREDENTIALS_PATH` env var
@@ -93,7 +93,7 @@ Credentials are a Matrix concept. The code supports checking both `config["crede
 - `tests/test_migrate_rollback_auto.py` — Verify rollback tests
 - `tests/test_cli_targeted.py` — Update if needed
 
-### Documentation files to modify:
+### Documentation files to modify
 
 - `docs/ADVANCED_CONFIGURATION.md` — Remove `MMRELAY_CREDENTIALS_PATH` from env var table
 - `docs/E2EE.md` — Remove `store_path` reference at line 184

--- a/src/mmrelay/constants/cli.py
+++ b/src/mmrelay/constants/cli.py
@@ -44,11 +44,20 @@ CLI_COMMANDS: Final[Mapping[str, str]] = MappingProxyType(
         # Config commands
         "generate_config": "mmrelay config generate",
         "check_config": "mmrelay config check",
+        "config_paths": "mmrelay config paths",
+        "config_diagnose": "mmrelay config diagnose",
         # Auth commands
         "auth_login": "mmrelay auth login",
         "auth_status": "mmrelay auth status",
+        "auth_logout": "mmrelay auth logout",
         # Service commands
         "service_install": "mmrelay service install",
+        "service_migrate": "mmrelay service migrate",
+        # Diagnostic commands
+        "paths": "mmrelay paths",
+        "doctor": "mmrelay doctor",
+        "verify_migration": "mmrelay verify-migration",
+        "migrate": "mmrelay migrate",
         # Main commands
         "start_relay": "mmrelay",
         "show_version": "mmrelay --version",

--- a/src/mmrelay/runtime_utils.py
+++ b/src/mmrelay/runtime_utils.py
@@ -28,8 +28,8 @@ def is_running_as_service() -> bool:
 
     Checks whether the INVOCATION_ID environment variable is set (systemd-provided) and, if not,
     inspects /proc/self/status to find the parent PID and then /proc/<ppid>/comm to compare the
-    parent process name against the expected systemd init binary name. If any file access,
-    permission, or parsing errors occur, the function returns False.
+    parent process name against the expected systemd init binary name. Invalid parent PIDs and
+    proc-filesystem access failures return False.
     Returns:
         bool: True when running under a systemd service, otherwise False.
     """
@@ -42,12 +42,19 @@ def is_running_as_service() -> bool:
             for line in status_file:
                 if line.startswith("PPid:"):
                     ppid = int(line.split()[1])
+                    if ppid <= 0:
+                        return False
                     with open(
                         PROC_COMM_PATH_TEMPLATE.format(ppid=ppid),
                         encoding=DEFAULT_TEXT_ENCODING,
                     ) as comm_file:
                         return comm_file.read().strip() == SYSTEMD_INIT_SYSTEM
-    except (FileNotFoundError, PermissionError, ValueError, IndexError) as e:
+    except (FileNotFoundError, PermissionError) as e:
+        _get_logger().debug(
+            "Service detection unavailable via proc filesystem",
+            extra={"error_type": type(e).__name__},
+        )
+    except (ValueError, IndexError) as e:
         _get_logger().debug(
             "Service detection failed via proc filesystem",
             exc_info=True,

--- a/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
+++ b/src/mmrelay/tools/sample-docker-compose-prebuilt.yaml
@@ -38,7 +38,7 @@ services:
       test:
         [
           CMD-SHELL,
-          "find $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} -mmin -2 | grep -q .",
+          "test -f $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} && find $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} -mmin -2 | grep -q .",
         ]
       interval: 30s
       timeout: 5s

--- a/src/mmrelay/tools/sample-docker-compose.yaml
+++ b/src/mmrelay/tools/sample-docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       test:
         [
           CMD-SHELL,
-          "find $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} -mmin -2 | grep -q .",
+          "test -f $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} && find $${MMRELAY_READY_FILE:-/tmp/mmrelay-ready} -mmin -2 | grep -q .",
         ]
       interval: 30s
       timeout: 5s

--- a/src/mmrelay/tools/sample.env
+++ b/src/mmrelay/tools/sample.env
@@ -7,6 +7,10 @@
 # Set this to an absolute host path (example: /home/youruser)
 MMRELAY_HOST_HOME=
 
+GID=
+# Container user UID/GID - should match your host user's UID and GID
+UID=
+
 # Preferred editor for config editing
 # Will be set automatically when you select an editor via 'make edit'
 EDITOR=nano

--- a/src/mmrelay/tools/sample.env
+++ b/src/mmrelay/tools/sample.env
@@ -7,9 +7,9 @@
 # Set this to an absolute host path (example: /home/youruser)
 MMRELAY_HOST_HOME=
 
-GID=
 # Container user UID/GID - should match your host user's UID and GID
 UID=
+GID=
 
 # Preferred editor for config editing
 # Will be set automatically when you select an editor via 'make edit'

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -1,26 +1,21 @@
 matrix:
-  # Run `mmrelay auth login` before starting MMRelay.
-  # Recommended docs: `docs/INSTRUCTIONS.md` and `docs/E2EE.md`.
-  #
-  # For Docker/Kubernetes environment-variable auth, see
-  # `docs/ADVANCED_CONFIGURATION.md`.
-  #
-  # Legacy password-in-config setup is documented in `docs/INSTRUCTIONS.md`.
-  #homeserver: https://example.matrix.org
-  #bot_user_id: "@botuser:example.matrix.org"
-  #password: your_matrix_password_here
+  # Start with `mmrelay auth login` before running MMRelay.
+  # This is the normal setup path; you do not need to fill in homeserver,
+  # bot_user_id, or password here.
+  # See `docs/INSTRUCTIONS.md`, `docs/E2EE.md`, and
+  # `docs/ADVANCED_CONFIGURATION.md` for the full setup and option reference.
   e2ee:
     enabled: true
 
 matrix_rooms:
-  # Add one or more Matrix room/channel mappings.
+  # Map Matrix rooms to Meshtastic channels.
   - id: "#someroomalias:example.matrix.org"
     meshtastic_channel: 0
   - id: "!someroomid:example.matrix.org"
     meshtastic_channel: 2
 
 meshtastic:
-  # See `docs/ADVANCED_CONFIGURATION.md` for connection, routing, and prefix options.
+  # See `docs/ADVANCED_CONFIGURATION.md` for the full option set.
   connection_type: tcp
   host: meshtastic.local
   serial_port: /dev/ttyUSB0
@@ -29,55 +24,11 @@ meshtastic:
   message_interactions:
     reactions: false
     replies: false
-
   broadcast_enabled: true
-
-  # Optional overrides. See `docs/ADVANCED_CONFIGURATION.md`.
-  #health_check:
-  #  enabled: false
-  #  connect_probe_enabled: false
-  #  heartbeat_interval: 60
-  #  initial_delay: 5
-  #  probe_timeout: 30
-  #packet_routing:
-  #  chat_portnums:
-  #    - "RANGE_TEST_APP"
-  #  disabled_portnums: []
-  #  encrypted_action: plugin_only
-  #message_delay: 2.5
-  #timeout: 30
-  #nodedb_refresh_interval: 15.0
-  #prefix_enabled: true
-  #prefix_format: "{display5}[M]: "
 
 logging:
   level: info
-  # See `docs/ADVANCED_CONFIGURATION.md` for logging levels and debug logging.
-  #log_to_file: true
-  #filename: ~/.mmrelay/logs/mmrelay.log
-  #max_log_size: 5242880
-  #backup_count: 1
-  #color_enabled: true
-  #rich_tracebacks: false
-  #debug:
-  #  matrix_nio: false
-  #  bleak: true
-  #  meshtastic: "warning"
-  #  full_packets: false
 
-#database:
-#  # See `docs/ADVANCED_CONFIGURATION.md` for database settings.
-#  path: ~/.mmrelay/database/meshtastic.sqlite
-#  enable_wal: true
-#  busy_timeout_ms: 5000
-#  pragmas:
-#    synchronous: NORMAL
-#    temp_store: MEMORY
-#  msg_map:
-#    msgs_to_keep: 500
-#    wipe_on_restart: true
-
-# Plugin examples. See `docs/ADVANCED_CONFIGURATION.md` for plugin options.
 plugins:
   ping:
     active: true
@@ -86,15 +37,3 @@ plugins:
     units: imperial
   nodes:
     active: true
-
-#community-plugins:
-#  sample_plugin:
-#    active: true
-#    repository: https://github.com/username/sample_plugin.git
-#    tag: master
-#
-#custom-plugins:
-#  my_custom_plugin:
-#    active: true
-#  another_custom_plugin:
-#    active: false

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -1,163 +1,98 @@
 matrix:
-  # MATRIX AUTHENTICATION - Choose ONE method:
+  # Run `mmrelay auth login` before starting MMRelay.
+  # Recommended docs: `docs/INSTRUCTIONS.md` and `docs/E2EE.md`.
   #
-  # Method 1 (RECOMMENDED): Use 'mmrelay auth login' command
-  # This creates secure credentials.json with E2EE support and persistent device identity.
-  # Run: mmrelay auth login
-  # Best for: All deployment types (pipx, Docker, Kubernetes)
-  # NO CONFIG FIELDS NEEDED - credentials.json provides all authentication data
+  # For Docker/Kubernetes environment-variable auth, see
+  # `docs/ADVANCED_CONFIGURATION.md`.
   #
-  # Method 2: Environment Variables (Kubernetes/Docker)
-  # Set these environment variables instead of using password in config:
-  #   MMRELAY_MATRIX_HOMESERVER=https://matrix.example.org
-  #   MMRELAY_MATRIX_BOT_USER_ID=@bot:example.org
-  #   MMRELAY_MATRIX_PASSWORD=your_password
-  #   MMRELAY_MATRIX_ACCESS_TOKEN=your_access_token  # Optional alternative to password
-  # Best for: Kubernetes deployments with secrets, automated CI/CD
-  # NO CONFIG FIELDS NEEDED - environment variables provide all authentication data
-  # Note: MMRELAY_HOME controls the base directory for credentials (default: ~/.mmrelay)
-  #
-  # Method 3 (LEGACY): Password in config.yaml (NOT RECOMMENDED)
-  # Uncomment the fields below. MMRelay will create credentials.json on first run.
-  # IMPORTANT: Remove the password from this file after first successful startup!
-  # Security: chmod 600 ~/.mmrelay/config.yaml (Linux/macOS)
-  # ONLY USE THIS if you cannot use Method 1 or Method 2
+  # Legacy password-in-config setup is documented in `docs/INSTRUCTIONS.md`.
   #homeserver: https://example.matrix.org
   #bot_user_id: "@botuser:example.matrix.org"
   #password: your_matrix_password_here
-  #
-  # See docs/KUBERNETES.md for Kubernetes-specific authentication setup
-  # See docs/E2EE.md for End-to-End Encryption configuration
-
-  # End-to-End Encryption (E2EE) configuration
-  # E2EE is automatically enabled when using credentials.json (auth login or password/env-based auth)
-  # AND E2EE dependencies are installed (Linux/macOS only)
-  # NOTE: E2EE is not available on Windows due to dependency limitations
-  #
-  # SETUP INSTRUCTIONS:
-  # 1. Install E2EE dependencies: pipx install 'mmrelay[e2e]' (Linux/macOS only)
-  # 2. Authenticate using Method 1 or Method 2 to create credentials.json
-  #    (If using the legacy config password, set it above and run once)
-  # 3. MMRelay will automatically create credentials.json with E2EE support
-  # 4. For interactive setup, use: mmrelay auth login
-  #
   e2ee:
     enabled: true
 
-  # Message prefix customization (Meshtastic → Matrix direction)
-  #prefix_enabled: true # Enable prefixes on messages from mesh (e.g., "[Alice/MyMesh]: message")
-  #prefix_format: "[{long}/{mesh}]: " # Default format. Variables: {long1-20}, {long}, {short}, {mesh1-20}, {mesh}
-
-matrix_rooms: # Needs at least 1 room & channel, but supports all Meshtastic channels
-  - id: "#someroomalias:example.matrix.org" # Matrix room aliases & IDs supported
+matrix_rooms:
+  # Add one or more Matrix room/channel mappings.
+  - id: "#someroomalias:example.matrix.org"
     meshtastic_channel: 0
   - id: "!someroomid:example.matrix.org"
     meshtastic_channel: 2
 
 meshtastic:
-  connection_type: tcp # Choose either "tcp", "serial", or "ble"
-  host: meshtastic.local # Only used when connection is "tcp"
-  #port: 4403 # TCP port override (default: 4403, only used with "tcp" connection)
-  serial_port: /dev/ttyUSB0 # Only used when connection is "serial"
-  ble_address: AA:BB:CC:DD:EE:FF # Only used when connection is "ble" - Uses either an address or name from a `meshtastic --ble-scan`
-  meshnet_name: Your Meshnet Name # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
-  message_interactions: # Configure reactions and replies (both require message storage in database)
-    reactions: false # Enable reaction relaying between platforms
-    replies: false   # Enable reply relaying between platforms
+  # See `docs/ADVANCED_CONFIGURATION.md` for connection, routing, and prefix options.
+  connection_type: tcp
+  host: meshtastic.local
+  serial_port: /dev/ttyUSB0
+  ble_address: AA:BB:CC:DD:EE:FF
+  meshnet_name: Your Meshnet Name
+  message_interactions:
+    reactions: false
+    replies: false
 
-  # Optional connection health monitoring overrides
+  broadcast_enabled: true
+
+  # Optional overrides. See `docs/ADVANCED_CONFIGURATION.md`.
   #health_check:
-  #  enabled: false                   # Enable periodic health checks (default: false)
-  #  connect_probe_enabled: false     # One-shot metadata probe after connect
-  #  heartbeat_interval: 60           # Seconds between periodic checks (default: 60)
-  #  initial_delay: 5                 # Seconds before first periodic check (default: 5)
-  #  probe_timeout: 30                # Timeout in seconds for each probe (default: 30)
-  # See docs/ADVANCED_CONFIGURATION.md for behavior and legacy-compatibility notes.
-
-  # Additional configuration options (commented out with defaults)
-  broadcast_enabled: true # Must be set to true to enable Matrix to Meshtastic messages
-  #detection_sensor: true # Defaults to true; set to false to disable detection sensor message forwarding
-
-  # Optional packet-routing overrides
+  #  enabled: false
+  #  connect_probe_enabled: false
+  #  heartbeat_interval: 60
+  #  initial_delay: 5
+  #  probe_timeout: 30
   #packet_routing:
   #  chat_portnums:
-  #    - "RANGE_TEST_APP"          # Additional portnums to treat as relay-eligible
-  #  disabled_portnums: []         # Drop completely: no plugins, no Matrix relay
-  #  encrypted_action: plugin_only # "plugin_only" (default) or "drop"
-  # Note: relay-eligible packets still need a usable channel for Matrix delivery.
-  # If channel is missing, plugins still run and only Matrix relay is skipped.
-  # See docs/ADVANCED_CONFIGURATION.md for behavior details.
-  #message_delay: 2.5 # Delay in seconds between messages sent to mesh (minimum: 2.0 due to firmware)
-  #timeout: 30 # Timeout in seconds for Meshtastic operations (default: 30, library default: 300)
-  # Seconds between refreshes of cached long/short node-name tables from Meshtastic NodeDB.
-  # Set to 0 to disable periodic refresh. Increase on large/busy meshes to reduce overhead;
-  # decrease if names appear stale. Future versions may expand this beyond name caches.
+  #    - "RANGE_TEST_APP"
+  #  disabled_portnums: []
+  #  encrypted_action: plugin_only
+  #message_delay: 2.5
+  #timeout: 30
   #nodedb_refresh_interval: 15.0
-
-  # Message prefix customization (Matrix → Meshtastic direction)
-  #prefix_enabled: true # Enable username prefixes on messages sent to mesh (e.g., "Alice[M]: message")
-  #prefix_format: "{display5}[M]: " # Default format. See ADVANCED_CONFIGURATION.md for all variables.
+  #prefix_enabled: true
+  #prefix_format: "{display5}[M]: "
 
 logging:
   level: info
-  #log_to_file: true                          # Set to true to enable file logging
-  #filename: ~/.mmrelay/logs/mmrelay.log      # Default location if log_to_file is true
-  #max_log_size: 5242880                      # 5 MB default if omitted
-  #backup_count: 1                            # Keeps 1 backup as the default if omitted
-  #color_enabled: true                        # Set to false to disable colored console output
-  #rich_tracebacks: false                     # Show rich tracebacks in console output (defaults to false)
-
-  # Component-specific debug logging (useful for troubleshooting)
-  # Values: true = DEBUG level, false = suppressed, or specify level: "debug", "info", "warning", "error"
+  # See `docs/ADVANCED_CONFIGURATION.md` for logging levels and debug logging.
+  #log_to_file: true
+  #filename: ~/.mmrelay/logs/mmrelay.log
+  #max_log_size: 5242880
+  #backup_count: 1
+  #color_enabled: true
+  #rich_tracebacks: false
   #debug:
-  #  matrix_nio: false      # Suppress matrix-nio logging
-  #  bleak: true             # Enable DEBUG level for BLE
-  #  meshtastic: "warning"   # Enable warning+ level for meshtastic
-  #  full_packets: false     # Log full packet details at DEBUG level (sanitized: removes keys, encrypted payloads)
+  #  matrix_nio: false
+  #  bleak: true
+  #  meshtastic: "warning"
+  #  full_packets: false
 
 #database:
-#  path: ~/.mmrelay/database/meshtastic.sqlite  # Default location
-#  enable_wal: true  # Enable Write-Ahead Logging for better concurrency
-#  busy_timeout_ms: 5000  # Milliseconds to wait if the database is busy
+#  # See `docs/ADVANCED_CONFIGURATION.md` for database settings.
+#  path: ~/.mmrelay/database/meshtastic.sqlite
+#  enable_wal: true
+#  busy_timeout_ms: 5000
 #  pragmas:
 #    synchronous: NORMAL
 #    temp_store: MEMORY
-#  msg_map: # The message map is necessary for the relay_reactions functionality. If `relay_reactions` is set to false, nothing will be saved to the message map.
-#    msgs_to_keep: 500 # If set to 0, it will not delete any messages; Defaults to 500
-#    wipe_on_restart: true # Clears out the message map when the relay is restarted; Defaults to False
+#  msg_map:
+#    msgs_to_keep: 500
+#    wipe_on_restart: true
 
-# These are core Plugins - Note: Some plugins are experimental and some need maintenance.
+# Plugin examples. See `docs/ADVANCED_CONFIGURATION.md` for plugin options.
 plugins:
-  # Global setting for all plugins: require bot mentions for commands
-  #require_bot_mention: true  # Set to false to disable mention requirements for all plugins
-  
   ping:
     active: true
-    #require_bot_mention: true  # Override global setting for this plugin only
-    #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
-    # When false (default): responds only to explicit !ping.
-    # When true: responds to bare mesh-side "ping" messages with "pong".
-    #mimic_mode: false
   weather:
     active: true
-    #require_bot_mention: true  # Override global setting for this plugin only
-    units: imperial # Options: metric, imperial - Default is metric
-    #channels: [] # Empty list, will only respond to DMs
+    units: imperial
   nodes:
     active: true
-    #require_bot_mention: true  # Override global setting for this plugin only
-    # Does not need to specify channels, as it's a Matrix-only plugin
 
 #community-plugins:
 #  sample_plugin:
 #    active: true
 #    repository: https://github.com/username/sample_plugin.git
 #    tag: master
-#  advanced_plugin:
-#    active: false
-#    repository: https://github.com/username/advanced_plugin.git
-#    tag: v1.3.0
-
+#
 #custom-plugins:
 #  my_custom_plugin:
 #    active: true

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -1,98 +1,144 @@
 matrix:
+  # Matrix authentication:
   # Run `mmrelay auth login` before starting MMRelay.
-  # Recommended docs: `docs/INSTRUCTIONS.md` and `docs/E2EE.md`.
+  # This is the normal setup path. Do not fill in `homeserver`,
+  # `bot_user_id`, or `password` here.
+  #
+  # No authentication fields are required in this file when using
+  # `mmrelay auth login`.
   #
   # For Docker/Kubernetes environment-variable auth, see
   # `docs/ADVANCED_CONFIGURATION.md`.
+  # See `docs/INSTRUCTIONS.md` for setup and `docs/E2EE.md` for
+  # End-to-End Encryption configuration.
+
+  # End-to-End Encryption (E2EE) configuration
+  # E2EE is automatically enabled when credentials are available and
+  # E2EE dependencies are installed (Linux/macOS only)
+  # NOTE: E2EE is not available on Windows due to dependency limitations
   #
-  # Legacy password-in-config setup is documented in `docs/INSTRUCTIONS.md`.
-  #homeserver: https://example.matrix.org
-  #bot_user_id: "@botuser:example.matrix.org"
-  #password: your_matrix_password_here
+  # SETUP INSTRUCTIONS:
+  # 1. Install E2EE dependencies: pipx install 'mmrelay[e2e]' (Linux/macOS only)
+  # 2. Authenticate using `mmrelay auth login` to create credentials.json
+  # 3. MMRelay will automatically create credentials.json with E2EE support
+  #
   e2ee:
     enabled: true
 
-matrix_rooms:
-  # Add one or more Matrix room/channel mappings.
-  - id: "#someroomalias:example.matrix.org"
+  # Message prefix customization (Meshtastic -> Matrix direction)
+  #prefix_enabled: true # Enable prefixes on messages from mesh (e.g., "[Alice/MyMesh]: message")
+  #prefix_format: "[{long}/{mesh}]: " # Default format. Variables: {long1-20}, {long}, {short}, {mesh1-20}, {mesh}
+
+matrix_rooms: # Needs at least 1 room & channel, but supports all Meshtastic channels
+  - id: "#someroomalias:example.matrix.org" # Matrix room aliases & IDs supported
     meshtastic_channel: 0
   - id: "!someroomid:example.matrix.org"
     meshtastic_channel: 2
 
 meshtastic:
-  # See `docs/ADVANCED_CONFIGURATION.md` for connection, routing, and prefix options.
-  connection_type: tcp
-  host: meshtastic.local
-  serial_port: /dev/ttyUSB0
-  ble_address: AA:BB:CC:DD:EE:FF
-  meshnet_name: Your Meshnet Name
-  message_interactions:
-    reactions: false
-    replies: false
+  connection_type: tcp # Choose either "tcp", "serial", or "ble"
+  host: meshtastic.local # Only used when connection is "tcp"
+  port: 4403 # TCP port override (default: 4403, only used with "tcp" connection)
+  serial_port: /dev/ttyUSB0 # Only used when connection is "serial"
+  ble_address: AA:BB:CC:DD:EE:FF # Only used when connection is "ble" - Uses either an address or name from a `meshtastic --ble-scan`
+  meshnet_name: Your Meshnet Name # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
+  message_interactions: # Configure reactions and replies (both require message storage in database)
+    reactions: false # Enable reaction relaying between platforms
+    replies: false   # Enable reply relaying between platforms
 
-  broadcast_enabled: true
-
-  # Optional overrides. See `docs/ADVANCED_CONFIGURATION.md`.
+  # Optional connection health monitoring overrides
   #health_check:
-  #  enabled: false
-  #  connect_probe_enabled: false
-  #  heartbeat_interval: 60
-  #  initial_delay: 5
-  #  probe_timeout: 30
+  #  enabled: false                   # Enable periodic health checks (default: false)
+  #  connect_probe_enabled: false     # One-shot metadata probe after connect
+  #  heartbeat_interval: 60           # Seconds between periodic checks (default: 60)
+  #  initial_delay: 5                 # Seconds before first periodic check (default: 5)
+  #  probe_timeout: 30                # Timeout in seconds for each probe (default: 30)
+  # See docs/ADVANCED_CONFIGURATION.md for behavior and legacy-compatibility notes.
+
+  # Additional configuration options (commented out with defaults)
+  broadcast_enabled: true # Must be set to true to enable Matrix to Meshtastic messages
+  #detection_sensor: true # Defaults to true; set to false to disable detection sensor message forwarding
+
+  # Optional packet-routing overrides
   #packet_routing:
   #  chat_portnums:
-  #    - "RANGE_TEST_APP"
-  #  disabled_portnums: []
-  #  encrypted_action: plugin_only
-  #message_delay: 2.5
-  #timeout: 30
+  #    - "RANGE_TEST_APP"          # Additional portnums to treat as relay-eligible
+  #  disabled_portnums: []         # Drop completely: no plugins, no Matrix relay
+  #  encrypted_action: plugin_only # "plugin_only" (default) or "drop"
+  # Note: relay-eligible packets still need a usable channel for Matrix delivery.
+  # If channel is missing, plugins still run and only Matrix relay is skipped.
+  # See docs/ADVANCED_CONFIGURATION.md for behavior details.
+  #message_delay: 2.5 # Delay in seconds between messages sent to mesh (minimum: 2.0 due to firmware)
+  #timeout: 30 # Timeout in seconds for Meshtastic operations (default: 30, library default: 300)
+  # Seconds between refreshes of cached long/short node-name tables from Meshtastic NodeDB.
+  # Set to 0 to disable periodic refresh. Increase on large/busy meshes to reduce overhead;
+  # decrease if names appear stale. Future versions may expand this beyond name caches.
   #nodedb_refresh_interval: 15.0
-  #prefix_enabled: true
-  #prefix_format: "{display5}[M]: "
+
+  # Message prefix customization (Matrix -> Meshtastic direction)
+  #prefix_enabled: true # Enable username prefixes on messages sent to mesh (e.g., "Alice[M]: message")
+  #prefix_format: "{display5}[M]: " # Default format. See ADVANCED_CONFIGURATION.md for all variables.
 
 logging:
   level: info
-  # See `docs/ADVANCED_CONFIGURATION.md` for logging levels and debug logging.
-  #log_to_file: true
-  #filename: ~/.mmrelay/logs/mmrelay.log
-  #max_log_size: 5242880
-  #backup_count: 1
-  #color_enabled: true
-  #rich_tracebacks: false
+  #log_to_file: true                          # Set to true to enable file logging
+  #filename: ~/.mmrelay/logs/mmrelay.log      # Default location if log_to_file is true
+  #max_log_size: 5242880                      # 5 MB default if omitted
+  #backup_count: 1                            # Keeps 1 backup as the default if omitted
+  #color_enabled: true                        # Set to false to disable colored console output
+  #rich_tracebacks: false                     # Show rich tracebacks in console output (defaults to false)
+
+  # Component-specific debug logging (useful for troubleshooting)
+  # Values: true = DEBUG level, false = suppressed, or specify level: "debug", "info", "warning", "error"
   #debug:
-  #  matrix_nio: false
-  #  bleak: true
-  #  meshtastic: "warning"
-  #  full_packets: false
+  #  matrix_nio: false      # Suppress matrix-nio logging
+  #  bleak: true             # Enable DEBUG level for BLE
+  #  meshtastic: "warning"   # Enable warning+ level for meshtastic
+  #  full_packets: false     # Log full packet details at DEBUG level (sanitized: removes keys, encrypted payloads)
 
 #database:
-#  # See `docs/ADVANCED_CONFIGURATION.md` for database settings.
-#  path: ~/.mmrelay/database/meshtastic.sqlite
-#  enable_wal: true
-#  busy_timeout_ms: 5000
+#  path: ~/.mmrelay/database/meshtastic.sqlite  # Default location
+#  enable_wal: true  # Enable Write-Ahead Logging for better concurrency
+#  busy_timeout_ms: 5000  # Milliseconds to wait if the database is busy
 #  pragmas:
 #    synchronous: NORMAL
 #    temp_store: MEMORY
-#  msg_map:
-#    msgs_to_keep: 500
-#    wipe_on_restart: true
+#  msg_map: # The message map is necessary for the relay_reactions functionality. If `relay_reactions` is set to false, nothing will be saved to the message map.
+#    msgs_to_keep: 500 # If set to 0, it will not delete any messages; Defaults to 500
+#    wipe_on_restart: true # Clears out the message map when the relay is restarted; Defaults to False
 
-# Plugin examples. See `docs/ADVANCED_CONFIGURATION.md` for plugin options.
+# These are core Plugins - Note: Some plugins are experimental and some need maintenance.
 plugins:
+  # Global setting for all plugins: require bot mentions for commands
+  #require_bot_mention: true  # Set to false to disable mention requirements for all plugins
+
   ping:
     active: true
+    #require_bot_mention: true  # Override global setting for this plugin only
+    #channels: [2,3,5] # List of channels the plugin will respond to; DMs are always processed if the plugin is active
+    # When false (default): responds only to explicit !ping.
+    # When true: responds to bare mesh-side "ping" messages with "pong".
+    #mimic_mode: false
   weather:
     active: true
-    units: imperial
+    #require_bot_mention: true  # Override global setting for this plugin only
+    units: imperial # Options: metric, imperial - Default is metric
+    #channels: [] # Empty list, will only respond to DMs
   nodes:
     active: true
+    #require_bot_mention: true  # Override global setting for this plugin only
+    # Does not need to specify channels, as it's a Matrix-only plugin
 
 #community-plugins:
 #  sample_plugin:
 #    active: true
 #    repository: https://github.com/username/sample_plugin.git
 #    tag: master
-#
+#  advanced_plugin:
+#    active: false
+#    repository: https://github.com/username/advanced_plugin.git
+#    tag: v1.3.0
+
 #custom-plugins:
 #  my_custom_plugin:
 #    active: true

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -1,21 +1,26 @@
 matrix:
-  # Start with `mmrelay auth login` before running MMRelay.
-  # This is the normal setup path; you do not need to fill in homeserver,
-  # bot_user_id, or password here.
-  # See `docs/INSTRUCTIONS.md`, `docs/E2EE.md`, and
-  # `docs/ADVANCED_CONFIGURATION.md` for the full setup and option reference.
+  # Run `mmrelay auth login` before starting MMRelay.
+  # Recommended docs: `docs/INSTRUCTIONS.md` and `docs/E2EE.md`.
+  #
+  # For Docker/Kubernetes environment-variable auth, see
+  # `docs/ADVANCED_CONFIGURATION.md`.
+  #
+  # Legacy password-in-config setup is documented in `docs/INSTRUCTIONS.md`.
+  #homeserver: https://example.matrix.org
+  #bot_user_id: "@botuser:example.matrix.org"
+  #password: your_matrix_password_here
   e2ee:
     enabled: true
 
 matrix_rooms:
-  # Map Matrix rooms to Meshtastic channels.
+  # Add one or more Matrix room/channel mappings.
   - id: "#someroomalias:example.matrix.org"
     meshtastic_channel: 0
   - id: "!someroomid:example.matrix.org"
     meshtastic_channel: 2
 
 meshtastic:
-  # See `docs/ADVANCED_CONFIGURATION.md` for the full option set.
+  # See `docs/ADVANCED_CONFIGURATION.md` for connection, routing, and prefix options.
   connection_type: tcp
   host: meshtastic.local
   serial_port: /dev/ttyUSB0
@@ -24,11 +29,55 @@ meshtastic:
   message_interactions:
     reactions: false
     replies: false
+
   broadcast_enabled: true
+
+  # Optional overrides. See `docs/ADVANCED_CONFIGURATION.md`.
+  #health_check:
+  #  enabled: false
+  #  connect_probe_enabled: false
+  #  heartbeat_interval: 60
+  #  initial_delay: 5
+  #  probe_timeout: 30
+  #packet_routing:
+  #  chat_portnums:
+  #    - "RANGE_TEST_APP"
+  #  disabled_portnums: []
+  #  encrypted_action: plugin_only
+  #message_delay: 2.5
+  #timeout: 30
+  #nodedb_refresh_interval: 15.0
+  #prefix_enabled: true
+  #prefix_format: "{display5}[M]: "
 
 logging:
   level: info
+  # See `docs/ADVANCED_CONFIGURATION.md` for logging levels and debug logging.
+  #log_to_file: true
+  #filename: ~/.mmrelay/logs/mmrelay.log
+  #max_log_size: 5242880
+  #backup_count: 1
+  #color_enabled: true
+  #rich_tracebacks: false
+  #debug:
+  #  matrix_nio: false
+  #  bleak: true
+  #  meshtastic: "warning"
+  #  full_packets: false
 
+#database:
+#  # See `docs/ADVANCED_CONFIGURATION.md` for database settings.
+#  path: ~/.mmrelay/database/meshtastic.sqlite
+#  enable_wal: true
+#  busy_timeout_ms: 5000
+#  pragmas:
+#    synchronous: NORMAL
+#    temp_store: MEMORY
+#  msg_map:
+#    msgs_to_keep: 500
+#    wipe_on_restart: true
+
+# Plugin examples. See `docs/ADVANCED_CONFIGURATION.md` for plugin options.
 plugins:
   ping:
     active: true
@@ -37,3 +86,15 @@ plugins:
     units: imperial
   nodes:
     active: true
+
+#community-plugins:
+#  sample_plugin:
+#    active: true
+#    repository: https://github.com/username/sample_plugin.git
+#    tag: master
+#
+#custom-plugins:
+#  my_custom_plugin:
+#    active: true
+#  another_custom_plugin:
+#    active: false

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -15,8 +15,7 @@ matrix:
   #   MMRELAY_MATRIX_ACCESS_TOKEN=your_access_token  # Optional alternative to password
   # Best for: Kubernetes deployments with secrets, automated CI/CD
   # NO CONFIG FIELDS NEEDED - environment variables provide all authentication data
-  # Tip (Kubernetes): set credentials_path to a writable PVC location
-  # credentials_path: /data/matrix/credentials.json
+  # Note: MMRELAY_HOME controls the base directory for credentials (default: ~/.mmrelay)
   #
   # Method 3 (LEGACY): Password in config.yaml (NOT RECOMMENDED)
   # Uncomment the fields below. MMRelay will create credentials.json on first run.
@@ -26,7 +25,6 @@ matrix:
   #homeserver: https://example.matrix.org
   #bot_user_id: "@botuser:example.matrix.org"
   #password: your_matrix_password_here
-  #credentials_path: /data/matrix/credentials.json
   #
   # See docs/KUBERNETES.md for Kubernetes-specific authentication setup
   # See docs/E2EE.md for End-to-End Encryption configuration

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -38,9 +38,9 @@ matrix_rooms: # Needs at least 1 room & channel, but supports all Meshtastic cha
 meshtastic:
   connection_type: tcp # Choose either "tcp", "serial", or "ble"
   host: meshtastic.local # Only used when connection is "tcp"
-  port: 4403 # TCP port override (default: 4403, only used with "tcp" connection)
-  serial_port: /dev/ttyUSB0 # Only used when connection is "serial"
-  ble_address: AA:BB:CC:DD:EE:FF # Only used when connection is "ble" - Uses either an address or name from a `meshtastic --ble-scan`
+  #port: 4403 # TCP port override (default: 4403, only used with "tcp" connection)
+  #serial_port: /dev/ttyUSB0 # Only used when connection is "serial"
+  #ble_address: AA:BB:CC:DD:EE:FF # Only used when connection is "ble" - Uses either an address or name from a `meshtastic --ble-scan`
   meshnet_name: Your Meshnet Name # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
   message_interactions: # Configure reactions and replies (both require message storage in database)
     reactions: false # Enable reaction relaying between platforms

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -59,6 +59,7 @@ matrix_rooms: # Needs at least 1 room & channel, but supports all Meshtastic cha
 meshtastic:
   connection_type: tcp # Choose either "tcp", "serial", or "ble"
   host: meshtastic.local # Only used when connection is "tcp"
+  #port: 4403 # TCP port override (default: 4403, only used with "tcp" connection)
   serial_port: /dev/ttyUSB0 # Only used when connection is "serial"
   ble_address: AA:BB:CC:DD:EE:FF # Only used when connection is "ble" - Uses either an address or name from a `meshtastic --ble-scan`
   meshnet_name: Your Meshnet Name # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
@@ -77,7 +78,7 @@ meshtastic:
 
   # Additional configuration options (commented out with defaults)
   broadcast_enabled: true # Must be set to true to enable Matrix to Meshtastic messages
-  #detection_sensor: true # Must be set to true to forward messages of Meshtastic's detection sensor module
+  #detection_sensor: true # Defaults to true; set to false to disable detection sensor message forwarding
 
   # Optional packet-routing overrides
   #packet_routing:
@@ -88,7 +89,7 @@ meshtastic:
   # Note: relay-eligible packets still need a usable channel for Matrix delivery.
   # If channel is missing, plugins still run and only Matrix relay is skipped.
   # See docs/ADVANCED_CONFIGURATION.md for behavior details.
-  #message_delay: 2.2 # Delay in seconds between messages sent to mesh (minimum: 2.0 due to firmware)
+  #message_delay: 2.5 # Delay in seconds between messages sent to mesh (minimum: 2.0 due to firmware)
   #timeout: 30 # Timeout in seconds for Meshtastic operations (default: 30, library default: 300)
   # Seconds between refreshes of cached long/short node-name tables from Meshtastic NodeDB.
   # Set to 0 to disable periodic refresh. Increase on large/busy meshes to reduce overhead;
@@ -103,7 +104,7 @@ logging:
   level: info
   #log_to_file: true                          # Set to true to enable file logging
   #filename: ~/.mmrelay/logs/mmrelay.log      # Default location if log_to_file is true
-  #max_log_size: 10485760                     # 10 MB default if omitted
+  #max_log_size: 5242880                      # 5 MB default if omitted
   #backup_count: 1                            # Keeps 1 backup as the default if omitted
   #color_enabled: true                        # Set to false to disable colored console output
   #rich_tracebacks: false                     # Show rich tracebacks in console output (defaults to false)
@@ -117,7 +118,7 @@ logging:
   #  full_packets: false     # Log full packet details at DEBUG level (sanitized: removes keys, encrypted payloads)
 
 #database:
-#  path: ~/.mmrelay/data/meshtastic.sqlite   # Default location
+#  path: ~/.mmrelay/database/meshtastic.sqlite  # Default location
 #  enable_wal: true  # Enable Write-Ahead Logging for better concurrency
 #  busy_timeout_ms: 5000  # Milliseconds to wait if the database is busy
 #  pragmas:

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -987,6 +987,26 @@ class TestMeshtasticUtils(unittest.TestCase):
         assert result is False
         assert mu._relay_startup_drain_complete_event.is_set() is True
 
+    def test_rollback_connect_attempt_none_event_is_safe_noop(self):
+        """Rollback should not raise AttributeError when the drain event is None."""
+        import mmrelay.meshtastic_utils as mu
+
+        mu._relay_startup_drain_expiry_timer = MagicMock()
+        mu._relay_startup_drain_deadline_monotonic_secs = 123.0
+        mu._startup_packet_drain_applied = True
+
+        with patch.object(mu, "get_startup_drain_complete_event", return_value=None):
+            result = mu._rollback_connect_attempt_state(
+                client=None,
+                client_assigned_for_this_connect=False,
+                startup_drain_armed_for_this_connect=True,
+                startup_drain_applied_for_this_connect=True,
+                reconnect_bootstrap_armed_for_this_connect=False,
+            )
+
+        assert result is False
+        assert mu._relay_startup_drain_deadline_monotonic_secs is None
+
     def test_send_text_reply_success(self):
         """
         Test that send_text_reply returns the expected result when sending a text reply succeeds.

--- a/tests/test_runtime_utils.py
+++ b/tests/test_runtime_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from typing import IO, Any, Callable
-from unittest.mock import mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 from mmrelay import runtime_utils
 
@@ -65,6 +65,22 @@ def test_is_running_as_service_false_when_parent_is_not_systemd() -> None:
         assert runtime_utils.is_running_as_service() is False
 
 
+def test_is_running_as_service_false_when_ppid_is_zero() -> None:
+    """Invalid parent PID 0 should return False without reading /proc/0/comm."""
+    status_handle = mock_open(read_data="Name:\tpython\nPPid:\t0\n").return_value
+
+    def _side_effect(path: str, *args: Any, **kwargs: Any) -> IO[Any]:
+        if path == runtime_utils.PROC_SELF_STATUS_PATH:
+            return status_handle
+        raise AssertionError(f"unexpected proc access: {path}")
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("builtins.open", side_effect=_side_effect),
+    ):
+        assert runtime_utils.is_running_as_service() is False
+
+
 def test_is_running_as_service_false_on_ppid_parse_error() -> None:
     """PPid parse error should safely return False."""
     with (
@@ -82,11 +98,17 @@ def test_is_running_as_service_false_on_ppid_parse_error() -> None:
 
 def test_is_running_as_service_false_on_file_not_found() -> None:
     """File not found error should safely return False."""
+    mock_logger = Mock()
     with (
         patch.dict(os.environ, {}, clear=True),
+        patch("mmrelay.runtime_utils._get_logger", return_value=mock_logger),
         patch("builtins.open", side_effect=FileNotFoundError("missing /proc")),
     ):
         assert runtime_utils.is_running_as_service() is False
+    mock_logger.debug.assert_called_once_with(
+        "Service detection unavailable via proc filesystem",
+        extra={"error_type": "FileNotFoundError"},
+    )
 
 
 def test_is_running_as_service_false_when_status_has_no_ppid_line() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This patch (1.3.3) tightens and corrects documentation and deployment artifacts, standardizes the runtime ready-file to /tmp/mmrelay-ready, bumps image/chart/kustomize versions to 1.3.3, improves container health checks and service-detection robustness, and adds a developer plan to remove explicit credentials/store-path configurability.

Key changes

Features
- Bumped Helm chart metadata, image defaults and kustomize image override to 1.3.3 (Chart.yaml, values.yaml, deploy/k8s/kustomization.yaml).
- Added CLI command mappings: config_paths, config_diagnose, auth_logout, service_migrate, paths, doctor, verify_migration, migrate (src/mmrelay/constants/cli.py).
- Added UID and GID placeholders to sample.env for container UID/GID mapping.
- Docs: added make targets/diagnostic commands (update-compose, doctor, paths) and new CLI/help coverage.

Fixes (docs, deployment, samples)
- Unified ready-file path to /tmp/mmrelay-ready across Dockerfile, Kubernetes manifests, Helm values, docker-compose samples, and documentation; readiness/startup probes now reference MMRELAY_READY_FILE or test -f "$MMRELAY_READY_FILE" where applicable.
- Removed /run/mmrelay emptyDir volume and /run/mmrelay container mounts from Kubernetes and Helm templates and corresponding docs.
- Dockerfile: updated MMRELAY_READY_FILE, reduced HEALTHCHECK --timeout from 10s → 5s, and added hadolint DL3013 suppression on the build RUN step.
- Docker Compose / sample-compose: healthcheck now first ensures the ready-file exists then checks freshness (modified within last 2 minutes); docs reflect increased start_period to 60s and the freshness-based health predicate.
- Documentation updates and clarifications:
  - Helm/Helm examples and docs pin image tag 1.3.3 and replace credentials Secret guidance with a matrixAuth bootstrap flow (or explicit manual credentials.json mounting when matrixAuth.enabled=false).
  - Advanced configuration docs: added MMRELAY_HOME and MMRELAY_LOG_PATH, explicit Matrix env→config mappings (MMRELAY_MATRIX_*), and clarified MMRELAY_LOG_FILE behavior.
  - Kubernetes docs: prefer pinned image tags, change example selector to app=mmrelay, update probe/troubleshooting examples to /tmp/mmrelay-ready, and set networkPolicy example default to disabled.
  - Docker docs: clarified SELinux volume mapping guidance (default host mapping without :Z; :Z shown as optional).
  - INSTRUCTIONS/WHATS_NEW: removed outdated OIDC/MAS language, set Python requirement to 3.10+, and adjusted Windows default home path to %LOCALAPPDATA%/mmrelay.
- Checkov/annotation: templated image tag used in skip annotation instead of hardcoded 1.3.0.
- Sample config: simplified Matrix auth guidance to prefer mmrelay auth login and MMRELAY_HOME-derived credentials; normalized various comment defaults and examples.

Refactors / Plans
- Added developer proposal document (docs/dev/2026-04-10-remove-credentials-store-path-configurability.md) to remove user-configurable credentials_path and E2EE store_path, deriving paths solely from MMRELAY_HOME; includes implementation checklist, test changes, and migration/verification guidance.

Runtime / robustness
- Improved service-detection logic (runtime_utils.is_running_as_service) to treat invalid PPid (≤ 0) as False and refine exception handling and logging semantics.

Tests
- Added unit tests covering None startup-drain-complete event handling and PPid=0 proc behavior (tests/test_meshtastic_utils.py, tests/test_runtime_utils.py).

Miscellaneous
- .gitignore: add top-level .codex ignore.
- .trunk/trunk.yaml: bumped lint tool pins (prettier, ruff) and added dotenv-linter ignore for sample.env.
- Small runtime fix: validate parent PID and improve error handling in service detection.

Breaking changes & migration notes

- Ready-file path: update external probes, manifests, monitoring, or scripts that reference /run/mmrelay/ready to /tmp/mmrelay-ready or use $MMRELAY_READY_FILE.
- Helm credentials model: chart docs now describe a matrixAuth bootstrap that writes /data/matrix/credentials.json. If you used the prior credentials Secret model, follow HELM.md migration options (use matrixAuth settings or mount an existing credentials.json via extraVolumes/extraVolumeMounts and disable the bootstrap).
- Planned removal: a future refactor will remove explicit credentials_path and store_path config/env overrides—review the developer plan if your deployments or automation rely on those overrides.
- Runtime: documented minimum Python runtime is now 3.10+; upgrade runtimes before adopting this release if running Python 3.8/3.9.
- Windows paths: default data location changed to %LOCALAPPDATA%/mmrelay; update local scripts or documentation if they reference the old %APPDATA% path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->