### PR TITLE
Switch Inno Setup installer builder to a maintained action & consolidate version management in pyproject.toml

### DIFF
--- a/.github/workflows/build-pyz-armv7.yml
+++ b/.github/workflows/build-pyz-armv7.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Extract version and git SHA
         id: get_version
         run: |
-          # Extract version from mmrelay module
-          VERSION=$(python3 -c "import sys; sys.path.insert(0, 'src'); from mmrelay import __version__; print(__version__)")
+          # Extract version from pyproject.toml
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Extracted version: $VERSION"
           GIT_SHA=$(git rev-parse --short HEAD)

--- a/.github/workflows/build-pyz-armv7.yml
+++ b/.github/workflows/build-pyz-armv7.yml
@@ -50,18 +50,23 @@ jobs:
 
       - name: Extract version and git SHA
         id: get_version
+        shell: bash
         run: |
+          set -euo pipefail
+
           # Extract version from pyproject.toml
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          VERSION="$(
+            python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
+          )"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Extracted version: $VERSION"
           GIT_SHA=$(git rev-parse --short HEAD)
-          echo "GIT_SHA=$GIT_SHA" >> $GITHUB_ENV
+          echo "GIT_SHA=$GIT_SHA" >> "$GITHUB_ENV"
           # Set FILE_VERSION to just the version for releases, or version-dev-SHA for PRs/manual runs
           if [ "${{ github.event_name }}" == "release" ]; then
-            echo "FILE_VERSION=$VERSION" >> $GITHUB_ENV
+            echo "FILE_VERSION=$VERSION" >> "$GITHUB_ENV"
           else
-            echo "FILE_VERSION=$VERSION-dev-$GIT_SHA" >> $GITHUB_ENV
+            echo "FILE_VERSION=$VERSION-dev-$GIT_SHA" >> "$GITHUB_ENV"
           fi
 
       - name: Build inside ARMv7 Docker (using pre-built builder)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Extract version and build info
         id: get_version
         run: |
-          VERSION=$(python3 -c "import sys; sys.path.insert(0, 'src'); from mmrelay import __version__; print(__version__)")
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,29 +24,34 @@ jobs:
 
       - name: Extract version and build info
         id: get_version
+        shell: bash
         run: |
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          VERSION="$(
+            python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
+          )"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo "build_date=$BUILD_DATE" >> $GITHUB_OUTPUT
+          echo "build_date=$BUILD_DATE" >> "$GITHUB_OUTPUT"
 
           VCS_REF=$(git rev-parse HEAD)
-          echo "vcs_ref=$VCS_REF" >> $GITHUB_OUTPUT
+          echo "vcs_ref=$VCS_REF" >> "$GITHUB_OUTPUT"
 
           GIT_SHA=$(git rev-parse --short HEAD)
-          echo "git_sha=$GIT_SHA" >> $GITHUB_OUTPUT
+          echo "git_sha=$GIT_SHA" >> "$GITHUB_OUTPUT"
 
           if [ "${{ github.event_name }}" == "release" ]; then
-            echo "docker_tag=$VERSION" >> $GITHUB_OUTPUT
-            echo "is_release=true" >> $GITHUB_OUTPUT
-            echo "should_tag_latest=true" >> $GITHUB_OUTPUT
+            echo "docker_tag=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+            echo "should_tag_latest=true" >> "$GITHUB_OUTPUT"
           else
             # Sanitize branch name for Docker tag (replace slashes and special chars)
             BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-            echo "docker_tag=$VERSION-dev-$BRANCH_NAME-$GIT_SHA" >> $GITHUB_OUTPUT
-            echo "is_release=false" >> $GITHUB_OUTPUT
-            echo "should_tag_latest=false" >> $GITHUB_OUTPUT
+            echo "docker_tag=$VERSION-dev-$BRANCH_NAME-$GIT_SHA" >> "$GITHUB_OUTPUT"
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "should_tag_latest=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up QEMU for multi-platform builds

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -59,9 +59,10 @@ jobs:
         run: pyinstaller --name=mmrelay.exe --onefile --console --collect-all rich src/mmrelay/main.py
 
       - name: Build installer
-        uses: nadeemjazmawe/inno-setup-action-cli@31fe986b893b62ba38889603be4a74452a8f6362 # v6.0.5
+        uses: sharktide/iscc-cli@6f80e2e08ffc0606116be38199a77902d266b09a # v1.0.0
         with:
-          filepath: "/DAppVersion=${{ env.FILE_VERSION }} ./scripts/mmrelay.iss"
+          filepath: "./scripts/mmrelay.iss"
+          options: "/DAppVersion=${{ env.FILE_VERSION }}"
 
       - name: Upload installer as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -36,17 +36,21 @@ jobs:
         id: get_version
         shell: bash
         run: |
+          set -euo pipefail
+
           # Extract version from pyproject.toml
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          VERSION="$(
+            python -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
+          )"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Extracted version: $VERSION"
           GIT_SHA=$(git rev-parse --short HEAD)
-          echo "GIT_SHA=$GIT_SHA" >> $GITHUB_ENV
+          echo "GIT_SHA=$GIT_SHA" >> "$GITHUB_ENV"
           # Set FILE_VERSION to just the version for releases, or version-dev-SHA for PRs/manual runs
           if [ "${{ github.event_name }}" == "release" ]; then
-            echo "FILE_VERSION=$VERSION" >> $GITHUB_ENV
+            echo "FILE_VERSION=$VERSION" >> "$GITHUB_ENV"
           else
-            echo "FILE_VERSION=$VERSION-dev-$GIT_SHA" >> $GITHUB_ENV
+            echo "FILE_VERSION=$VERSION-dev-$GIT_SHA" >> "$GITHUB_ENV"
           fi
 
       - name: Install dependencies

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -36,8 +36,8 @@ jobs:
         id: get_version
         shell: bash
         run: |
-          # Extract version from mmrelay module
-          VERSION=$(python3 -c "import sys; sys.path.insert(0, 'src'); from mmrelay import __version__; print(__version__)")
+          # Extract version from pyproject.toml
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Extracted version: $VERSION"
           GIT_SHA=$(git rev-parse --short HEAD)

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -63,6 +63,8 @@ jobs:
         run: pyinstaller --name=mmrelay.exe --onefile --console --collect-all rich src/mmrelay/main.py
 
       - name: Build installer
+        # Intentionally using a SHA-pinned action that supports `filepath` + `options`.
+        # Keep this pinned to control supply-chain risk and avoid interface drift.
         uses: sharktide/iscc-cli@6f80e2e08ffc0606116be38199a77902d266b09a # v1.0.0
         with:
           filepath: "./scripts/mmrelay.iss"

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -11,15 +11,18 @@ jobs:
   bump-main-to-next-patch:
     if: github.event.release.target_commitish == 'main'
     runs-on: ubuntu-latest
+    env:
+      RELEASE_BUMP_PAT: ${{ secrets.RELEASE_BUMP_PAT }}
 
     steps:
       - name: Validate release bump token
-        if: ${{ secrets.RELEASE_BUMP_PAT == '' }}
         shell: bash
         run: |
           set -euo pipefail
-          echo "::error::RELEASE_BUMP_PAT secret is required for post-release push to main."
-          exit 1
+          if [[ -z "${RELEASE_BUMP_PAT:-}" ]]; then
+            echo "::error::RELEASE_BUMP_PAT secret is required for post-release push to main."
+            exit 1
+          fi
 
       - name: Checkout main branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -60,7 +63,7 @@ jobs:
           echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push version bump
-        if: ${{ steps.bump.outputs.current != steps.bump.outputs.new && secrets.RELEASE_BUMP_PAT != '' }}
+        if: steps.bump.outputs.current != steps.bump.outputs.new
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -13,12 +13,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate release bump token
+        if: ${{ secrets.RELEASE_BUMP_PAT == '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::error::RELEASE_BUMP_PAT secret is required for post-release push to main."
+          exit 1
+
       - name: Checkout main branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_BUMP_PAT || github.token }}
+          token: ${{ secrets.RELEASE_BUMP_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -52,7 +60,7 @@ jobs:
           echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push version bump
-        if: steps.bump.outputs.current != steps.bump.outputs.new
+        if: ${{ steps.bump.outputs.current != steps.bump.outputs.new && secrets.RELEASE_BUMP_PAT != '' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -64,11 +64,14 @@ jobs:
 
       - name: Commit and push version bump
         if: steps.bump.outputs.current != steps.bump.outputs.new
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         shell: bash
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
-          git commit -m "chore(version): bump to ${{ steps.bump.outputs.new }} after release ${{ github.event.release.tag_name }}"
+          git commit -m "chore(version): bump to ${NEW_VERSION} after release ${RELEASE_TAG}"
           git push origin HEAD:main

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          pip install bump-my-version
+          pip install bump-my-version==1.3.0
 
       - name: Bump patch version
         id: bump

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -1,0 +1,63 @@
+name: Post-Release Version Bump
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bump-main-to-next-patch:
+    if: github.event.release.target_commitish == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BUMP_PAT || github.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install bump-my-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install bump-my-version
+
+      - name: Bump patch version
+        id: bump
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CURRENT_VERSION="$(
+            python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
+          )"
+
+          bump-my-version bump patch
+
+          NEW_VERSION="$(
+            python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
+          )"
+
+          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push version bump
+        if: steps.bump.outputs.current != steps.bump.outputs.new
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore(version): bump to ${{ steps.bump.outputs.new }} after release ${{ github.event.release.tag_name }}"
+          git push origin HEAD:main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mmrelay"
-dynamic = ["version"]
+version = "1.3.5"
 description = "Bridge between Meshtastic mesh networks and Matrix chat rooms"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -66,9 +66,6 @@ mmrelay = "mmrelay.cli:main"
 [tool.setuptools]
 package-dir = { "" = "src" }
 include-package-data = false
-
-[tool.setuptools.dynamic]
-version = { attr = "mmrelay.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,16 +88,8 @@ allow_dirty = false
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = """
-[project]
-name = "mmrelay"
-version = "{current_version}"
-"""
-replace = """
-[project]
-name = "mmrelay"
-version = "{new_version}"
-"""
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,8 @@ allow_dirty = false
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = 'version = "{current_version}"'
-replace = 'version = "{new_version}"'
+search = "\nversion = \"{current_version}\""
+replace = "\nversion = \"{new_version}\""
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,31 @@ where = ["src"]
 
 [tool.setuptools.exclude-package-data]
 "*" = ["__pycache__/*", "*.py[cod]"]
+
+[tool.bumpversion]
+current_version = "1.3.5"
+parse = '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+commit = false
+tag = false
+allow_dirty = false
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = """
+[project]
+name = "mmrelay"
+version = "{current_version}"
+"""
+replace = """
+[project]
+name = "mmrelay"
+version = "{new_version}"
+"""
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'current_version = "{current_version}"'
+replace = 'current_version = "{new_version}"'

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -1,5 +1,3 @@
 """
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
-
-__version__: str = "1.3.4"

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -1,3 +1,7 @@
 """
 Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix chat rooms.
 """
+
+from mmrelay._version import __version__
+
+__all__ = ["__version__"]

--- a/src/mmrelay/_version.py
+++ b/src/mmrelay/_version.py
@@ -56,7 +56,10 @@ def _version_from_pyproject() -> str | None:
         if tomllib is not None:
             with pyproject.open("rb") as handle:
                 data = tomllib.load(handle)
-            version = data.get("project", {}).get("version")
+            project = data.get("project")
+            if not isinstance(project, dict):
+                return None
+            version = project.get("version")
             if isinstance(version, str):
                 normalized = version.strip()
                 return normalized or None

--- a/src/mmrelay/_version.py
+++ b/src/mmrelay/_version.py
@@ -1,0 +1,105 @@
+"""
+Version helpers with source-checkout fallback support.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as metadata_version
+from pathlib import Path
+from typing import Final
+
+_PACKAGE_NAME: Final[str] = "mmrelay"
+_UNKNOWN_VERSION: Final[str] = "0+unknown"
+_PROJECT_VERSION_RE: Final[re.Pattern[str]] = re.compile(
+    r"""^version\s*=\s*["'](?P<version>[^"']+)["']\s*$"""
+)
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback path
+    tomllib = None  # type: ignore[assignment]
+
+
+def _version_from_metadata() -> str | None:
+    """
+    Return installed package version metadata, if available.
+    """
+    try:
+        return metadata_version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return None
+
+
+def _find_pyproject_toml() -> Path | None:
+    """
+    Find pyproject.toml by walking upward from this module.
+    """
+    this_file = Path(__file__).resolve()
+    for parent in this_file.parents:
+        candidate = parent / "pyproject.toml"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _version_from_pyproject() -> str | None:
+    """
+    Read project.version from pyproject.toml in source checkouts.
+    """
+    pyproject = _find_pyproject_toml()
+    if pyproject is None:
+        return None
+
+    try:
+        if tomllib is not None:
+            with pyproject.open("rb") as handle:
+                data = tomllib.load(handle)
+            version = data.get("project", {}).get("version")
+            if isinstance(version, str):
+                normalized = version.strip()
+                return normalized or None
+
+        # Python 3.10 fallback: parse only [project] version entry.
+        in_project_section = False
+        for line in pyproject.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith("[") and stripped.endswith("]"):
+                in_project_section = stripped == "[project]"
+                continue
+            if not in_project_section:
+                continue
+            match = _PROJECT_VERSION_RE.match(stripped)
+            if match:
+                normalized = match.group("version").strip()
+                return normalized or None
+    except (OSError, UnicodeError, ValueError):
+        return None
+
+    return None
+
+
+def get_version() -> str:
+    """
+    Return application version with stable fallbacks.
+
+    Precedence:
+    1) Installed package metadata
+    2) pyproject.toml from source checkout
+    3) 0+unknown sentinel
+    """
+    metadata_value = _version_from_metadata()
+    if metadata_value:
+        return metadata_value
+
+    pyproject_value = _version_from_pyproject()
+    if pyproject_value:
+        return pyproject_value
+
+    return _UNKNOWN_VERSION
+
+
+__version__: Final[str] = get_version()

--- a/src/mmrelay/_version.py
+++ b/src/mmrelay/_version.py
@@ -13,7 +13,7 @@ from typing import Final
 _PACKAGE_NAME: Final[str] = "mmrelay"
 _UNKNOWN_VERSION: Final[str] = "0+unknown"
 _PROJECT_VERSION_RE: Final[re.Pattern[str]] = re.compile(
-    r"""^version\s*=\s*["'](?P<version>[^"']+)["']\s*$"""
+    r"""^version\s*=\s*["'](?P<version>[^"']+)["']\s*(?:#.*)?$"""
 )
 
 try:
@@ -60,6 +60,7 @@ def _version_from_pyproject() -> str | None:
             if isinstance(version, str):
                 normalized = version.strip()
                 return normalized or None
+            return None
 
         # Python 3.10 fallback: parse only [project] version entry.
         in_project_section = False

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -13,12 +13,14 @@ import platform
 import shutil
 import sys
 from collections.abc import Mapping
+
+# Import version from package
+from importlib.metadata import version as _get_version
 from typing import Any
 
 import yaml
 
-# Import version from package
-from mmrelay import __version__
+__version__ = _get_version("mmrelay")
 from mmrelay.cli_utils import (
     get_command,
     get_deprecation_warning,

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -20,7 +20,10 @@ from typing import Any
 
 import yaml
 
-__version__ = _get_version("mmrelay")
+try:
+    __version__ = _get_version("mmrelay")
+except Exception:
+    __version__ = "unknown"
 from mmrelay.cli_utils import (
     get_command,
     get_deprecation_warning,

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -13,17 +13,11 @@ import platform
 import shutil
 import sys
 from collections.abc import Mapping
-
-# Import version from package
-from importlib.metadata import version as _get_version
 from typing import Any
 
 import yaml
 
-try:
-    __version__ = _get_version("mmrelay")
-except Exception:
-    __version__ = "unknown"
+from mmrelay._version import __version__
 from mmrelay.cli_utils import (
     get_command,
     get_deprecation_warning,

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -27,9 +27,13 @@ from nio import (
 )
 from nio.events.room_events import RoomMemberEvent
 
+# isort: skip
 from mmrelay import meshtastic_utils
 
-__version__ = _get_version("mmrelay")
+try:
+    __version__ = _get_version("mmrelay")
+except Exception:
+    __version__ = "unknown"
 from mmrelay.cli_utils import msg_suggest_check_config, msg_suggest_generate_config
 from mmrelay.constants.app import (
     APP_DISPLAY_NAME,

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -10,10 +10,6 @@ import signal
 import sys
 import tempfile
 import threading
-
-# Import version from package
-# Import meshtastic_utils as a module to set event_loop
-from importlib.metadata import version as _get_version
 from pathlib import Path
 from typing import Any, Callable, cast
 
@@ -27,13 +23,7 @@ from nio import (
 )
 from nio.events.room_events import RoomMemberEvent
 
-# isort: skip
-from mmrelay import meshtastic_utils
-
-try:
-    __version__ = _get_version("mmrelay")
-except Exception:
-    __version__ = "unknown"
+from mmrelay._version import __version__
 from mmrelay.cli_utils import msg_suggest_check_config, msg_suggest_generate_config
 from mmrelay.constants.app import (
     APP_DISPLAY_NAME,
@@ -90,6 +80,9 @@ from mmrelay.message_queue import (
 )
 from mmrelay.paths import get_home_dir, get_legacy_dirs, get_legacy_env_vars
 from mmrelay.plugin_loader import load_plugins, shutdown_plugins
+
+# Import as module to set event_loop.
+from mmrelay import meshtastic_utils  # isort: skip
 
 # Initialize logger
 logger = get_logger(name=APP_DISPLAY_NAME)

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -10,6 +10,10 @@ import signal
 import sys
 import tempfile
 import threading
+
+# Import version from package
+# Import meshtastic_utils as a module to set event_loop
+from importlib.metadata import version as _get_version
 from pathlib import Path
 from typing import Any, Callable, cast
 
@@ -23,9 +27,9 @@ from nio import (
 )
 from nio.events.room_events import RoomMemberEvent
 
-# Import version from package
-# Import meshtastic_utils as a module to set event_loop
-from mmrelay import __version__, meshtastic_utils
+from mmrelay import meshtastic_utils
+
+__version__ = _get_version("mmrelay")
 from mmrelay.cli_utils import msg_suggest_check_config, msg_suggest_generate_config
 from mmrelay.constants.app import (
     APP_DISPLAY_NAME,

--- a/tests/test_version_helper.py
+++ b/tests/test_version_helper.py
@@ -38,3 +38,45 @@ def test_get_version_uses_unknown_sentinel_when_unavailable() -> None:
         patch.object(version_helper, "_version_from_pyproject", return_value=None),
     ):
         assert version_helper.get_version() == "0+unknown"
+
+
+def test_version_from_pyproject_reads_real_toml(tmp_path) -> None:
+    """
+    pyproject parsing should read [project].version from a real file.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "mmrelay"\nversion = "4.5.6"\n',
+        encoding="utf-8",
+    )
+    with patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject):
+        assert version_helper._version_from_pyproject() == "4.5.6"
+
+
+def test_version_from_pyproject_regex_fallback_without_tomllib(tmp_path) -> None:
+    """
+    Python 3.10 fallback should parse version when tomllib is unavailable.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "mmrelay"\nversion = "7.8.9"\n',
+        encoding="utf-8",
+    )
+    with (
+        patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject),
+        patch.object(version_helper, "tomllib", new=None),
+    ):
+        assert version_helper._version_from_pyproject() == "7.8.9"
+
+
+def test_version_from_pyproject_returns_none_for_malformed_toml(tmp_path) -> None:
+    """
+    Malformed pyproject TOML should safely return None.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "mmrelay"\nversion = [\n',
+        encoding="utf-8",
+    )
+    with patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject):
+        assert version_helper._version_from_pyproject() is None

--- a/tests/test_version_helper.py
+++ b/tests/test_version_helper.py
@@ -2,7 +2,7 @@
 Tests for shared version helper behavior.
 """
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import mmrelay._version as version_helper
 
@@ -96,8 +96,13 @@ def test_version_from_pyproject_tomllib_missing_version_does_not_fallback(
         '[project]\nname = "mmrelay"\ndynamic = ["version"]\n',
         encoding="utf-8",
     )
+    mock_tomllib = Mock()
+    mock_tomllib.load.return_value = {
+        "project": {"name": "mmrelay", "dynamic": ["version"]}
+    }
     with (
         patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject),
+        patch.object(version_helper, "tomllib", new=mock_tomllib),
         patch.object(
             type(pyproject),
             "read_text",

--- a/tests/test_version_helper.py
+++ b/tests/test_version_helper.py
@@ -69,6 +69,44 @@ def test_version_from_pyproject_regex_fallback_without_tomllib(tmp_path) -> None
         assert version_helper._version_from_pyproject() == "7.8.9"
 
 
+def test_version_from_pyproject_regex_fallback_allows_inline_comment(tmp_path) -> None:
+    """
+    Python 3.10 fallback should parse version lines with inline comments.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "mmrelay"\nversion = "7.8.9"  # comment\n',
+        encoding="utf-8",
+    )
+    with (
+        patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject),
+        patch.object(version_helper, "tomllib", new=None),
+    ):
+        assert version_helper._version_from_pyproject() == "7.8.9"
+
+
+def test_version_from_pyproject_tomllib_missing_version_does_not_fallback(
+    tmp_path,
+) -> None:
+    """
+    When tomllib is available and project.version is missing, fallback scanner is not used.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "mmrelay"\ndynamic = ["version"]\n',
+        encoding="utf-8",
+    )
+    with (
+        patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject),
+        patch.object(
+            type(pyproject),
+            "read_text",
+            side_effect=AssertionError("fallback scanner should not run"),
+        ),
+    ):
+        assert version_helper._version_from_pyproject() is None
+
+
 def test_version_from_pyproject_returns_none_for_malformed_toml(tmp_path) -> None:
     """
     Malformed pyproject TOML should safely return None.

--- a/tests/test_version_helper.py
+++ b/tests/test_version_helper.py
@@ -1,0 +1,40 @@
+"""
+Tests for shared version helper behavior.
+"""
+
+from unittest.mock import patch
+
+import mmrelay._version as version_helper
+
+
+def test_get_version_prefers_metadata() -> None:
+    """
+    Installed package metadata should take precedence.
+    """
+    with (
+        patch.object(version_helper, "_version_from_metadata", return_value="9.9.9"),
+        patch.object(version_helper, "_version_from_pyproject", return_value="1.2.3"),
+    ):
+        assert version_helper.get_version() == "9.9.9"
+
+
+def test_get_version_falls_back_to_pyproject() -> None:
+    """
+    Source checkout pyproject version should be used when metadata is unavailable.
+    """
+    with (
+        patch.object(version_helper, "_version_from_metadata", return_value=None),
+        patch.object(version_helper, "_version_from_pyproject", return_value="1.2.3"),
+    ):
+        assert version_helper.get_version() == "1.2.3"
+
+
+def test_get_version_uses_unknown_sentinel_when_unavailable() -> None:
+    """
+    Unknown sentinel should be returned when no version source is available.
+    """
+    with (
+        patch.object(version_helper, "_version_from_metadata", return_value=None),
+        patch.object(version_helper, "_version_from_pyproject", return_value=None),
+    ):
+        assert version_helper.get_version() == "0+unknown"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR centralizes and hardens project version handling by moving the canonical version into pyproject.toml, adding a runtime version helper that resolves versions from installed metadata or from pyproject.toml with safe fallbacks, updating CI workflows to extract version from pyproject.toml, switching the Windows Inno Setup action to a maintained action, and adding tests and a post-release bump workflow.

## Changes by Category

- Features
  - Added src/mmrelay/_version.py:
    - get_version() resolves the package version with precedence: importlib.metadata (installed package) → pyproject.toml (source checkout).
    - Uses tomllib on Python 3.11+; a conservative, regex-based fallback parser is used otherwise.
    - Exposes __version__ at import time.
  - Exposed __version__ in src/mmrelay/__init__.py by importing from mmrelay._version and added __all__ = ["__version__"].
  - Added post-release workflow .github/workflows/post-release-version-bump.yml that runs bump-my-version (pinned to 1.3.0) to bump the patch on main after releases.
  - Updated Windows packaging action to sharktide/iscc-cli and moved the /DAppVersion value into the action's options parameter.

- Refactors
  - Moved canonical version into pyproject.toml (project.version set statically) and removed the previous dynamic setuptools configuration that sourced mmrelay.__version__.
  - Updated runtime modules (src/mmrelay/cli.py, src/mmrelay/main.py) to import version from mmrelay._version instead of importing the package to read its version.
  - CI workflows (.github/workflows/build-pyz-armv7.yml, docker-publish.yml, package-windows.yml) now extract version by parsing pyproject.toml (using tomllib when available) rather than importing mmrelay; steps now run with shell: bash and stricter flags (set -euo pipefail) and quote $GITHUB_OUTPUT/$GITHUB_ENV writes.

- Fixes / Robustness
  - Version retrieval is defensive: parsing/IO errors are caught and treated as missing, and get_version() falls back to a sentinel rather than raising.
  - The runtime helper returns a safe sentinel when resolution fails (implementation uses "0+unknown"; some CI/workflows may treat missing values as "unknown").
  - Tests added/expanded (tests/test_version_helper.py) to cover metadata precedence, real TOML parsing, regex fallback (including inline comments), tomllib mocking, and malformed TOML handling.

- CI / Packaging
  - Workflows updated to read project.version from pyproject.toml; changed writes to $GITHUB_OUTPUT/$GITHUB_ENV to use proper quoting.
  - Added bump-my-version / bumpversion configuration in pyproject.toml to support automated version bumping from the new post-release workflow.

## Breaking changes / Migration notes
- Canonical version is now stored in pyproject.toml. CI, build scripts, or tools that previously obtained version by importing the package should switch to parsing pyproject.toml (tomllib) or use importlib.metadata.version("mmrelay") when the package is installed. The new helper (mmrelay._version.get_version / mmrelay.__version__) is available for runtime use.
- mmrelay.__version__ remains available but its resolution strategy changed (it may return the pyproject.toml value when package metadata is absent).
- Windows packaging action configuration changed: the Inno Setup version/definition is provided via the action's options parameter (not embedded in filepath), so custom workflow templates should be updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->