### PR TITLE
Harden community plugin handling + simplify dependency install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ community-plugins:
 ```
 
 Community plugins run in the same MMRelay process and inherit its permissions. Use trusted sources and prefer commit-pinned refs.
+Community plugin dependency installation is disabled by default; enable it only for trusted repositories with `security.auto_install_deps: true`.
 
 ### Plugin System
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 
 > **Encryption note**: MMRelay supports encrypted Matrix rooms (Matrix E2EE). For details on how this works and its security implications, see the [E2EE Setup Guide](docs/E2EE.md).
 >
-> **BLE integration note (v1.3.3)**: MMRelay now integrates with [mtjk (Meshtastic Python fork)](https://github.com/jeremiah-k/mtjk) while preserving compatibility boundaries for older Meshtastic Python BLE interfaces. Technical details: [BLE Dual-Library Compatibility](docs/dev/BLE_DUAL_LIBRARY_COMPATIBILITY.md).
+> **Improved BLE stability (v1.3.3)**: BLE reliability improved in v1.3.3 after switching BLE handling to [mtjk](https://github.com/jeremiah-k/mtjk).
 
 ## Documentation
 
@@ -53,18 +53,22 @@ Produce high-level details about your mesh:
 
 See the full list of [core plugins](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Core-Plugins).
 
-### Community & Custom Plugins
+### Plugin System
 
-MMRelay's plugin system allows you to extend functionality in two ways:
+MMRelay supports three plugin types:
 
-- **Custom Plugins**: Create personal plugins for your own use, stored in `~/.mmrelay/plugins/custom/`
-- **Community Plugins**: Share your creations with others or use plugins developed by the community
+- **Core Plugins**: Built in with MMRelay
+- **Community Plugins**: Git-based plugins that MMRelay syncs for you
+- **Custom Plugins**: Local/manual plugins for private use and development
+
+MMRelay manages plugin directories under `MMRELAY_HOME` (default `~/.mmrelay`).
+Most users only need `config.yaml`; path details matter mainly when authoring custom plugins.
 
 Check the [Community Plugins Development Guide](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Community-Plugin-Development-Guide) in our wiki to get started.
 
 ✨️ Visit the [Community Plugins List](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Community-Plugin-List)!
 
-#### Install a Community Plugin
+### Install a Community Plugin
 
 Add the repository under the `community-plugins` section in `config.yaml`:
 
@@ -83,14 +87,6 @@ community-plugins:
 - Explicit `branch` and `tag` refs are allowed for dependency install, but MMRelay logs warnings.
 - Missing ref (implicit default branch) is not eligible for dependency install.
 - Dependencies install once per resolved local commit and are skipped when unchanged.
-
-### Plugin System
-
-Plugins make it easy to extend functionality without modifying the core program. MMRelay features a powerful plugin system with standardized locations:
-
-- **Core Plugins**: Pre-installed with the package
-- **Custom Plugins**: Your own plugins in `~/.mmrelay/plugins/custom/`
-- **Community Plugins**: Third-party plugins in `~/.mmrelay/plugins/community/`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ community-plugins:
     install_requirements: true
 ```
 
-Community plugins run in the same MMRelay process and inherit its permissions. Use trusted sources and prefer commit-pinned refs.
-Dependency installation is per-plugin: set `install_requirements: true` only for trusted plugins.
-When `install_requirements: true` is used with explicit `branch` or `tag` refs, MMRelay logs a warning but allows installation.
-When no ref is specified (implicit default branch), MMRelay logs a warning and skips dependency installation.
-Requirements are installed once per resolved local commit and skipped when that commit is unchanged.
+- Community plugins run in the same MMRelay process and inherit its permissions. Use trusted sources.
+- Dependency installation is per-plugin and defaults to off (`install_requirements: false`).
+- Prefer commit-pinned refs.
+- Explicit `branch` and `tag` refs are allowed for dependency install, but MMRelay logs warnings.
+- Missing ref (implicit default branch) is not eligible for dependency install.
+- Dependencies install once per resolved local commit and are skipped when unchanged.
 
 ### Plugin System
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@ community-plugins:
     active: true
     repository: https://github.com/jeremiah-k/mmr-plugin-template.git
     commit: 0123456789abcdef0123456789abcdef01234567
+    install_requirements: true
 ```
 
 Community plugins run in the same MMRelay process and inherit its permissions. Use trusted sources and prefer commit-pinned refs.
-Community plugin dependency installation is disabled by default; enable it only for trusted repositories with `security.auto_install_deps: true`.
+Dependency installation is per-plugin: set `install_requirements: true` only for trusted plugins pinned to a full commit SHA.
+When `install_requirements: true` is used with `branch`, `tag`, or no ref, MMRelay logs a warning and skips installation.
+For commit-pinned plugins, requirements are installed once per commit and skipped when the pinned revision is unchanged.
 
 ### Plugin System
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ community-plugins:
   example-plugin:
     active: true
     repository: https://github.com/jeremiah-k/mmr-plugin-template.git
-    tag: main
+    commit: 0123456789abcdef0123456789abcdef01234567
 ```
+
+Community plugins run in the same MMRelay process and inherit its permissions. Use trusted sources and prefer commit-pinned refs.
 
 ### Plugin System
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ community-plugins:
 ```
 
 Community plugins run in the same MMRelay process and inherit its permissions. Use trusted sources and prefer commit-pinned refs.
-Dependency installation is per-plugin: set `install_requirements: true` only for trusted plugins pinned to a full commit SHA.
-When `install_requirements: true` is used with `branch`, `tag`, or no ref, MMRelay logs a warning and skips installation.
-For commit-pinned plugins, requirements are installed once per commit and skipped when the pinned revision is unchanged.
+Dependency installation is per-plugin: set `install_requirements: true` only for trusted plugins.
+When `install_requirements: true` is used with explicit `branch` or `tag` refs, MMRelay logs a warning but allows installation.
+When no ref is specified (implicit default branch), MMRelay logs a warning and skips dependency installation.
+Requirements are installed once per resolved local commit and skipped when that commit is unchanged.
 
 ### Plugin System
 

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -3104,7 +3104,6 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
         # Determine what to use (commit, tag, branch, or default)
         # Priority: commit > tag > branch
         explicit_branch_ref = False
-        allow_moving_ref = plugin_info.get("allow_moving_ref") is True
         if commit:
             if tag or branch:
                 logger.warning(
@@ -3134,7 +3133,7 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
         if ref["type"] == "tag" and not tag_ref_warning_logged:
             logger.warning("Tags can be retargeted; commit pins are safer")
             tag_ref_warning_logged = True
-        elif ref["type"] == "branch" and explicit_branch_ref and not allow_moving_ref:
+        elif ref["type"] == "branch" and explicit_branch_ref:
             logger.warning(
                 "Branch refs are moving targets and not recommended in production"
             )
@@ -3197,10 +3196,9 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                     validation_result.repo_url,
                     repo_path,
                 )
-            if _check_auto_install_enabled(config, plugin_type=PLUGIN_TYPE_COMMUNITY):
-                _install_requirements_for_repo(
-                    repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
-                )
+            _install_requirements_for_repo(
+                repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
+            )
             ready_community_plugins.append(plugin_name)
         else:
             logger.error("Repository URL not specified for a community plugin")

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -2,6 +2,7 @@
 import hashlib
 import importlib
 import importlib.util
+import json
 import os
 import re
 import shlex
@@ -13,6 +14,7 @@ import tempfile
 import threading
 import time
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from types import ModuleType
 from typing import Any, Final, Iterator, NamedTuple, NoReturn, Sequence, cast
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
@@ -105,6 +107,9 @@ _global_scheduler_stop_event: threading.Event | None = None
 # Plugin dependency directory (may not be set if base dir can't be resolved)
 _PLUGIN_DEPS_DIR: str | None = None
 PLUGIN_REQUIREMENTS_FILENAME: Final[str] = "requirements.txt"
+PLUGIN_STATE_FILENAME: Final[str] = ".mmrelay-plugin-state.json"
+COMMUNITY_PLUGIN_UPDATE_CHECK_INTERVAL: Final[timedelta] = timedelta(hours=24)
+_community_dep_install_warning_logged = False
 
 
 def _is_safe_plugin_name(name: str) -> bool:
@@ -729,9 +734,10 @@ def _reset_caches_for_tests() -> None:
 
     Sets the module globals `sorted_active_plugins` to an empty list and `plugins_loaded` to False to ensure test isolation.
     """
-    global sorted_active_plugins, plugins_loaded
+    global sorted_active_plugins, plugins_loaded, _community_dep_install_warning_logged
     sorted_active_plugins = []
     plugins_loaded = False
+    _community_dep_install_warning_logged = False
 
 
 def _refresh_dependency_paths() -> None:
@@ -786,7 +792,11 @@ def _refresh_dependency_paths() -> None:
     importlib.invalidate_caches()
 
 
-def _install_requirements_for_repo(repo_path: str, repo_name: str) -> None:
+def _install_requirements_for_repo(
+    repo_path: str,
+    repo_name: str,
+    plugin_type: str = PLUGIN_TYPE_CUSTOM,
+) -> None:
     """
     Install dependencies listed in repo_path/requirements.txt for a community plugin and refresh import paths.
 
@@ -804,12 +814,22 @@ def _install_requirements_for_repo(repo_path: str, repo_name: str) -> None:
     if not os.path.isfile(requirements_path):
         return
 
-    if not _check_auto_install_enabled(config):
+    if not _check_auto_install_enabled(config, plugin_type=plugin_type):
         logger.warning(
             "Auto-install of requirements for %s disabled by config; skipping.",
             repo_name,
         )
         return
+
+    global _community_dep_install_warning_logged
+    if (
+        plugin_type == PLUGIN_TYPE_COMMUNITY
+        and not _community_dep_install_warning_logged
+    ):
+        logger.warning(
+            "Community plugin dependencies execute arbitrary code and are unsafe"
+        )
+        _community_dep_install_warning_logged = True
 
     try:
         in_pipx = any(key in os.environ for key in PIPX_ENVIRONMENT_KEYS)
@@ -1120,21 +1140,32 @@ def _run_git(
     return _run(cmd, timeout=timeout, **kwargs)
 
 
-def _check_auto_install_enabled(config: Any) -> bool:
+def _check_auto_install_enabled(
+    config: Any, plugin_type: str = PLUGIN_TYPE_CUSTOM
+) -> bool:
     """
-    Determine whether automatic dependency installation is enabled for the given configuration.
+    Determine whether automatic dependency installation is enabled for the given configuration and plugin type.
 
     Parameters:
-        config (dict|Any): Configuration mapping expected to contain a "security" dict with an optional
-            boolean "auto_install_deps" key. If `config` is falsy or missing the key, automatic
-            installation is considered enabled by default.
+        config (dict|Any): Configuration mapping expected to contain a "security" dict
+            with an optional boolean "auto_install_deps" key.
+        plugin_type (str): Plugin source category. Community plugin dependency
+            auto-install is disabled by default unless explicitly enabled in config.
 
     Returns:
-        True if automatic installation is enabled, False otherwise.
+        True if automatic installation is enabled for the plugin type, False otherwise.
     """
-    if not config:
-        return True
-    return bool(config.get("security", {}).get("auto_install_deps", True))
+    if not isinstance(config, dict):
+        return plugin_type != PLUGIN_TYPE_COMMUNITY
+
+    security_config = config.get("security", {})
+    if not isinstance(security_config, dict):
+        security_config = {}
+
+    # Keep existing custom plugin behavior, but require explicit opt-in for
+    # community plugin dependency installation.
+    default_enabled = plugin_type != PLUGIN_TYPE_COMMUNITY
+    return bool(security_config.get("auto_install_deps", default_enabled))
 
 
 def _raise_install_error(pkg_name: str) -> NoReturn:
@@ -1151,6 +1182,321 @@ def _raise_install_error(pkg_name: str) -> NoReturn:
         f"Auto-install disabled; cannot install {pkg_name}. See docs for enabling."
     )
     raise subprocess.CalledProcessError(1, "pip/pipx")
+
+
+def _state_file_path(repo_path: str) -> str:
+    """
+    Build the plugin state file path for a community plugin repository.
+
+    Parameters:
+        repo_path (str): Filesystem path to the plugin repository.
+
+    Returns:
+        str: Absolute path to the state file inside the repository.
+    """
+    return os.path.join(repo_path, PLUGIN_STATE_FILENAME)
+
+
+def _load_plugin_state(repo_path: str) -> dict[str, Any]:
+    """
+    Load persisted community plugin state from disk.
+
+    Parameters:
+        repo_path (str): Filesystem path to the plugin repository.
+
+    Returns:
+        dict[str, Any]: Parsed state object, or an empty dict if unavailable.
+    """
+    state_path = _state_file_path(repo_path)
+    try:
+        with open(state_path, encoding=DEFAULT_TEXT_ENCODING) as handle:
+            loaded_state = json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        logger.debug("Failed to read plugin state file %s: %s", state_path, exc)
+        return {}
+
+    if isinstance(loaded_state, dict):
+        return cast(dict[str, Any], loaded_state)
+
+    logger.debug("Ignoring invalid plugin state in %s: expected object", state_path)
+    return {}
+
+
+def _save_plugin_state(repo_path: str, state: dict[str, Any]) -> None:
+    """
+    Persist community plugin state to disk using an atomic replace.
+
+    Parameters:
+        repo_path (str): Filesystem path to the plugin repository.
+        state (dict[str, Any]): Serializable state mapping to persist.
+    """
+    state_path = _state_file_path(repo_path)
+    tmp_path: str | None = None
+    try:
+        os.makedirs(repo_path, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding=DEFAULT_TEXT_ENCODING,
+            delete=False,
+            dir=repo_path,
+        ) as temp_handle:
+            json.dump(state, temp_handle, indent=2, sort_keys=True)
+            temp_handle.write("\n")
+            tmp_path = temp_handle.name
+        os.replace(tmp_path, state_path)
+    except (OSError, TypeError, ValueError) as exc:
+        logger.debug("Failed to write plugin state file %s: %s", state_path, exc)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def _parse_state_timestamp(value: Any) -> datetime | None:
+    """
+    Parse an ISO timestamp from plugin state.
+
+    Parameters:
+        value (Any): Raw timestamp value from state.
+
+    Returns:
+        datetime | None: Parsed UTC datetime, or None when invalid.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _resolve_remote_default_branch(repo_path: str) -> str | None:
+    """
+    Resolve the remote default branch name for origin.
+
+    Parameters:
+        repo_path (str): Filesystem path to the plugin repository.
+
+    Returns:
+        str | None: Default branch name (for example "main"), or None.
+    """
+    try:
+        result = _run_git(
+            [
+                "git",
+                "-C",
+                repo_path,
+                "ls-remote",
+                "--symref",
+                GIT_REMOTE_ORIGIN,
+                "HEAD",
+            ],
+            timeout=GIT_COMMAND_TIMEOUT_SECONDS,
+            capture_output=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return None
+
+    for line in result.stdout.splitlines():
+        if not line.startswith("ref: ") or not line.endswith("\tHEAD"):
+            continue
+        ref_value = line.split("\t", 1)[0].replace("ref: ", "", 1).strip()
+        prefix = "refs/heads/"
+        if ref_value.startswith(prefix):
+            return ref_value[len(prefix) :]
+    return None
+
+
+def _resolve_local_head_commit(repo_path: str) -> str | None:
+    """
+    Resolve the current local HEAD commit SHA for a repository.
+
+    Parameters:
+        repo_path (str): Filesystem path to the plugin repository.
+
+    Returns:
+        str | None: Full commit SHA, or None when unavailable.
+    """
+    try:
+        result = _run_git(
+            ["git", "-C", repo_path, GIT_REV_PARSE_CMD, GIT_REF_HEAD],
+            timeout=GIT_COMMAND_TIMEOUT_SECONDS,
+            capture_output=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return None
+
+    commit_sha = result.stdout.strip()
+    return commit_sha if COMMIT_HASH_PATTERN.fullmatch(commit_sha) else None
+
+
+def _resolve_remote_branch_head_commit(repo_path: str, branch_name: str) -> str | None:
+    """
+    Resolve the remote HEAD commit SHA for a specific branch on origin.
+
+    Parameters:
+        repo_path (str): Filesystem path to the plugin repository.
+        branch_name (str): Branch name to resolve.
+
+    Returns:
+        str | None: Commit SHA for origin/<branch_name>, or None.
+    """
+    try:
+        result = _run_git(
+            [
+                "git",
+                "-C",
+                repo_path,
+                "ls-remote",
+                GIT_REMOTE_ORIGIN,
+                f"refs/heads/{branch_name}",
+            ],
+            timeout=GIT_COMMAND_TIMEOUT_SECONDS,
+            capture_output=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+        return None
+
+    first_line = next((line.strip() for line in result.stdout.splitlines() if line), "")
+    if not first_line:
+        return None
+    remote_sha = first_line.split("\t", 1)[0].strip()
+    return remote_sha if COMMIT_HASH_PATTERN.fullmatch(remote_sha) else None
+
+
+def _get_repo_host_info(repo_url: str) -> tuple[str, str, str] | None:
+    """
+    Extract host, owner, and repository name from a GitHub-style URL.
+
+    Supports:
+    - https://github.com/owner/repo.git
+    - git@github.com:owner/repo.git
+
+    Parameters:
+        repo_url (str): Repository URL to parse.
+
+    Returns:
+        tuple[str, str, str] | None: (host, owner, repo_name), or None if parsing fails.
+    """
+    trimmed_url = (repo_url or "").strip()
+    if not trimmed_url:
+        return None
+
+    ssh_match = re.match(r"^git@([^:]+):([^/]+)/([^/]+?)(?:\.git)?/?$", trimmed_url)
+    if ssh_match:
+        host, owner, repo_name = ssh_match.groups()
+        return host.lower(), owner, repo_name
+
+    parsed = urlsplit(trimmed_url)
+    host = (parsed.hostname or "").lower()
+    path = (parsed.path or "").strip("/")
+    parts = path.split("/")
+    if not host or len(parts) < 2:
+        return None
+    owner = parts[0]
+    repo_name = parts[1]
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+    if not owner or not repo_name:
+        return None
+    return host, owner, repo_name
+
+
+def _build_compare_url(repo_url: str, base_sha: str, head_sha: str) -> str | None:
+    """
+    Build a GitHub compare URL between two explicit commits.
+
+    Parameters:
+        repo_url (str): Repository URL.
+        base_sha (str): Older/base commit SHA.
+        head_sha (str): Newer/head commit SHA.
+
+    Returns:
+        str | None: Compare URL for GitHub repositories, otherwise None.
+    """
+    if not base_sha or not head_sha:
+        return None
+
+    repo_info = _get_repo_host_info(repo_url)
+    if repo_info is None:
+        return None
+    host, owner, repo_name = repo_info
+    if host != "github.com":
+        return None
+
+    return f"https://github.com/{owner}/{repo_name}/compare/{base_sha}...{head_sha}"
+
+
+def _check_commit_pin_for_upstream_updates(
+    plugin_name: str,
+    repo_url: str,
+    repo_path: str,
+) -> None:
+    """
+    Check whether a commit-pinned community plugin is behind the upstream default branch.
+
+    The check is throttled by the state file's `last_checked_at` value and never
+    raises. It only logs a new notification when upstream default-branch HEAD
+    changes since the last notification.
+
+    Parameters:
+        plugin_name (str): Configured plugin name for logging.
+        repo_url (str): Repository URL used for optional compare URL generation.
+        repo_path (str): Filesystem path to the checked-out repository.
+    """
+    try:
+        state = _load_plugin_state(repo_path)
+        now = datetime.now(timezone.utc)
+        last_checked_at = _parse_state_timestamp(state.get("last_checked_at"))
+        if (
+            last_checked_at is not None
+            and now - last_checked_at < COMMUNITY_PLUGIN_UPDATE_CHECK_INTERVAL
+        ):
+            return
+
+        pinned_sha = _resolve_local_head_commit(repo_path)
+        default_branch = _resolve_remote_default_branch(repo_path)
+        upstream_sha = None
+        if default_branch:
+            upstream_sha = _resolve_remote_branch_head_commit(repo_path, default_branch)
+
+        if default_branch:
+            state["last_seen_default_branch"] = default_branch
+        if upstream_sha:
+            state["last_seen_default_branch_head"] = upstream_sha
+
+        if pinned_sha and upstream_sha and upstream_sha != pinned_sha:
+            last_notified_upstream = state.get("last_notified_upstream_head")
+            if not isinstance(last_notified_upstream, str):
+                last_notified_upstream = ""
+            if upstream_sha != last_notified_upstream:
+                logger.warning(
+                    "Plugin '%s' is pinned to %s, upstream is now %s",
+                    plugin_name,
+                    pinned_sha,
+                    upstream_sha,
+                )
+                compare_url = _build_compare_url(repo_url, pinned_sha, upstream_sha)
+                if compare_url:
+                    logger.warning("Compare: %s", compare_url)
+                state["last_notified_upstream_head"] = upstream_sha
+
+        state["last_checked_at"] = now.isoformat()
+        _save_plugin_state(repo_path, state)
+    except Exception as exc:  # pragma: no cover - defensive safety net
+        logger.debug(
+            "Failed to check upstream updates for community plugin %s: %s",
+            plugin_name,
+            exc,
+        )
 
 
 def _fetch_commit_with_fallback(repo_path: str, ref_value: str, repo_name: str) -> bool:
@@ -2609,6 +2955,7 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
         CONFIG_SECTION_COMMUNITY_PLUGINS, community_plugins_config
     )
     ready_community_plugins = []
+    tag_ref_warning_logged = False
 
     if active_community_plugins:
         # Ensure all community plugin directories exist
@@ -2695,6 +3042,8 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
 
         # Determine what to use (commit, tag, branch, or default)
         # Priority: commit > tag > branch
+        explicit_branch_ref = False
+        allow_moving_ref = plugin_info.get("allow_moving_ref") is True
         if commit:
             if tag or branch:
                 logger.warning(
@@ -2710,9 +3059,21 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
             ref = {"type": "tag", "value": tag}
         elif branch:
             ref = {"type": "branch", "value": branch}
+            explicit_branch_ref = True
         else:
             # Default to the first configured default branch if neither is specified.
+            logger.warning(
+                "No ref specified; defaulting to branch 'main' is deprecated and unsafe"
+            )
             ref = {"type": "branch", "value": DEFAULT_BRANCHES[0]}
+
+        if ref["type"] == "tag" and not tag_ref_warning_logged:
+            logger.warning("Tags can be retargeted; commit pins are safer")
+            tag_ref_warning_logged = True
+        elif ref["type"] == "branch" and explicit_branch_ref and not allow_moving_ref:
+            logger.warning(
+                "Branch refs are moving targets and not recommended in production"
+            )
 
         if repo_url:
             if community_plugins_dir is None:
@@ -2766,7 +3127,15 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
             if not success:
                 logger.warning(f"Failed to clone/update plugin {plugin_name}, skipping")
                 continue
-            _install_requirements_for_repo(repo_path, repo_name)
+            if ref["type"] == "commit":
+                _check_commit_pin_for_upstream_updates(
+                    plugin_name,
+                    validation_result.repo_url,
+                    repo_path,
+                )
+            _install_requirements_for_repo(
+                repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
+            )
             ready_community_plugins.append(plugin_name)
         else:
             logger.error("Repository URL not specified for a community plugin")

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -822,15 +822,6 @@ def _install_requirements_for_repo(
         return
 
     global _community_dep_install_warning_logged
-    if (
-        plugin_type == PLUGIN_TYPE_COMMUNITY
-        and not _community_dep_install_warning_logged
-    ):
-        logger.warning(
-            "Community plugin dependencies execute arbitrary code and are unsafe"
-        )
-        _community_dep_install_warning_logged = True
-
     try:
         in_pipx = any(key in os.environ for key in PIPX_ENVIRONMENT_KEYS)
 
@@ -873,6 +864,14 @@ def _install_requirements_for_repo(
             # Check if there are actual packages to install (not just flags)
             packages = [r for r in safe_requirements if not r.startswith("-")]
             if packages:
+                if (
+                    plugin_type == PLUGIN_TYPE_COMMUNITY
+                    and not _community_dep_install_warning_logged
+                ):
+                    logger.warning(
+                        "Community plugin dependencies execute arbitrary code and are unsafe"
+                    )
+                    _community_dep_install_warning_logged = True
                 # Write safe requirements to a temporary file to handle hashed requirements
                 # and environment markers properly
                 with tempfile.NamedTemporaryFile(
@@ -918,6 +917,14 @@ def _install_requirements_for_repo(
                     requirements_path,
                 )
             else:
+                if (
+                    plugin_type == PLUGIN_TYPE_COMMUNITY
+                    and not _community_dep_install_warning_logged
+                ):
+                    logger.warning(
+                        "Community plugin dependencies execute arbitrary code and are unsafe"
+                    )
+                    _community_dep_install_warning_logged = True
                 cmd = [
                     sys.executable,
                     "-m",
@@ -2515,7 +2522,11 @@ def clone_or_update_repo(repo_url: str, ref: dict[str, str], plugins_dir: str) -
     )
 
 
-def load_plugins_from_directory(directory: str, recursive: bool = False) -> list[Any]:
+def load_plugins_from_directory(
+    directory: str,
+    recursive: bool = False,
+    plugin_type: str = PLUGIN_TYPE_CUSTOM,
+) -> list[Any]:
     """
     Discover and instantiate top-level Plugin classes from Python modules in a directory.
 
@@ -2524,6 +2535,7 @@ def load_plugins_from_directory(directory: str, recursive: bool = False) -> list
     Parameters:
         directory (str): Path to the directory containing plugin Python files.
         recursive (bool): If True, scan subdirectories recursively; otherwise scan only the top-level directory.
+        plugin_type (str): Plugin source category used for dependency auto-install policy.
 
     Returns:
         list[Any]: Instances of discovered `Plugin` classes; returns an empty list if none are found.
@@ -2613,13 +2625,24 @@ def load_plugins_from_directory(directory: str, recursive: bool = False) -> list
 
                         # Try to automatically install the missing dependency
                         try:
-                            if not _check_auto_install_enabled(config):
+                            if not _check_auto_install_enabled(
+                                config, plugin_type=plugin_type
+                            ):
                                 _raise_install_error(missing_pkg)
                             # Check if we're running in a pipx environment
                             in_pipx = (
                                 "PIPX_HOME" in os.environ
                                 or "PIPX_LOCAL_VENVS" in os.environ
                             )
+                            global _community_dep_install_warning_logged
+                            if (
+                                plugin_type == PLUGIN_TYPE_COMMUNITY
+                                and not _community_dep_install_warning_logged
+                            ):
+                                logger.warning(
+                                    "Community plugin dependencies execute arbitrary code and are unsafe"
+                                )
+                                _community_dep_install_warning_logged = True
 
                             if in_pipx:
                                 logger.info(
@@ -3100,10 +3123,13 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
             explicit_branch_ref = True
         else:
             # Default to the first configured default branch if neither is specified.
+            default_branch = DEFAULT_BRANCHES[0]
             logger.warning(
-                "No ref specified; defaulting to branch 'main' is deprecated and unsafe"
+                "No ref specified for %s; defaulting to branch '%s' is deprecated and unsafe",
+                plugin_name,
+                default_branch,
             )
-            ref = {"type": "branch", "value": DEFAULT_BRANCHES[0]}
+            ref = {"type": "branch", "value": default_branch}
 
         if ref["type"] == "tag" and not tag_ref_warning_logged:
             logger.warning("Tags can be retargeted; commit pins are safer")
@@ -3219,7 +3245,11 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                     logger.info(f"Loading community plugin from: {plugin_path}")
                     try:
                         plugins.extend(
-                            load_plugins_from_directory(plugin_path, recursive=True)
+                            load_plugins_from_directory(
+                                plugin_path,
+                                recursive=True,
+                                plugin_type=PLUGIN_TYPE_COMMUNITY,
+                            )
                         )
                         plugin_found = True
                         break

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -108,6 +108,12 @@ _global_scheduler_stop_event: threading.Event | None = None
 _PLUGIN_DEPS_DIR: str | None = None
 PLUGIN_REQUIREMENTS_FILENAME: Final[str] = "requirements.txt"
 PLUGIN_STATE_FILENAME: Final[str] = ".mmrelay-plugin-state.json"
+PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: Final[str] = (
+    "last_installed_requirements_commit"
+)
+PLUGIN_STATE_LAST_REQUIREMENTS_INSTALLED_AT: Final[str] = (
+    "last_requirements_installed_at"
+)
 COMMUNITY_PLUGIN_UPDATE_CHECK_INTERVAL: Final[timedelta] = timedelta(hours=24)
 _community_dep_install_warning_logged = False
 
@@ -796,30 +802,28 @@ def _install_requirements_for_repo(
     repo_path: str,
     repo_name: str,
     plugin_type: str = PLUGIN_TYPE_CUSTOM,
-) -> None:
+) -> bool:
     """
     Install dependencies listed in repo_path/requirements.txt for a community plugin and refresh import paths.
 
-    This function is a no-op if no requirements file exists or if automatic installation is disabled by configuration.
-    When enabled, it will install allowed dependency entries either into the application's pipx environment (when pipx is in use)
-    or into the current Python environment (using pip). After a successful installation the interpreter import/search paths are refreshed
-    so newly installed packages become importable. Failures are logged and do not raise from this function.
+    This function is a no-op if no requirements file exists. It installs allowed dependency
+    entries either into the application's pipx environment (when pipx is in use) or into
+    the current Python environment (using pip). After a successful installation the
+    interpreter import/search paths are refreshed so newly installed packages become
+    importable. Failures are logged and do not raise from this function.
 
     Parameters:
         repo_path: Filesystem path to the plugin repository (looks for a requirements.txt file at this location).
         repo_name: Human-readable repository name used in log messages and warnings.
+
+    Returns:
+        bool: True when dependency handling completed without installation errors (including
+        no-op cases), False when installation failed.
     """
 
     requirements_path = os.path.join(repo_path, PLUGIN_REQUIREMENTS_FILENAME)
     if not os.path.isfile(requirements_path):
-        return
-
-    if not _check_auto_install_enabled(config, plugin_type=plugin_type):
-        logger.warning(
-            "Auto-install of requirements for %s disabled by config; skipping.",
-            repo_name,
-        )
-        return
+        return True
 
     global _community_dep_install_warning_logged
     try:
@@ -963,6 +967,7 @@ def _install_requirements_for_repo(
             _refresh_dependency_paths()
         else:
             logger.info("No dependency installation run for plugin %s", repo_name)
+        return True
     except (
         OSError,
         subprocess.CalledProcessError,
@@ -977,6 +982,7 @@ def _install_requirements_for_repo(
             "Plugin %s may not work correctly without its dependencies",
             repo_name,
         )
+        return False
 
 
 def _get_plugin_dirs(plugin_type: str) -> list[str]:
@@ -1147,46 +1153,18 @@ def _run_git(
     return _run(cmd, timeout=timeout, **kwargs)
 
 
-def _check_auto_install_enabled(
-    config: Any, plugin_type: str = PLUGIN_TYPE_CUSTOM
-) -> bool:
-    """
-    Determine whether automatic dependency installation is enabled for the given configuration and plugin type.
-
-    Parameters:
-        config (dict|Any): Configuration mapping expected to contain a "security" dict
-            with an optional boolean "auto_install_deps" key.
-        plugin_type (str): Plugin source category. Community plugin dependency
-            auto-install is disabled by default unless explicitly enabled in config.
-
-    Returns:
-        True if automatic installation is enabled for the plugin type, False otherwise.
-    """
-    if not isinstance(config, dict):
-        return plugin_type != PLUGIN_TYPE_COMMUNITY
-
-    security_config = config.get("security", {})
-    if not isinstance(security_config, dict):
-        security_config = {}
-
-    # Keep existing custom plugin behavior, but require explicit opt-in for
-    # community plugin dependency installation.
-    default_enabled = plugin_type != PLUGIN_TYPE_COMMUNITY
-    return bool(security_config.get("auto_install_deps", default_enabled))
-
-
 def _raise_install_error(pkg_name: str) -> NoReturn:
     """
-    Emit a warning that automatic dependency installation is disabled and raise a subprocess.CalledProcessError.
+    Emit a warning that dependency auto-install is blocked and raise a subprocess.CalledProcessError.
 
     Parameters:
         pkg_name (str): Package name referenced in the warning message.
 
     Raises:
-        subprocess.CalledProcessError: Always raised to indicate installation cannot proceed because auto-install is disabled.
+        subprocess.CalledProcessError: Always raised to indicate installation cannot proceed because auto-install is blocked.
     """
     logger.warning(
-        f"Auto-install disabled; cannot install {pkg_name}. See docs for enabling."
+        f"Auto-install blocked by policy; cannot install {pkg_name}. See docs for enabling."
     )
     raise subprocess.CalledProcessError(1, "pip/pipx")
 
@@ -2530,7 +2508,7 @@ def load_plugins_from_directory(
     """
     Discover and instantiate top-level Plugin classes from Python modules in a directory.
 
-    Scans the given directory (optionally recursively) for .py modules, imports each module in an isolated namespace, and returns instantiated top-level `Plugin` objects found. On import failure due to a missing dependency and when automatic installation is enabled, the function may attempt to install the missing package and refresh import paths before retrying. The function does not raise on individual plugin load failures; it returns only successfully instantiated plugins.
+    Scans the given directory (optionally recursively) for .py modules, imports each module in an isolated namespace, and returns instantiated top-level `Plugin` objects found. On import failure due to a missing dependency, the function may attempt an auto-install retry for non-community plugins and refresh import paths before retrying. The function does not raise on individual plugin load failures; it returns only successfully instantiated plugins.
 
     Parameters:
         directory (str): Path to the directory containing plugin Python files.
@@ -2625,9 +2603,7 @@ def load_plugins_from_directory(
 
                         # Try to automatically install the missing dependency
                         try:
-                            if not _check_auto_install_enabled(
-                                config, plugin_type=plugin_type
-                            ):
+                            if plugin_type == PLUGIN_TYPE_COMMUNITY:
                                 _raise_install_error(missing_pkg)
                             # Check if we're running in a pipx environment
                             in_pipx = (
@@ -3073,6 +3049,8 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
         commit = plugin_info.get("commit")
         tag = plugin_info.get("tag")
         branch = plugin_info.get("branch")
+        install_requirements_raw = plugin_info.get("install_requirements", False)
+        install_requirements = False
 
         # Validate that repo_url and ref fields are strings if provided
         if repo_url is not None and not isinstance(repo_url, str):
@@ -3100,6 +3078,14 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                 invalid_ref_field,
             )
             continue
+        if isinstance(install_requirements_raw, bool):
+            install_requirements = install_requirements_raw
+        elif install_requirements_raw is not None:
+            logger.warning(
+                "Ignoring non-boolean 'install_requirements' value for %s plugin '%s'; expected true/false.",
+                CONFIG_SECTION_COMMUNITY_PLUGINS,
+                plugin_name,
+            )
 
         # Determine what to use (commit, tag, branch, or default)
         # Priority: commit > tag > branch
@@ -3196,9 +3182,44 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                     validation_result.repo_url,
                     repo_path,
                 )
-            _install_requirements_for_repo(
-                repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
-            )
+            if install_requirements:
+                ref_value = str(ref.get("value", "")).strip()
+                if ref.get("type") != "commit" or not _is_full_commit_sha(ref_value):
+                    logger.warning(
+                        "Skipping dependency install for community plugin '%s': install_requirements requires a full 40-character commit pin; branch, tag, and default refs are not allowed.",
+                        plugin_name,
+                    )
+                else:
+                    pinned_sha = _resolve_local_head_commit(repo_path)
+                    if pinned_sha is None:
+                        logger.warning(
+                            "Skipping dependency install for community plugin '%s': unable to resolve checked-out commit.",
+                            plugin_name,
+                        )
+                    else:
+                        state = _load_plugin_state(repo_path)
+                        last_installed_commit = state.get(
+                            PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT
+                        )
+                        if (
+                            isinstance(last_installed_commit, str)
+                            and last_installed_commit == pinned_sha
+                        ):
+                            logger.debug(
+                                "Skipping requirements install for community plugin %s; already installed for commit %s",
+                                plugin_name,
+                                pinned_sha,
+                            )
+                        elif _install_requirements_for_repo(
+                            repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
+                        ):
+                            state[PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT] = (
+                                pinned_sha
+                            )
+                            state[PLUGIN_STATE_LAST_REQUIREMENTS_INSTALLED_AT] = (
+                                datetime.now(timezone.utc).isoformat()
+                            )
+                            _save_plugin_state(repo_path, state)
             ready_community_plugins.append(plugin_name)
         else:
             logger.error("Repository URL not specified for a community plugin")

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -2610,15 +2610,6 @@ def load_plugins_from_directory(
                                 "PIPX_HOME" in os.environ
                                 or "PIPX_LOCAL_VENVS" in os.environ
                             )
-                            global _community_dep_install_warning_logged
-                            if (
-                                plugin_type == PLUGIN_TYPE_COMMUNITY
-                                and not _community_dep_install_warning_logged
-                            ):
-                                logger.warning(
-                                    "Community plugin dependencies execute arbitrary code and are unsafe"
-                                )
-                                _community_dep_install_warning_logged = True
 
                             if in_pipx:
                                 logger.info(
@@ -3126,7 +3117,8 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
             tag_ref_warning_logged = True
         elif ref["type"] == "branch" and explicit_branch_ref:
             logger.warning(
-                "Branch refs are moving targets and not recommended in production"
+                "Community plugin '%s' uses a branch ref; branch refs are moving targets and not recommended in production",
+                plugin_name,
             )
 
         if repo_url:

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -1197,6 +1197,19 @@ def _state_file_path(repo_path: str) -> str:
     return os.path.join(repo_path, PLUGIN_STATE_FILENAME)
 
 
+def _is_full_commit_sha(value: str) -> bool:
+    """
+    Check whether a string is a full 40-character hexadecimal commit SHA.
+
+    Parameters:
+        value (str): Candidate commit SHA string.
+
+    Returns:
+        bool: `True` for full 40-char hex SHAs, else `False`.
+    """
+    return bool(re.fullmatch(r"[0-9a-fA-F]{40}", (value or "").strip()))
+
+
 def _load_plugin_state(repo_path: str) -> dict[str, Any]:
     """
     Load persisted community plugin state from disk.
@@ -1244,6 +1257,8 @@ def _save_plugin_state(repo_path: str, state: dict[str, Any]) -> None:
         ) as temp_handle:
             json.dump(state, temp_handle, indent=2, sort_keys=True)
             temp_handle.write("\n")
+            temp_handle.flush()
+            os.fsync(temp_handle.fileno())
             tmp_path = temp_handle.name
         os.replace(tmp_path, state_path)
     except (OSError, TypeError, ValueError) as exc:
@@ -1288,6 +1303,7 @@ def _resolve_remote_default_branch(repo_path: str) -> str | None:
     Returns:
         str | None: Default branch name (for example "main"), or None.
     """
+    result: subprocess.CompletedProcess[str] | None = None
     try:
         result = _run_git(
             [
@@ -1302,16 +1318,34 @@ def _resolve_remote_default_branch(repo_path: str) -> str | None:
             timeout=GIT_COMMAND_TIMEOUT_SECONDS,
             capture_output=True,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
-        return None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug(
+            "Unable to resolve remote default branch for %s via symref: %s",
+            repo_path,
+            exc,
+        )
 
-    for line in result.stdout.splitlines():
-        if not line.startswith("ref: ") or not line.endswith("\tHEAD"):
-            continue
-        ref_value = line.split("\t", 1)[0].replace("ref: ", "", 1).strip()
-        prefix = "refs/heads/"
-        if ref_value.startswith(prefix):
-            return ref_value[len(prefix) :]
+    if result is not None:
+        for raw_line in result.stdout.splitlines():
+            line = raw_line.strip()
+            if not line.startswith("ref:"):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            ref_value = parts[1].strip()
+            prefix = "refs/heads/"
+            if ref_value.startswith(prefix):
+                return ref_value[len(prefix) :]
+
+    for fallback_branch in DEFAULT_BRANCHES:
+        if _resolve_remote_branch_head_commit(repo_path, fallback_branch):
+            return fallback_branch
+
+    logger.debug(
+        "Could not determine remote default branch for %s; skipping update check",
+        repo_path,
+    )
     return None
 
 
@@ -1331,11 +1365,12 @@ def _resolve_local_head_commit(repo_path: str) -> str | None:
             timeout=GIT_COMMAND_TIMEOUT_SECONDS,
             capture_output=True,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("Unable to resolve local HEAD commit for %s: %s", repo_path, exc)
         return None
 
     commit_sha = result.stdout.strip()
-    return commit_sha if COMMIT_HASH_PATTERN.fullmatch(commit_sha) else None
+    return commit_sha if _is_full_commit_sha(commit_sha) else None
 
 
 def _resolve_remote_branch_head_commit(repo_path: str, branch_name: str) -> str | None:
@@ -1362,14 +1397,20 @@ def _resolve_remote_branch_head_commit(repo_path: str, branch_name: str) -> str 
             timeout=GIT_COMMAND_TIMEOUT_SECONDS,
             capture_output=True,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug(
+            "Unable to resolve remote branch head for %s (%s): %s",
+            repo_path,
+            branch_name,
+            exc,
+        )
         return None
 
     first_line = next((line.strip() for line in result.stdout.splitlines() if line), "")
     if not first_line:
         return None
     remote_sha = first_line.split("\t", 1)[0].strip()
-    return remote_sha if COMMIT_HASH_PATTERN.fullmatch(remote_sha) else None
+    return remote_sha if _is_full_commit_sha(remote_sha) else None
 
 
 def _get_repo_host_info(repo_url: str) -> tuple[str, str, str] | None:
@@ -1397,14 +1438,11 @@ def _get_repo_host_info(repo_url: str) -> tuple[str, str, str] | None:
 
     parsed = urlsplit(trimmed_url)
     host = (parsed.hostname or "").lower()
-    path = (parsed.path or "").strip("/")
-    parts = path.split("/")
-    if not host or len(parts) < 2:
+    path = (parsed.path or "").strip()
+    https_match = re.match(r"^/([^/]+)/([^/]+?)(?:\.git)?/?$", path)
+    if not host or https_match is None:
         return None
-    owner = parts[0]
-    repo_name = parts[1]
-    if repo_name.endswith(".git"):
-        repo_name = repo_name[:-4]
+    owner, repo_name = https_match.groups()
     if not owner or not repo_name:
         return None
     return host, owner, repo_name
@@ -3133,9 +3171,10 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                     validation_result.repo_url,
                     repo_path,
                 )
-            _install_requirements_for_repo(
-                repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
-            )
+            if _check_auto_install_enabled(config, plugin_type=PLUGIN_TYPE_COMMUNITY):
+                _install_requirements_for_repo(
+                    repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
+                )
             ready_community_plugins.append(plugin_name)
         else:
             logger.error("Repository URL not specified for a community plugin")

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -3090,20 +3090,25 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
         # Determine what to use (commit, tag, branch, or default)
         # Priority: commit > tag > branch
         explicit_branch_ref = False
+        has_explicit_ref = False
         if commit:
+            has_explicit_ref = True
             if tag or branch:
                 logger.warning(
                     f"Commit specified along with tag/branch for plugin {plugin_name}, using commit"
                 )
             ref = {"type": "commit", "value": commit}
         elif tag and branch:
+            has_explicit_ref = True
             logger.warning(
                 f"Both tag and branch specified for plugin {plugin_name}, using tag"
             )
             ref = {"type": "tag", "value": tag}
         elif tag:
+            has_explicit_ref = True
             ref = {"type": "tag", "value": tag}
         elif branch:
+            has_explicit_ref = True
             ref = {"type": "branch", "value": branch}
             explicit_branch_ref = True
         else:
@@ -3184,12 +3189,35 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                 )
             if install_requirements:
                 ref_value = str(ref.get("value", "")).strip()
-                if ref.get("type") != "commit" or not _is_full_commit_sha(ref_value):
+                ref_type = str(ref.get("type", "")).strip()
+                if not has_explicit_ref:
                     logger.warning(
-                        "Skipping dependency install for community plugin '%s': install_requirements requires a full 40-character commit pin; branch, tag, and default refs are not allowed.",
+                        "Skipping dependency install for community plugin '%s': "
+                        "install_requirements requires an explicit ref; "
+                        "implicit default-branch refs are not eligible.",
+                        plugin_name,
+                    )
+                elif ref_type == "commit" and not _is_full_commit_sha(ref_value):
+                    logger.warning(
+                        "Skipping dependency install for community plugin '%s': "
+                        "commit refs for install_requirements must use a full "
+                        "40-character SHA.",
                         plugin_name,
                     )
                 else:
+                    if ref_type == "branch":
+                        logger.warning(
+                            "Community plugin '%s' uses install_requirements with an "
+                            "explicit branch ref; installs will follow moving upstream "
+                            "commits.",
+                            plugin_name,
+                        )
+                    elif ref_type == "tag":
+                        logger.warning(
+                            "Community plugin '%s' uses install_requirements with an "
+                            "explicit tag ref; tags can be retargeted.",
+                            plugin_name,
+                        )
                     pinned_sha = _resolve_local_head_commit(repo_path)
                     if pinned_sha is None:
                         logger.warning(

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -141,7 +141,7 @@ plugins:
 #    commit: fedcba9876543210fedcba9876543210fedcba98
 #
 # Community plugins run in-process. Use trusted sources.
-# Prefer commit pins. Set install_requirements: true to install deps (once per resolved commit).
+# Prefer commit pins. install_requirements: true installs deps once per resolved commit.
 
 #custom-plugins:
 #  my_custom_plugin:

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -134,6 +134,7 @@ plugins:
 #    active: true
 #    repository: https://github.com/username/sample_plugin.git
 #    commit: 0123456789abcdef0123456789abcdef01234567
+#    install_requirements: true # Allowed only with full commit pins
 #  advanced_plugin:
 #    active: false
 #    repository: https://github.com/username/advanced_plugin.git
@@ -141,9 +142,9 @@ plugins:
 #
 # Community plugins run in-process and inherit MMRelay permissions.
 # Use trusted sources and prefer commit-pinned refs.
-# Community dependency auto-install is disabled by default.
-#security:
-#  auto_install_deps: true # Only enable for trusted community plugin repositories.
+# Community dependency installation is per-plugin and disabled by default.
+# install_requirements is ignored for branch/tag/missing refs.
+# When enabled with a commit pin, requirements are installed once per commit.
 
 #custom-plugins:
 #  my_custom_plugin:

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -143,8 +143,10 @@ plugins:
 # Community plugins run in-process and inherit MMRelay permissions.
 # Use trusted sources and prefer commit-pinned refs.
 # Community dependency installation is per-plugin and disabled by default.
-# install_requirements is ignored for branch/tag/missing refs.
-# When enabled with a commit pin, requirements are installed once per commit.
+# install_requirements is allowed for explicit commit/branch/tag refs.
+# branch/tag installs log warnings because refs can move/retarget.
+# missing refs (implicit default branch) are not eligible for install.
+# When enabled, requirements are installed once per resolved local commit.
 
 #custom-plugins:
 #  my_custom_plugin:

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -141,6 +141,9 @@ plugins:
 #
 # Community plugins run in-process and inherit MMRelay permissions.
 # Use trusted sources and prefer commit-pinned refs.
+# Community dependency auto-install is disabled by default.
+#security:
+#  auto_install_deps: true # Only enable for trusted community plugin repositories.
 
 #custom-plugins:
 #  my_custom_plugin:

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -134,19 +134,14 @@ plugins:
 #    active: true
 #    repository: https://github.com/username/sample_plugin.git
 #    commit: 0123456789abcdef0123456789abcdef01234567
-#    install_requirements: true # Allowed only with full commit pins
+#    install_requirements: true # Optional; commit pins preferred
 #  advanced_plugin:
 #    active: false
 #    repository: https://github.com/username/advanced_plugin.git
 #    commit: fedcba9876543210fedcba9876543210fedcba98
 #
-# Community plugins run in-process and inherit MMRelay permissions.
-# Use trusted sources and prefer commit-pinned refs.
-# Community dependency installation is per-plugin and disabled by default.
-# install_requirements is allowed for explicit commit/branch/tag refs.
-# branch/tag installs log warnings because refs can move/retarget.
-# missing refs (implicit default branch) are not eligible for install.
-# When enabled, requirements are installed once per resolved local commit.
+# Community plugins run in-process. Use trusted sources.
+# Prefer commit pins. Set install_requirements: true to install deps (once per resolved commit).
 
 #custom-plugins:
 #  my_custom_plugin:

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -133,11 +133,14 @@ plugins:
 #  sample_plugin:
 #    active: true
 #    repository: https://github.com/username/sample_plugin.git
-#    tag: master
+#    commit: 0123456789abcdef0123456789abcdef01234567
 #  advanced_plugin:
 #    active: false
 #    repository: https://github.com/username/advanced_plugin.git
-#    tag: v1.3.0
+#    commit: fedcba9876543210fedcba9876543210fedcba98
+#
+# Community plugins run in-process and inherit MMRelay permissions.
+# Use trusted sources and prefer commit-pinned refs.
 
 #custom-plugins:
 #  my_custom_plugin:

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1546,23 +1546,32 @@ class Plugin:
         mock_start_scheduler.assert_called_once()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
-    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=True)
+    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch("mmrelay.plugin_loader._load_plugin_state", return_value={})
+    @patch(
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
+    )
     @patch("mmrelay.plugin_loader.load_plugins_from_directory")
     @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
     @patch("mmrelay.plugin_loader.logger")
-    def test_load_plugins_opted_in_branch_and_tag_skip_dependency_install(
+    def test_load_plugins_opted_in_branch_allows_dependency_install_with_warning(
         self,
         mock_logger,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_load_state,
+        mock_save_state,
         mock_install_reqs,
         mock_clone_repo,
     ):
-        """Branch/tag refs with install_requirements should warn and skip installation."""
+        """Explicit branch refs should warn but still allow dependency installation."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
         config = {
@@ -1572,13 +1581,141 @@ class Plugin:
                     "repository": "https://github.com/user/repo.git",
                     "branch": "main",
                     "install_requirements": True,
-                },
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_resolve_local_head_commit.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_load_state.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_install_reqs.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
+        saved_state = mock_save_state.call_args.args[1]
+        self.assertEqual(
+            saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT),
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+        mock_logger.warning.assert_any_call(
+            "Community plugin '%s' uses install_requirements with an explicit branch "
+            "ref; installs will follow moving upstream commits.",
+            "branch-plugin",
+        )
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=True)
+    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch("mmrelay.plugin_loader._load_plugin_state", return_value={})
+    @patch(
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
+    )
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_opted_in_tag_allows_dependency_install_with_warning(
+        self,
+        mock_logger,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_load_state,
+        mock_save_state,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Explicit tag refs should warn but still allow dependency installation."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
                 "tag-plugin": {
                     "active": True,
-                    "repository": "https://github.com/user/repo2.git",
+                    "repository": "https://github.com/user/repo.git",
                     "tag": "v1.0.0",
                     "install_requirements": True,
-                },
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_resolve_local_head_commit.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_load_state.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_install_reqs.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
+        saved_state = mock_save_state.call_args.args[1]
+        self.assertEqual(
+            saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT),
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+        mock_logger.warning.assert_any_call(
+            "Community plugin '%s' uses install_requirements with an explicit tag "
+            "ref; tags can be retargeted.",
+            "tag-plugin",
+        )
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader._resolve_local_head_commit")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_opted_in_missing_ref_skips_dependency_install(
+        self,
+        mock_logger,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Missing refs with install_requirements should warn and skip installation."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
+                "default-branch-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "install_requirements": True,
+                }
             },
             "plugins": {},
         }
@@ -1591,9 +1728,13 @@ class Plugin:
         load_plugins(config)
 
         mock_install_reqs.assert_not_called()
-        warning_message = "Skipping dependency install for community plugin '%s': install_requirements requires a full 40-character commit pin; branch, tag, and default refs are not allowed."
-        mock_logger.warning.assert_any_call(warning_message, "branch-plugin")
-        mock_logger.warning.assert_any_call(warning_message, "tag-plugin")
+        mock_resolve_local_head_commit.assert_not_called()
+        mock_logger.warning.assert_any_call(
+            "Skipping dependency install for community plugin '%s': "
+            "install_requirements requires an explicit ref; "
+            "implicit default-branch refs are not eligible.",
+            "default-branch-plugin",
+        )
         mock_start_scheduler.assert_called_once()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1243,11 +1243,11 @@ class Plugin:
     def test_load_plugins_missing_ref_warns_unsafe_default(
         self,
         mock_logger,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_install_reqs,
+        mock_install_reqs,
         mock_clone_repo,
     ):
         """Missing refs should warn and still default to the main branch."""
@@ -1276,6 +1276,12 @@ class Plugin:
             "test-plugin",
             "main",
         )
+        mock_start_scheduler.assert_called_once()
+        mock_install_reqs.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1284,17 +1290,17 @@ class Plugin:
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
     @patch("mmrelay.plugin_loader.logger")
-    def test_load_plugins_branch_warning_respects_allow_moving_ref(
+    def test_load_plugins_branch_warning_for_each_explicit_branch_ref(
         self,
         mock_logger,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_install_reqs,
+        mock_install_reqs,
         mock_clone_repo,
     ):
-        """Branch refs warn unless allow_moving_ref is explicitly true."""
+        """Branch refs should always warn for explicit branch pins."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
 
@@ -1309,7 +1315,6 @@ class Plugin:
                     "active": True,
                     "repository": "https://github.com/user/repo2.git",
                     "branch": "main",
-                    "allow_moving_ref": True,
                 },
             },
             "plugins": {},
@@ -1332,9 +1337,11 @@ class Plugin:
         ]
         self.assertEqual(
             len(warning_calls),
-            1,
-            "Expected one branch warning for the plugin without allow_moving_ref",
+            2,
+            "Expected one branch warning per explicitly branch-pinned plugin",
         )
+        mock_start_scheduler.assert_called_once()
+        self.assertEqual(mock_install_reqs.call_count, 2)
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1346,11 +1353,11 @@ class Plugin:
     def test_load_plugins_tag_warning_once_per_startup(
         self,
         mock_logger,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_install_reqs,
+        mock_install_reqs,
         mock_clone_repo,
     ):
         """Tag ref warning should be emitted once per load cycle."""
@@ -1387,6 +1394,8 @@ class Plugin:
             if call_args.args and call_args.args[0] == tag_warning
         ]
         self.assertEqual(len(warning_calls), 1)
+        mock_start_scheduler.assert_called_once()
+        self.assertEqual(mock_install_reqs.call_count, 2)
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1400,11 +1409,11 @@ class Plugin:
         self,
         mock_logger,
         mock_update_check,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_install_reqs,
+        mock_install_reqs,
         mock_clone_repo,
     ):
         """Commit refs should not emit branch/tag safety warnings."""
@@ -1443,6 +1452,12 @@ class Plugin:
             warning_texts,
         )
         mock_update_check.assert_called_once()
+        mock_start_scheduler.assert_called_once()
+        mock_install_reqs.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1450,16 +1465,16 @@ class Plugin:
     @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
-    def test_load_plugins_skips_community_dep_install_when_disabled(
+    def test_load_plugins_calls_community_dep_installer_even_when_disabled(
         self,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
         mock_install_reqs,
         mock_clone_repo,
     ):
-        """Community dependency installer function should not be called when disabled."""
+        """Loader should always call installer helper and let it enforce policy."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
 
@@ -1486,7 +1501,12 @@ class Plugin:
             load_plugins(config)
 
         mock_update_check.assert_called_once()
-        mock_install_reqs.assert_not_called()
+        mock_install_reqs.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
+        mock_start_scheduler.assert_called_once()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader.load_plugins_from_directory")

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -518,6 +518,51 @@ class Plugin:
         self.assertEqual(len(plugins), 1)
         self.assertEqual(plugins[0].plugin_name, "auto_plugin")
 
+    def test_load_plugins_from_directory_community_missing_dependency_respects_disabled_auto_install(
+        self,
+    ):
+        """Community plugin dependency retry should not install when disabled."""
+        plugin_content = """
+import missingdep_for_community
+
+class Plugin:
+    pass
+"""
+        plugin_file = os.path.join(self.custom_dir, "community_missing_dep.py")
+        with open(plugin_file, "w", encoding="utf-8") as handle:
+            handle.write(plugin_content)
+
+        original_config = pl.config
+        pl.config = {"security": {"auto_install_deps": False}}
+        try:
+            with (
+                patch(
+                    "mmrelay.plugin_loader._check_auto_install_enabled",
+                    return_value=False,
+                ) as mock_auto_install_enabled,
+                patch(
+                    "mmrelay.plugin_loader._raise_install_error",
+                    side_effect=subprocess.CalledProcessError(1, "pip/pipx"),
+                ) as mock_raise_install_error,
+                patch("mmrelay.plugin_loader._run") as mock_run,
+            ):
+                plugins = load_plugins_from_directory(
+                    self.custom_dir,
+                    plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+                )
+        finally:
+            pl.config = original_config
+
+        self.assertEqual(plugins, [])
+        self.assertTrue(
+            any(
+                kwargs.get("plugin_type") == pl.PLUGIN_TYPE_COMMUNITY
+                for _, kwargs in mock_auto_install_enabled.call_args_list
+            )
+        )
+        mock_raise_install_error.assert_called_once_with("missingdep_for_community")
+        mock_run.assert_not_called()
+
     def test_load_plugins_from_directory_auto_install_retry_no_plugin_class(self):
         orig_pipx_home = os.environ.get("PIPX_HOME")
         orig_pipx_local_venvs = os.environ.get("PIPX_LOCAL_VENVS")
@@ -796,7 +841,11 @@ class Plugin:
             pl.sorted_active_plugins = []
             load_plugins(config)
 
-        mock_load.assert_called_once_with(found_path, recursive=True)
+        mock_load.assert_called_once_with(
+            found_path,
+            recursive=True,
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
         mock_logger.warning.assert_any_call(
             "Community plugin 'missing_plugin' not found in any of the plugin directories"
         )
@@ -1223,7 +1272,9 @@ class Plugin:
         load_plugins(config)
 
         mock_logger.warning.assert_any_call(
-            "No ref specified; defaulting to branch 'main' is deprecated and unsafe"
+            "No ref specified for %s; defaulting to branch '%s' is deprecated and unsafe",
+            "test-plugin",
+            "main",
         )
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
@@ -1436,6 +1487,52 @@ class Plugin:
 
         mock_update_check.assert_called_once()
         mock_install_reqs.assert_not_called()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    def test_load_plugins_community_loader_passes_plugin_type(
+        self,
+        mock_update_check,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_clone_repo,
+    ):
+        """Community plugin load should pass plugin_type to directory loader."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+        os.makedirs(os.path.join(self.community_dir, "repo"), exist_ok=True)
+
+        load_plugins(config)
+
+        mock_load_from_dir.assert_any_call(
+            os.path.join(self.community_dir, "repo"),
+            recursive=True,
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
+        mock_update_check.assert_called_once()
+        mock_start_scheduler.assert_called_once()
 
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
@@ -3953,14 +4050,20 @@ class TestDependencyInstallation(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader.logger")
-    @patch("mmrelay.plugin_loader._collect_requirements", return_value=[])
+    @patch("mmrelay.plugin_loader._run")
+    @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_community_requirements_warns_once_when_enabled(
-        self, _mock_collect, mock_logger
+        self, mock_collect, mock_run, mock_logger
     ):
         """Community dependency auto-install should emit the risk warning once."""
-        pl._community_dep_install_warning_logged = False
-        with patch(
-            "mmrelay.plugin_loader.config", {"security": {"auto_install_deps": True}}
+        mock_collect.return_value = ["requests==2.28.0"]
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+        with (
+            patch.object(pl, "_community_dep_install_warning_logged", False),
+            patch(
+                "mmrelay.plugin_loader.config",
+                {"security": {"auto_install_deps": True}},
+            ),
         ):
             _install_requirements_for_repo(
                 self.repo_path,
@@ -5174,7 +5277,8 @@ class TestCommunityPluginSecurityHelpers(unittest.TestCase):
             ),
             stderr="",
         )
-        self.assertEqual(pl._resolve_remote_default_branch("/tmp/repo"), "main")
+        with tempfile.TemporaryDirectory() as repo_path:
+            self.assertEqual(pl._resolve_remote_default_branch(repo_path), "main")
 
     @patch("mmrelay.plugin_loader._resolve_remote_branch_head_commit")
     @patch("mmrelay.plugin_loader._run_git")
@@ -5193,9 +5297,10 @@ class TestCommunityPluginSecurityHelpers(unittest.TestCase):
             None,
         ]
 
-        resolved = pl._resolve_remote_default_branch("/tmp/repo")
-        self.assertEqual(resolved, "main")
-        mock_resolve_remote_branch_head.assert_any_call("/tmp/repo", "main")
+        with tempfile.TemporaryDirectory() as repo_path:
+            resolved = pl._resolve_remote_default_branch(repo_path)
+            self.assertEqual(resolved, "main")
+            mock_resolve_remote_branch_head.assert_any_call(repo_path, "main")
 
     @patch("mmrelay.plugin_loader._run_git")
     def test_resolve_local_head_commit_rejects_non_full_sha(self, mock_run_git):
@@ -5206,7 +5311,8 @@ class TestCommunityPluginSecurityHelpers(unittest.TestCase):
             stdout="deadbeef\n",
             stderr="",
         )
-        self.assertIsNone(pl._resolve_local_head_commit("/tmp/repo"))
+        with tempfile.TemporaryDirectory() as repo_path:
+            self.assertIsNone(pl._resolve_local_head_commit(repo_path))
 
     @patch("mmrelay.plugin_loader._run_git")
     def test_resolve_remote_branch_head_commit_rejects_non_full_sha(self, mock_run_git):
@@ -5217,7 +5323,8 @@ class TestCommunityPluginSecurityHelpers(unittest.TestCase):
             stdout="deadbeef\trefs/heads/main\n",
             stderr="",
         )
-        self.assertIsNone(pl._resolve_remote_branch_head_commit("/tmp/repo", "main"))
+        with tempfile.TemporaryDirectory() as repo_path:
+            self.assertIsNone(pl._resolve_remote_branch_head_commit(repo_path, "main"))
 
     @patch("mmrelay.plugin_loader._resolve_local_head_commit")
     @patch("mmrelay.plugin_loader._resolve_remote_default_branch")

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1393,6 +1393,50 @@ class Plugin:
         )
         mock_update_check.assert_called_once()
 
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    def test_load_plugins_skips_community_dep_install_when_disabled(
+        self,
+        _mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Community dependency installer function should not be called when disabled."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+
+        config = {
+            "security": {"auto_install_deps": False},
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        with patch(
+            "mmrelay.plugin_loader._check_commit_pin_for_upstream_updates"
+        ) as mock_update_check:
+            load_plugins(config)
+
+        mock_update_check.assert_called_once()
+        mock_install_reqs.assert_not_called()
+
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
     @patch("mmrelay.plugin_loader.logger")
@@ -5131,6 +5175,49 @@ class TestCommunityPluginSecurityHelpers(unittest.TestCase):
             stderr="",
         )
         self.assertEqual(pl._resolve_remote_default_branch("/tmp/repo"), "main")
+
+    @patch("mmrelay.plugin_loader._resolve_remote_branch_head_commit")
+    @patch("mmrelay.plugin_loader._run_git")
+    def test_resolve_remote_default_branch_falls_back_to_main_master(
+        self, mock_run_git, mock_resolve_remote_branch_head
+    ):
+        """Default branch resolver should fallback to main/master when symref parse fails."""
+        mock_run_git.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="0123456789abcdef0123456789abcdef01234567\tHEAD\n",
+            stderr="",
+        )
+        mock_resolve_remote_branch_head.side_effect = [
+            "0123456789abcdef0123456789abcdef01234567",
+            None,
+        ]
+
+        resolved = pl._resolve_remote_default_branch("/tmp/repo")
+        self.assertEqual(resolved, "main")
+        mock_resolve_remote_branch_head.assert_any_call("/tmp/repo", "main")
+
+    @patch("mmrelay.plugin_loader._run_git")
+    def test_resolve_local_head_commit_rejects_non_full_sha(self, mock_run_git):
+        """Local HEAD resolver should only accept full 40-char SHAs."""
+        mock_run_git.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="deadbeef\n",
+            stderr="",
+        )
+        self.assertIsNone(pl._resolve_local_head_commit("/tmp/repo"))
+
+    @patch("mmrelay.plugin_loader._run_git")
+    def test_resolve_remote_branch_head_commit_rejects_non_full_sha(self, mock_run_git):
+        """Remote branch head resolver should only accept full 40-char SHAs."""
+        mock_run_git.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="deadbeef\trefs/heads/main\n",
+            stderr="",
+        )
+        self.assertIsNone(pl._resolve_remote_branch_head_commit("/tmp/repo", "main"))
 
     @patch("mmrelay.plugin_loader._resolve_local_head_commit")
     @patch("mmrelay.plugin_loader._resolve_remote_default_branch")

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -518,10 +518,8 @@ class Plugin:
         self.assertEqual(len(plugins), 1)
         self.assertEqual(plugins[0].plugin_name, "auto_plugin")
 
-    def test_load_plugins_from_directory_community_missing_dependency_respects_disabled_auto_install(
-        self,
-    ):
-        """Community plugin dependency retry should not install when disabled."""
+    def test_load_plugins_from_directory_community_missing_dependency_blocked(self):
+        """Community plugin dependency retry should be blocked by policy."""
         plugin_content = """
 import missingdep_for_community
 
@@ -532,34 +530,19 @@ class Plugin:
         with open(plugin_file, "w", encoding="utf-8") as handle:
             handle.write(plugin_content)
 
-        original_config = pl.config
-        pl.config = {"security": {"auto_install_deps": False}}
-        try:
-            with (
-                patch(
-                    "mmrelay.plugin_loader._check_auto_install_enabled",
-                    return_value=False,
-                ) as mock_auto_install_enabled,
-                patch(
-                    "mmrelay.plugin_loader._raise_install_error",
-                    side_effect=subprocess.CalledProcessError(1, "pip/pipx"),
-                ) as mock_raise_install_error,
-                patch("mmrelay.plugin_loader._run") as mock_run,
-            ):
-                plugins = load_plugins_from_directory(
-                    self.custom_dir,
-                    plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
-                )
-        finally:
-            pl.config = original_config
+        with (
+            patch(
+                "mmrelay.plugin_loader._raise_install_error",
+                side_effect=subprocess.CalledProcessError(1, "pip/pipx"),
+            ) as mock_raise_install_error,
+            patch("mmrelay.plugin_loader._run") as mock_run,
+        ):
+            plugins = load_plugins_from_directory(
+                self.custom_dir,
+                plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            )
 
         self.assertEqual(plugins, [])
-        self.assertTrue(
-            any(
-                kwargs.get("plugin_type") == pl.PLUGIN_TYPE_COMMUNITY
-                for _, kwargs in mock_auto_install_enabled.call_args_list
-            )
-        )
         mock_raise_install_error.assert_called_once_with("missingdep_for_community")
         mock_run.assert_not_called()
 
@@ -1277,11 +1260,7 @@ class Plugin:
             "main",
         )
         mock_start_scheduler.assert_called_once()
-        mock_install_reqs.assert_called_once_with(
-            os.path.join(self.community_dir, "repo"),
-            "repo",
-            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
-        )
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1341,7 +1320,7 @@ class Plugin:
             "Expected one branch warning per explicitly branch-pinned plugin",
         )
         mock_start_scheduler.assert_called_once()
-        self.assertEqual(mock_install_reqs.call_count, 2)
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1395,7 +1374,7 @@ class Plugin:
         ]
         self.assertEqual(len(warning_calls), 1)
         mock_start_scheduler.assert_called_once()
-        self.assertEqual(mock_install_reqs.call_count, 2)
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1453,11 +1432,7 @@ class Plugin:
         )
         mock_update_check.assert_called_once()
         mock_start_scheduler.assert_called_once()
-        mock_install_reqs.assert_called_once_with(
-            os.path.join(self.community_dir, "repo"),
-            "repo",
-            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
-        )
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1465,7 +1440,7 @@ class Plugin:
     @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
-    def test_load_plugins_calls_community_dep_installer_even_when_disabled(
+    def test_load_plugins_skips_community_dep_installer_by_default(
         self,
         mock_start_scheduler,
         mock_get_custom_dirs,
@@ -1474,12 +1449,11 @@ class Plugin:
         mock_install_reqs,
         mock_clone_repo,
     ):
-        """Loader should always call installer helper and let it enforce policy."""
+        """Community dependency install should be skipped unless explicitly enabled."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
 
         config = {
-            "security": {"auto_install_deps": False},
             "community-plugins": {
                 "commit-plugin": {
                     "active": True,
@@ -1501,10 +1475,260 @@ class Plugin:
             load_plugins(config)
 
         mock_update_check.assert_called_once()
+        mock_install_reqs.assert_not_called()
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=True)
+    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch("mmrelay.plugin_loader._load_plugin_state", return_value={})
+    @patch(
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
+    )
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    def test_load_plugins_installs_community_requirements_when_opted_in_commit(
+        self,
+        mock_update_check,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_load_state,
+        mock_save_state,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Opted-in commit-pinned community plugin should install requirements."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_update_check.assert_called_once()
+        mock_resolve_local_head_commit.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_load_state.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
         mock_install_reqs.assert_called_once_with(
             os.path.join(self.community_dir, "repo"),
             "repo",
             plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
+        saved_state = mock_save_state.call_args.args[1]
+        self.assertEqual(
+            saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT),
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_opted_in_branch_and_tag_skip_dependency_install(
+        self,
+        mock_logger,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Branch/tag refs with install_requirements should warn and skip installation."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
+                "branch-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "branch": "main",
+                    "install_requirements": True,
+                },
+                "tag-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo2.git",
+                    "tag": "v1.0.0",
+                    "install_requirements": True,
+                },
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_install_reqs.assert_not_called()
+        warning_message = "Skipping dependency install for community plugin '%s': install_requirements requires a full 40-character commit pin; branch, tag, and default refs are not allowed."
+        mock_logger.warning.assert_any_call(warning_message, "branch-plugin")
+        mock_logger.warning.assert_any_call(warning_message, "tag-plugin")
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch(
+        "mmrelay.plugin_loader._load_plugin_state",
+        return_value={
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567"
+        },
+    )
+    @patch(
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
+    )
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    def test_load_plugins_opted_in_commit_unchanged_skips_dependency_install(
+        self,
+        mock_update_check,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_load_state,
+        mock_save_state,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Dependency install should be skipped when commit is already installed."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_update_check.assert_called_once()
+        mock_resolve_local_head_commit.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_load_state.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_install_reqs.assert_not_called()
+        mock_save_state.assert_not_called()
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=True)
+    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch(
+        "mmrelay.plugin_loader._load_plugin_state",
+        return_value={
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+    )
+    @patch(
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
+    )
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    def test_load_plugins_opted_in_commit_changed_installs_requirements(
+        self,
+        mock_update_check,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_load_state,
+        mock_save_state,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Dependency install should run when commit changes."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_update_check.assert_called_once()
+        mock_resolve_local_head_commit.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_load_state.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_install_reqs.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
+        saved_state = mock_save_state.call_args.args[1]
+        self.assertEqual(
+            saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT),
+            "0123456789abcdef0123456789abcdef01234567",
         )
         mock_start_scheduler.assert_called_once()
 
@@ -2608,54 +2832,6 @@ class TestGitOperations(BaseGitTest):
             ["git", "clone"], timeout=300, retry_attempts=5
         )
 
-    def test_check_auto_install_enabled_default(self):
-        """Test auto-install enabled by default."""
-        from mmrelay.plugin_loader import _check_auto_install_enabled
-
-        result = _check_auto_install_enabled(None)
-        self.assertTrue(result)
-
-    def test_check_auto_install_enabled_explicit_true(self):
-        """Test auto-install explicitly enabled."""
-        from mmrelay.plugin_loader import _check_auto_install_enabled
-
-        config = {"security": {"auto_install_deps": True}}
-        result = _check_auto_install_enabled(config)
-        self.assertTrue(result)
-
-    def test_check_auto_install_enabled_explicit_false(self):
-        """Test auto-install explicitly disabled."""
-        from mmrelay.plugin_loader import _check_auto_install_enabled
-
-        config = {"security": {"auto_install_deps": False}}
-        result = _check_auto_install_enabled(config)
-        self.assertFalse(result)
-
-    def test_check_auto_install_enabled_missing_security(self):
-        """Test auto-install when security section missing."""
-        from mmrelay.plugin_loader import _check_auto_install_enabled
-
-        config = {"other": "value"}
-        result = _check_auto_install_enabled(config)
-        self.assertTrue(result)
-
-    def test_check_auto_install_enabled_community_default_off(self):
-        """Community plugin dependency installs should default to disabled."""
-        from mmrelay.plugin_loader import _check_auto_install_enabled
-
-        result = _check_auto_install_enabled(None, plugin_type=pl.PLUGIN_TYPE_COMMUNITY)
-        self.assertFalse(result)
-
-    def test_check_auto_install_enabled_community_explicit_true(self):
-        """Community dependency installs should honor explicit config opt-in."""
-        from mmrelay.plugin_loader import _check_auto_install_enabled
-
-        config = {"security": {"auto_install_deps": True}}
-        result = _check_auto_install_enabled(
-            config, plugin_type=pl.PLUGIN_TYPE_COMMUNITY
-        )
-        self.assertTrue(result)
-
     @patch("mmrelay.plugin_loader.logger")
     def test_raise_install_error(self, mock_logger):
         """Test _raise_install_error logs and raises exception."""
@@ -2665,7 +2841,7 @@ class TestGitOperations(BaseGitTest):
             _raise_install_error("test-package")
 
         mock_logger.warning.assert_called_once_with(
-            "Auto-install disabled; cannot install test-package. See docs for enabling."
+            "Auto-install blocked by policy; cannot install test-package. See docs for enabling."
         )
 
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
@@ -4057,19 +4233,6 @@ class TestDependencyInstallation(BaseGitTest):
         super().tearDown()
 
     @patch("mmrelay.plugin_loader.logger")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
-    def test_install_plugin_requirements_disabled(
-        self, mock_check_enabled, mock_logger
-    ):
-        """Test dependency installation when disabled."""
-        mock_check_enabled.return_value = False
-        _install_requirements_for_repo(self.repo_path, "test-plugin")
-        mock_logger.warning.assert_called_with(
-            "Auto-install of requirements for %s disabled by config; skipping.",
-            "test-plugin",
-        )
-
-    @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_community_requirements_warns_once_when_enabled(
@@ -4078,13 +4241,7 @@ class TestDependencyInstallation(BaseGitTest):
         """Community dependency auto-install should emit the risk warning once."""
         mock_collect.return_value = ["requests==2.28.0"]
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
-        with (
-            patch.object(pl, "_community_dep_install_warning_logged", False),
-            patch(
-                "mmrelay.plugin_loader.config",
-                {"security": {"auto_install_deps": True}},
-            ),
-        ):
+        with patch.object(pl, "_community_dep_install_warning_logged", False):
             _install_requirements_for_repo(
                 self.repo_path,
                 "test-plugin",
@@ -4107,19 +4264,14 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertEqual(len(warning_calls), 1)
 
     @patch("mmrelay.plugin_loader._collect_requirements")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
-    def test_install_plugin_requirements_no_file(
-        self, mock_check_enabled, mock_collect
-    ):
+    def test_install_plugin_requirements_no_file(self, mock_collect):
         """Test dependency installation when requirements file doesn't exist."""
-        mock_check_enabled.return_value = True
         os.remove(self.requirements_path)
         _install_requirements_for_repo(self.repo_path, "test-plugin")
         mock_collect.assert_not_called()
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     @patch("mmrelay.plugin_loader._filter_risky_requirements")
     @patch("mmrelay.plugin_loader._collect_requirements")
     @patch("shutil.which", return_value=None)
@@ -4132,12 +4284,10 @@ class TestDependencyInstallation(BaseGitTest):
         mock_which,
         mock_collect,
         mock_filter,
-        mock_check_enabled,
         mock_run,
         mock_logger,
     ):
         """Test dependency installation with pip in virtual environment."""
-        mock_check_enabled.return_value = True
         mock_collect.return_value = ["requests==2.28.0"]
         mock_filter.return_value = (["requests==2.28.0"], [], False)
 
@@ -4163,10 +4313,12 @@ class TestDependencyInstallation(BaseGitTest):
         assert "-r" in called_cmd
         assert called_cmd[called_cmd.index("-r") + 1] == temp_req
         mock_run.assert_called_once_with(called_cmd, timeout=600)
+        mock_unlink.assert_called_once_with(temp_req)
+        mock_which.assert_not_called()
+        mock_logger.info.assert_called()
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     @patch("mmrelay.plugin_loader._filter_risky_requirements")
     @patch("mmrelay.plugin_loader._collect_requirements")
     @patch("shutil.which", return_value="/usr/bin/pipx")
@@ -4175,12 +4327,10 @@ class TestDependencyInstallation(BaseGitTest):
         mock_which,
         mock_collect,
         mock_filter,
-        mock_check_enabled,
         mock_run,
         mock_logger,
     ):
         """Test dependency installation with pipx."""
-        mock_check_enabled.return_value = True
         mock_collect.return_value = [
             "requests==2.28.0",
             "--extra-index-url https://pypi.org/simple",
@@ -4211,15 +4361,14 @@ class TestDependencyInstallation(BaseGitTest):
 
         # Verify timeout
         assert call_args[1]["timeout"] == 600
+        mock_which.assert_called_once_with("pipx")
+        mock_logger.info.assert_called()
 
     def test_install_plugin_requirements_pip_install(self):
         """Test dependency installation with pip."""
         with (
             patch("mmrelay.plugin_loader.logger"),
             patch("mmrelay.plugin_loader._run") as mock_run,
-            patch(
-                "mmrelay.plugin_loader._check_auto_install_enabled"
-            ) as mock_check_enabled,
             patch("mmrelay.plugin_loader._filter_risky_requirements") as mock_filter,
             patch("mmrelay.plugin_loader._collect_requirements") as mock_collect,
             patch("sys.prefix", "/fake/prefix"),
@@ -4230,7 +4379,6 @@ class TestDependencyInstallation(BaseGitTest):
             ) as mock_temp_file,
             patch("mmrelay.plugin_loader.os.unlink"),
         ):
-            mock_check_enabled.return_value = True
             mock_collect.return_value = ["requests==2.28.0"]
             mock_filter.return_value = (["requests==2.28.0"], [], False)
 
@@ -4263,19 +4411,16 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     @patch("mmrelay.plugin_loader._filter_risky_requirements")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_with_flagged_deps(
         self,
         mock_collect,
         mock_filter,
-        mock_check_enabled,
         mock_run,
         mock_logger,
     ):
         """Test dependency installation with flagged dependencies."""
-        mock_check_enabled.return_value = True
         mock_collect.return_value = [
             "requests==2.28.0",
             "git+https://github.com/user/repo.git",
@@ -4291,22 +4436,20 @@ class TestDependencyInstallation(BaseGitTest):
             1,
             "test-plugin",
         )
+        mock_run.assert_called_once()
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     @patch("mmrelay.plugin_loader._filter_risky_requirements")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_installation_error(
         self,
         mock_collect,
         mock_filter,
-        mock_check_enabled,
         mock_run,
         mock_logger,
     ):
         """Test handling of installation errors."""
-        mock_check_enabled.return_value = True
         mock_collect.return_value = ["requests==2.28.0"]
         mock_filter.return_value = (["requests==2.28.0"], [], False)
         mock_run.side_effect = subprocess.CalledProcessError(1, "pip")
@@ -4318,9 +4461,6 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch("mmrelay.plugin_loader.logger"),
             patch("mmrelay.plugin_loader._run") as mock_run,
-            patch(
-                "mmrelay.plugin_loader._check_auto_install_enabled"
-            ) as mock_check_enabled,
             patch("mmrelay.plugin_loader._filter_risky_requirements") as mock_filter,
             patch("mmrelay.plugin_loader._collect_requirements") as mock_collect,
             patch("sys.prefix", "/fake/prefix"),
@@ -4331,7 +4471,6 @@ class TestDependencyInstallation(BaseGitTest):
             ) as mock_temp_file,
             patch("mmrelay.plugin_loader.os.unlink"),
         ):
-            mock_check_enabled.return_value = True
             mock_collect.return_value = ["requests==2.28.0"]
             mock_filter.return_value = (["requests==2.28.0"], [], False)
 
@@ -4364,7 +4503,6 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     @patch("mmrelay.plugin_loader._filter_risky_requirements")
     @patch("mmrelay.plugin_loader._collect_requirements")
     @patch("shutil.which", return_value="/usr/bin/pipx")
@@ -4373,12 +4511,10 @@ class TestDependencyInstallation(BaseGitTest):
         mock_which,
         mock_collect,
         mock_filter,
-        mock_check_enabled,
         mock_run,
         mock_logger,
     ):
         """Test handling of pipx inject failure."""
-        mock_check_enabled.return_value = True
         mock_collect.return_value = ["requests==2.28.0"]
         mock_filter.return_value = (["requests==2.28.0"], [], False)
         mock_run.side_effect = subprocess.CalledProcessError(1, "pipx")
@@ -4395,14 +4531,12 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     @patch("mmrelay.plugin_loader._filter_risky_requirements")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_pipx_no_packages(
-        self, mock_collect, mock_filter, mock_check_enabled, mock_run, mock_logger
+        self, mock_collect, mock_filter, mock_run, mock_logger
     ):
         """Test pipx injection when no packages to install."""
-        mock_check_enabled.return_value = True
         mock_collect.return_value = ["--extra-index-url https://pypi.org/simple"]
         mock_filter.return_value = (
             ["--extra-index-url https://pypi.org/simple"],
@@ -4426,14 +4560,12 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     @patch("mmrelay.plugin_loader._filter_risky_requirements")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_allow_untrusted(
-        self, mock_collect, mock_filter, mock_check_enabled, mock_run, mock_logger
+        self, mock_collect, mock_filter, mock_run, mock_logger
     ):
         """Test dependency installation with untrusted dependencies allowed."""
-        mock_check_enabled.return_value = True
         mock_collect.return_value = [
             "requests==2.28.0",
             "git+https://github.com/user/repo.git",
@@ -5272,6 +5404,9 @@ class TestCommunityPluginSecurityHelpers(unittest.TestCase):
             expected_state = {
                 "last_notified_upstream_head": "abc123",
                 "last_checked_at": "2026-01-01T00:00:00+00:00",
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: (
+                    "0123456789abcdef0123456789abcdef01234567"
+                ),
             }
             pl._save_plugin_state(repo_path, expected_state)
             loaded_state = pl._load_plugin_state(repo_path)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1184,6 +1184,215 @@ class Plugin:
             self.community_dir,
         )
 
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_missing_ref_warns_unsafe_default(
+        self,
+        mock_logger,
+        _mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        _mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Missing refs should warn and still default to the main branch."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+
+        config = {
+            "community-plugins": {
+                "test-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_logger.warning.assert_any_call(
+            "No ref specified; defaulting to branch 'main' is deprecated and unsafe"
+        )
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_branch_warning_respects_allow_moving_ref(
+        self,
+        mock_logger,
+        _mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        _mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Branch refs warn unless allow_moving_ref is explicitly true."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+
+        config = {
+            "community-plugins": {
+                "warn-branch": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "branch": "main",
+                },
+                "allow-branch": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo2.git",
+                    "branch": "main",
+                    "allow_moving_ref": True,
+                },
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        branch_warning = (
+            "Branch refs are moving targets and not recommended in production"
+        )
+        warning_calls = [
+            call_args
+            for call_args in mock_logger.warning.call_args_list
+            if call_args.args and call_args.args[0] == branch_warning
+        ]
+        self.assertEqual(
+            len(warning_calls),
+            1,
+            "Expected one branch warning for the plugin without allow_moving_ref",
+        )
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_tag_warning_once_per_startup(
+        self,
+        mock_logger,
+        _mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        _mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Tag ref warning should be emitted once per load cycle."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+
+        config = {
+            "community-plugins": {
+                "tag-one": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "tag": "v1.0.0",
+                },
+                "tag-two": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo2.git",
+                    "tag": "v2.0.0",
+                },
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        tag_warning = "Tags can be retargeted; commit pins are safer"
+        warning_calls = [
+            call_args
+            for call_args in mock_logger.warning.call_args_list
+            if call_args.args and call_args.args[0] == tag_warning
+        ]
+        self.assertEqual(len(warning_calls), 1)
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_commit_ref_emits_no_branch_or_tag_warning(
+        self,
+        mock_logger,
+        mock_update_check,
+        _mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        _mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Commit refs should not emit branch/tag safety warnings."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        warning_texts = {
+            call_args.args[0]
+            for call_args in mock_logger.warning.call_args_list
+            if call_args.args
+        }
+        self.assertNotIn(
+            "Tags can be retargeted; commit pins are safer",
+            warning_texts,
+        )
+        self.assertNotIn(
+            "Branch refs are moving targets and not recommended in production",
+            warning_texts,
+        )
+        mock_update_check.assert_called_once()
+
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
     @patch("mmrelay.plugin_loader.logger")
@@ -2267,6 +2476,23 @@ class TestGitOperations(BaseGitTest):
 
         config = {"other": "value"}
         result = _check_auto_install_enabled(config)
+        self.assertTrue(result)
+
+    def test_check_auto_install_enabled_community_default_off(self):
+        """Community plugin dependency installs should default to disabled."""
+        from mmrelay.plugin_loader import _check_auto_install_enabled
+
+        result = _check_auto_install_enabled(None, plugin_type=pl.PLUGIN_TYPE_COMMUNITY)
+        self.assertFalse(result)
+
+    def test_check_auto_install_enabled_community_explicit_true(self):
+        """Community dependency installs should honor explicit config opt-in."""
+        from mmrelay.plugin_loader import _check_auto_install_enabled
+
+        config = {"security": {"auto_install_deps": True}}
+        result = _check_auto_install_enabled(
+            config, plugin_type=pl.PLUGIN_TYPE_COMMUNITY
+        )
         self.assertTrue(result)
 
     @patch("mmrelay.plugin_loader.logger")
@@ -3682,6 +3908,37 @@ class TestDependencyInstallation(BaseGitTest):
             "test-plugin",
         )
 
+    @patch("mmrelay.plugin_loader.logger")
+    @patch("mmrelay.plugin_loader._collect_requirements", return_value=[])
+    def test_install_community_requirements_warns_once_when_enabled(
+        self, _mock_collect, mock_logger
+    ):
+        """Community dependency auto-install should emit the risk warning once."""
+        pl._community_dep_install_warning_logged = False
+        with patch(
+            "mmrelay.plugin_loader.config", {"security": {"auto_install_deps": True}}
+        ):
+            _install_requirements_for_repo(
+                self.repo_path,
+                "test-plugin",
+                plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            )
+            _install_requirements_for_repo(
+                self.repo_path,
+                "test-plugin",
+                plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            )
+
+        risk_warning = (
+            "Community plugin dependencies execute arbitrary code and are unsafe"
+        )
+        warning_calls = [
+            call_args
+            for call_args in mock_logger.warning.call_args_list
+            if call_args.args and call_args.args[0] == risk_warning
+        ]
+        self.assertEqual(len(warning_calls), 1)
+
     @patch("mmrelay.plugin_loader._collect_requirements")
     @patch("mmrelay.plugin_loader._check_auto_install_enabled")
     def test_install_plugin_requirements_no_file(
@@ -4813,6 +5070,128 @@ class TestDependencyInstallation(BaseGitTest):
         # Should return False when all operations fail
         self.assertFalse(result)
         mock_logger.warning.assert_called()
+
+
+class TestCommunityPluginSecurityHelpers(unittest.TestCase):
+    """Focused tests for community plugin security-hardening helpers."""
+
+    def test_build_compare_url_supports_https_github(self):
+        """Compare URL should be generated for https GitHub repository URLs."""
+        compare_url = pl._build_compare_url(
+            "https://github.com/owner/repo.git",
+            "aaaabbbb",
+            "ccccdddd",
+        )
+        self.assertEqual(
+            compare_url,
+            "https://github.com/owner/repo/compare/aaaabbbb...ccccdddd",
+        )
+
+    def test_build_compare_url_supports_ssh_github(self):
+        """Compare URL should be generated for git@github.com repository URLs."""
+        compare_url = pl._build_compare_url(
+            "git@github.com:owner/repo.git",
+            "11112222",
+            "33334444",
+        )
+        self.assertEqual(
+            compare_url,
+            "https://github.com/owner/repo/compare/11112222...33334444",
+        )
+
+    def test_state_file_read_write_round_trip(self):
+        """State files should persist and reload plugin state safely."""
+        with tempfile.TemporaryDirectory() as repo_path:
+            expected_state = {
+                "last_notified_upstream_head": "abc123",
+                "last_checked_at": "2026-01-01T00:00:00+00:00",
+            }
+            pl._save_plugin_state(repo_path, expected_state)
+            loaded_state = pl._load_plugin_state(repo_path)
+            self.assertEqual(loaded_state, expected_state)
+
+    def test_state_file_invalid_json_returns_empty(self):
+        """Invalid state JSON should be ignored without raising."""
+        with tempfile.TemporaryDirectory() as repo_path:
+            state_path = os.path.join(repo_path, pl.PLUGIN_STATE_FILENAME)
+            with open(state_path, "w", encoding="utf-8") as handle:
+                handle.write("{invalid json}")
+            self.assertEqual(pl._load_plugin_state(repo_path), {})
+
+    @patch("mmrelay.plugin_loader._run_git")
+    def test_resolve_remote_default_branch_parses_symref_output(self, mock_run_git):
+        """Default branch resolver should parse `git ls-remote --symref` output."""
+        mock_run_git.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(
+                "ref: refs/heads/main\tHEAD\n"
+                "0123456789abcdef0123456789abcdef01234567\tHEAD\n"
+            ),
+            stderr="",
+        )
+        self.assertEqual(pl._resolve_remote_default_branch("/tmp/repo"), "main")
+
+    @patch("mmrelay.plugin_loader._resolve_local_head_commit")
+    @patch("mmrelay.plugin_loader._resolve_remote_default_branch")
+    @patch("mmrelay.plugin_loader._resolve_remote_branch_head_commit")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_check_commit_pin_update_detection_and_dedupe(
+        self,
+        mock_logger,
+        mock_resolve_remote_head,
+        mock_resolve_default_branch,
+        mock_resolve_local_head,
+    ):
+        """Commit update notification should persist and dedupe by upstream head."""
+        pinned_sha = "0123456789abcdef0123456789abcdef01234567"
+        upstream_sha = "89abcdef0123456789abcdef0123456789abcdef"
+        mock_resolve_local_head.return_value = pinned_sha
+        mock_resolve_default_branch.return_value = "main"
+        mock_resolve_remote_head.return_value = upstream_sha
+        compare_url = (
+            "https://github.com/owner/repo/compare/"
+            "0123456789abcdef0123456789abcdef01234567..."
+            "89abcdef0123456789abcdef0123456789abcdef"
+        )
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            pl._check_commit_pin_for_upstream_updates(
+                "demo-plugin",
+                "https://github.com/owner/repo.git",
+                repo_path,
+            )
+            state = pl._load_plugin_state(repo_path)
+            self.assertEqual(state.get("last_notified_upstream_head"), upstream_sha)
+            self.assertIsInstance(state.get("last_checked_at"), str)
+            mock_logger.warning.assert_any_call(
+                "Plugin '%s' is pinned to %s, upstream is now %s",
+                "demo-plugin",
+                pinned_sha,
+                upstream_sha,
+            )
+            mock_logger.warning.assert_any_call("Compare: %s", compare_url)
+
+            # Force re-check by setting an old timestamp, but keep same notified head.
+            state["last_checked_at"] = "2000-01-01T00:00:00+00:00"
+            pl._save_plugin_state(repo_path, state)
+            mock_logger.warning.reset_mock()
+
+            pl._check_commit_pin_for_upstream_updates(
+                "demo-plugin",
+                "https://github.com/owner/repo.git",
+                repo_path,
+            )
+
+            self.assertFalse(
+                any(
+                    call_args.args
+                    and call_args.args[0]
+                    == "Plugin '%s' is pinned to %s, upstream is now %s"
+                    for call_args in mock_logger.warning.call_args_list
+                ),
+                "Expected no duplicate pinned-vs-upstream warning",
+            )
 
 
 class TestExecPluginModuleThreadSafety(unittest.TestCase):

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1036,11 +1036,11 @@ class Plugin:
     @patch("mmrelay.plugin_loader.start_global_scheduler")
     def test_load_plugins_commit_priority_over_tag_and_branch(
         self,
-        _,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        __,
+        mock_install_reqs,
         mock_clone_repo,
     ):
         """Test that commit ref takes priority over tag and branch in plugin config."""
@@ -1075,6 +1075,8 @@ class Plugin:
             {"type": "commit", "value": "deadbeef"},
             self.community_dir,
         )
+        mock_start_scheduler.assert_called_once()
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1084,11 +1086,11 @@ class Plugin:
     @patch("mmrelay.plugin_loader.start_global_scheduler")
     def test_load_plugins_tag_priority_over_branch(
         self,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_install_reqs,
+        mock_install_reqs,
         mock_clone_repo,
     ):
         """Test that tag ref takes priority over branch in plugin config."""
@@ -1122,6 +1124,8 @@ class Plugin:
             {"type": "tag", "value": "v1.0.0"},
             self.community_dir,
         )
+        mock_start_scheduler.assert_called_once()
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1133,11 +1137,11 @@ class Plugin:
     def test_load_plugins_commit_with_tag_and_branch_warning(
         self,
         mock_logger,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_install_reqs,
+        mock_install_reqs,
         mock_clone_repo,
     ):
         """Test that warning is logged when commit is specified with tag/branch."""
@@ -1170,6 +1174,8 @@ class Plugin:
         mock_logger.warning.assert_any_call(
             "Commit specified along with tag/branch for plugin test-plugin, using commit"
         )
+        mock_start_scheduler.assert_called_once()
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1179,11 +1185,11 @@ class Plugin:
     @patch("mmrelay.plugin_loader.start_global_scheduler")
     def test_load_plugins_default_to_main_branch(
         self,
-        _mock_start_scheduler,
+        mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_install_reqs,
+        mock_install_reqs,
         mock_clone_repo,
     ):
         """Test that plugin defaults to main branch when no ref is specified."""
@@ -1215,6 +1221,8 @@ class Plugin:
             {"type": "branch", "value": "main"},
             self.community_dir,
         )
+        mock_start_scheduler.assert_called_once()
+        mock_install_reqs.assert_not_called()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
@@ -1307,7 +1315,8 @@ class Plugin:
         load_plugins(config)
 
         branch_warning = (
-            "Branch refs are moving targets and not recommended in production"
+            "Community plugin '%s' uses a branch ref; branch refs are moving "
+            "targets and not recommended in production"
         )
         warning_calls = [
             call_args
@@ -1318,6 +1327,10 @@ class Plugin:
             len(warning_calls),
             2,
             "Expected one branch warning per explicitly branch-pinned plugin",
+        )
+        self.assertEqual(
+            {call_args.args[1] for call_args in warning_calls},
+            {"warn-branch", "allow-branch"},
         )
         mock_start_scheduler.assert_called_once()
         mock_install_reqs.assert_not_called()
@@ -1427,7 +1440,8 @@ class Plugin:
             warning_texts,
         )
         self.assertNotIn(
-            "Branch refs are moving targets and not recommended in production",
+            "Community plugin '%s' uses a branch ref; branch refs are moving "
+            "targets and not recommended in production",
             warning_texts,
         )
         mock_update_check.assert_called_once()
@@ -4382,7 +4396,7 @@ class TestDependencyInstallation(BaseGitTest):
         """Community dependency auto-install should emit the risk warning once."""
         mock_collect.return_value = ["requests==2.28.0"]
         mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
-        with patch.object(pl, "_community_dep_install_warning_logged", False):
+        with patch.object(pl, "_community_dep_install_warning_logged", new=False):
             _install_requirements_for_repo(
                 self.repo_path,
                 "test-plugin",


### PR DESCRIPTION
## Overview

This PR improves how community plugins are handled by making dependency installation explicit, safer by default, and easier to reason about. It removes implicit behavior, introduces per-plugin install control, and ensures installs only occur when a plugin revision changes.

## Key changes

### Features

* Per-plugin install opt-in: adds `install_requirements` for community plugins to explicitly allow installing dependencies.
* Persistent plugin state: introduces `.mmrelay-plugin-state.json` to track the last installed commit and avoid redundant installs.
* Once-per-commit installs: dependencies are installed only when the resolved plugin commit changes.
* Upstream change notifications: commit-pinned plugins log a notice when the upstream default branch moves ahead of the pinned commit.
* Improved docs and examples: README and sample config now clearly document expected usage and recommended patterns.

### Behavior / Safety improvements

* Community plugin dependencies are no longer auto-installed by default.
* Missing dependencies for community plugins now raise a clear policy error instead of triggering implicit installs.
* Install behavior is tied to explicit refs:

  * Commit (recommended): installs allowed
  * Branch/tag: installs allowed with warnings (moving/retargetable refs)
  * No ref: install skipped with warning
* Full 40-character commit SHAs are required for commit-based install eligibility.
* One-time warning is logged about the risks of installing community plugin dependencies.

### Refactors

* Simplified install flow and centralized dependency install behavior.
* Removed previous global config-based install gating in favor of per-plugin control.
* Improved internal handling of plugin type throughout the load process.

### Tests

* Expanded coverage for:

  * install opt-in behavior
  * ref handling (commit / tag / branch / missing)
  * once-per-commit install logic
  * state persistence and recovery
  * upstream change notifications
* Cleaned up test structure and removed unused mocks.

### Documentation

* Updated README and sample config with concise guidance.
* Clarified that community plugins run in-process and require trust.
* Added clear explanation of `install_requirements` and install behavior.

## Breaking changes / migration notes

* Community plugin dependency installation is no longer implicit.
* To enable installs, configurations must:

  * set `install_requirements: true`
  * provide an explicit ref (commit recommended)
* Configurations that relied on implicit installs or omitted refs may no longer install dependencies automatically.

---

## Migration example

**Before:**

```yaml
community-plugins:
  my-plugin:
    active: true
    repository: https://github.com/example/my-plugin
```

**After (recommended):**

```yaml
community-plugins:
  my-plugin:
    active: true
    repository: https://github.com/example/my-plugin
    commit: 0123456789abcdef0123456789abcdef01234567
    install_requirements: true
```

**Alternative (allowed, not recommended for production):**

```yaml
community-plugins:
  my-plugin:
    active: true
    repository: https://github.com/example/my-plugin
    branch: main
    install_requirements: true
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->