### PR TITLE
feat: Add marine weather forecast for sea-based coordinates

### DIFF
--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -85,53 +85,97 @@ class Plugin(BasePlugin):
             return cmd
         return CANONICAL_WEATHER_MODE
 
-    def _get_marine_forecast(
-        self, latitude: float, longitude: float
+    def generate_marine_forecast(
+        self,
+        latitude: float,
+        longitude: float,
+        mode: str = WEATHER_MODE_CURRENT,
     ) -> str | None:
         """
         Fetch marine weather data (wave height, period, and direction) for given coordinates.
 
-        Queries the Open-Meteo marine weather API to retrieve current wave conditions.
-        The API returns no data for land coordinates, so a ``None`` return value naturally
-        indicates that the location is not at sea (or that the data is unavailable).
+        Queries the Open-Meteo marine weather API.  The query parameters mirror the
+        terrestrial forecast mode so that marine data is always temporally consistent
+        with the rest of the response:
+
+        - ``current`` → ``current`` endpoint (instantaneous conditions).
+        - ``hourly`` → ``hourly`` endpoint, sliced at the same +3h/+6h/+12h offsets
+          derived from ``HOURLY_CONFIG`` and anchored to the current hour via
+          ``datetime.now()``.
+        - ``daily`` → ``daily`` endpoint (dominant direction and max height/period per day).
+
+        The API returns no data for land coordinates, so a ``None`` return value
+        naturally indicates that the location is not at sea (or that data is unavailable).
 
         Parameters:
             latitude (float): Latitude in decimal degrees.
             longitude (float): Longitude in decimal degrees.
+            mode (str): Forecast mode — ``WEATHER_MODE_DAILY`` uses the daily endpoint,
+                        ``WEATHER_MODE_CURRENT`` uses the current-conditions endpoint,
+                        and any other value (e.g. ``hourly``) uses the hourly endpoint.
 
         Returns:
-            str | None: Formatted marine forecast string (e.g., "🌊 Sea State: Waves 1.5m (8.0s) 185°")
-                        when wave data is available, or ``None`` if the coordinates are on land,
-                        the API returns no data, or the request fails.
+            str | None: Formatted marine forecast string when wave data is available,
+                        or ``None`` if the coordinates are on land, the API returns no
+                        data, or the request fails.
+
+                        Current example:
+                            ``"🌊 Sea State: Waves 1.5m (8.0s) 185°"``
+                        Hourly example:
+                            ``"🌊 Waves: Now 1.5m | +3h 1.8m | +6h 2.1m | +12h 1.9m"``
+                        Daily example:
+                            ``"🌊 Waves: Mon 1.5m (8.0s) 185° | Tue …"``
         """
         try:
-            url = (
-                f"https://marine-api.open-meteo.com/v1/marine?"
-                f"latitude={latitude}&longitude={longitude}&"
-                f"current=wave_height,wave_direction,wave_period&"
-                f"timezone=auto"
-            )
+            mode_key = self._normalize_mode(mode)
+            if mode_key == WEATHER_MODE_DAILY:
+                url = (
+                    f"https://marine-api.open-meteo.com/v1/marine?"
+                    f"latitude={latitude}&longitude={longitude}&"
+                    f"daily=wave_height_max,wave_direction_dominant,wave_period_max&"
+                    f"timezone=auto"
+                )
+            elif mode_key == WEATHER_MODE_CURRENT:
+                url = (
+                    f"https://marine-api.open-meteo.com/v1/marine?"
+                    f"latitude={latitude}&longitude={longitude}&"
+                    f"current=wave_height,wave_direction,wave_period&"
+                    f"timezone=auto"
+                )
+            else:
+                url = (
+                    f"https://marine-api.open-meteo.com/v1/marine?"
+                    f"latitude={latitude}&longitude={longitude}&"
+                    f"hourly=wave_height,wave_direction,wave_period&"
+                    f"timezone=auto"
+                )
+
             response = requests.get(url, timeout=WEATHER_API_TIMEOUT_SECONDS)
             response.raise_for_status()
             data = response.json()
 
-            current = data.get("current", {})
-            wave_height = current.get("wave_height")
-            wave_dir = current.get("wave_direction")
-            wave_period = current.get("wave_period")
+            if mode_key == WEATHER_MODE_DAILY:
+                return self._format_daily_marine(data)
+            if mode_key == WEATHER_MODE_CURRENT:
+                return self._format_current_marine(data)
 
-            if wave_height is None:
-                return None
+            # Hourly mode: anchor to the current hour using datetime.now()
+            now = datetime.now()
+            base_index = now.hour
+            hourly_times = data.get("hourly", {}).get("time", [])
+            if hourly_times:
+                try:
+                    base_key = now.replace(
+                        minute=0, second=0, microsecond=0
+                    ).strftime("%Y-%m-%dT%H:00")
+                    base_index = hourly_times.index(base_key)
+                except ValueError:
+                    pass
 
-            marine_parts = [f"🌊 Sea State: Waves {round(wave_height, 1)}m"]
+            mode_offsets = HOURLY_CONFIG.get(mode_key, HOURLY_CONFIG[WEATHER_MODE_CURRENT])
+            offsets = [o for o in mode_offsets.get("offsets", ()) if isinstance(o, int)]
 
-            if wave_period is not None:
-                marine_parts[0] += f" ({round(wave_period, 1)}s)"
-
-            if wave_dir is not None:
-                marine_parts.append(f"{round(wave_dir)}{DEGREE_SYMBOL}")
-
-            return " ".join(marine_parts)
+            return self._format_hourly_marine(data, base_index, offsets)
 
         except requests.exceptions.RequestException:
             self.logger.debug(
@@ -141,38 +185,91 @@ class Plugin(BasePlugin):
             )
             return None
 
-    def _append_marine_forecast(
-        self, terrestrial: str, latitude: float, longitude: float
-    ) -> str:
+    def _format_current_marine(self, data: dict) -> str | None:
+        """Format current/hourly marine API response into a single-line string."""
+        current = data.get("current", {})
+        wave_height = current.get("wave_height")
+        wave_dir = current.get("wave_direction")
+        wave_period = current.get("wave_period")
+
+        if wave_height is None:
+            return None
+
+        parts = [f"🌊 Sea State: Waves {round(wave_height, 1)}m"]
+        if wave_period is not None:
+            parts[0] += f" ({round(wave_period, 1)}s)"
+        if wave_dir is not None:
+            parts.append(f"{round(wave_dir)}{DEGREE_SYMBOL}")
+
+        return " ".join(parts)
+
+    def _format_daily_marine(self, data: dict) -> str | None:
+        """Format daily marine API response into a multi-day single-line string."""
+        daily = data.get("daily", {})
+        heights = daily.get("wave_height_max") or []
+        directions = daily.get("wave_direction_dominant") or []
+        periods = daily.get("wave_period_max") or []
+        times = daily.get("time") or []
+
+        if not heights:
+            return None
+
+        day_parts = []
+        for i, height in enumerate(heights):
+            if height is None:
+                continue
+            try:
+                label = datetime.fromisoformat(times[i]).strftime("%a")
+            except (IndexError, ValueError):
+                label = f"D{i}"
+
+            part = f"{label} {round(height, 1)}m"
+            period = periods[i] if i < len(periods) else None
+            direction = directions[i] if i < len(directions) else None
+            if period is not None:
+                part += f" ({round(period, 1)}s)"
+            if direction is not None:
+                part += f" {round(direction)}{DEGREE_SYMBOL}"
+            day_parts.append(part)
+
+        if not day_parts:
+            return None
+
+        return self._trim_to_max_bytes("🌊 Waves: " + " | ".join(day_parts))
+
+    def _format_hourly_marine(
+        self, data: dict, base_index: int, offsets: list[int]
+    ) -> str | None:
+        """Format hourly marine API response into a multi-slot single-line string.
+
+        Uses the ``base_index`` and ``offsets`` already calculated by
+        ``generate_forecast`` — the same values used for the terrestrial hourly
+        forecast — so no additional time-parsing is needed here.
         """
-        Append marine weather data to a terrestrial forecast string if available.
+        hourly = data.get("hourly", {})
+        heights = hourly.get("wave_height") or []
 
-        Calls the marine API and, when wave data is returned (i.e. coordinates are at
-        sea), appends it to ``terrestrial`` separated by `` | `` and trims the result
-        to the message byte limit.  If no marine data is available the original
-        ``terrestrial`` string is returned unchanged.
+        if not heights:
+            return None
 
-        Parameters:
-            terrestrial (str): Already-formatted terrestrial forecast string.
-            latitude (float): Latitude in decimal degrees.
-            longitude (float): Longitude in decimal degrees.
+        now_height = heights[base_index] if base_index < len(heights) else None
+        if now_height is None:
+            return None
 
-        Returns:
-            str: The terrestrial forecast, optionally extended with sea-state data.
-        """
-        marine_data = self._get_marine_forecast(latitude, longitude)
-        if marine_data:
-            return self._trim_to_max_bytes(f"{terrestrial} | {marine_data}")
-        return terrestrial
+        slot_parts = [f"Now {round(now_height, 1)}m"]
+        for offset in offsets:
+            idx = min(base_index + offset, len(heights) - 1)
+            h = heights[idx]
+            if h is not None:
+                slot_parts.append(f"+{offset}h {round(h, 1)}m")
+
+        return self._trim_to_max_bytes("🌊 Waves: " + " | ".join(slot_parts))
 
     def generate_forecast(
         self, latitude: float, longitude: float, mode: str = CANONICAL_WEATHER_MODE
     ) -> str:
         """
-        Generate a concise one-line weather forecast for the given GPS coordinates and requested mode.
-
-        Marine weather data is automatically requested and, when the coordinates are at sea,
-        appended to the terrestrial forecast with wave height, period, and direction.
+        Generate a concise one-line terrestrial weather forecast for the given GPS coordinates and mode.
 
         Parameters:
             latitude (float): Latitude in decimal degrees.
@@ -234,11 +331,7 @@ class Plugin(BasePlugin):
                 terrestrial_forecast = self._build_daily_forecast(
                     data, units, temperature_unit, daily_days
                 )
-                return self._append_marine_forecast(
-                    terrestrial_forecast, latitude, longitude
-                )
-
-            # Extract relevant weather data
+                return terrestrial_forecast
             current_temp = data["current_weather"]["temperature"]
             current_weather_code = data["current_weather"]["weathercode"]
             is_day = data["current_weather"]["is_day"]
@@ -394,9 +487,7 @@ class Plugin(BasePlugin):
                     parts.append(f"Precip {precip_now}%")
 
                 terrestrial_forecast = self._trim_to_max_bytes(" | ".join(parts))
-                return self._append_marine_forecast(
-                    terrestrial_forecast, latitude, longitude
-                )
+                return terrestrial_forecast
 
             slots = [
                 slot
@@ -414,9 +505,7 @@ class Plugin(BasePlugin):
                 slots,
             )
 
-            return self._append_marine_forecast(
-                terrestrial_forecast, latitude, longitude
-            )
+            return terrestrial_forecast
 
         except (KeyError, IndexError, TypeError, ValueError, AttributeError):
             self.logger.exception("Malformed weather data")
@@ -684,8 +773,8 @@ class Plugin(BasePlugin):
                 coords = self._determine_mesh_location(meshtastic_client)
 
         weather_notice = "Cannot determine location"
+        mode = parsed_command
         if coords:
-            mode = parsed_command
             weather_notice = await asyncio.to_thread(
                 self.generate_forecast,
                 latitude=coords[0],
@@ -708,6 +797,28 @@ class Plugin(BasePlugin):
                 text=weather_notice,
                 channel=channel,
             )
+
+        # Fetch marine data and send as a separate message (Meshtastic has ~200 byte limit)
+        if coords:
+            marine = await asyncio.to_thread(
+                self.generate_marine_forecast,
+                coords[0],
+                coords[1],
+                mode,
+            )
+            if marine:
+                await asyncio.sleep(self.get_response_delay())
+                if is_direct_message:
+                    self.send_message(
+                        text=marine,
+                        destination_id=fromId,
+                    )
+                else:
+                    self.send_message(
+                        text=marine,
+                        channel=channel,
+                    )
+
         return True
 
     def get_matrix_commands(self) -> list[str]:
@@ -777,13 +888,23 @@ class Plugin(BasePlugin):
             )
             return True
 
-        forecast = await asyncio.to_thread(
+        terrestrial = await asyncio.to_thread(
             self.generate_forecast,
             latitude=coords[0],
             longitude=coords[1],
             mode=parsed_command,
         )
-        await self.send_matrix_message(room.room_id, forecast, formatted=False)
+        marine = await asyncio.to_thread(
+            self.generate_marine_forecast,
+            coords[0],
+            coords[1],
+            parsed_command,
+        )
+        if marine:
+            full_forecast = self._trim_to_max_bytes(f"{terrestrial} | {marine}")
+        else:
+            full_forecast = terrestrial
+        await self.send_matrix_message(room.room_id, full_forecast, formatted=False)
         return True
 
     async def _resolve_location_from_args(

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -90,6 +90,7 @@ class Plugin(BasePlugin):
         latitude: float,
         longitude: float,
         mode: str = WEATHER_MODE_CURRENT,
+        units: str = "metric",
     ) -> str | None:
         """
         Fetch marine weather data (wave height, period, and direction) for given coordinates.
@@ -113,16 +114,20 @@ class Plugin(BasePlugin):
             mode (str): Forecast mode — ``WEATHER_MODE_DAILY`` uses the daily endpoint,
                         ``WEATHER_MODE_CURRENT`` uses the current-conditions endpoint,
                         and any other value (e.g. ``hourly``) uses the hourly endpoint.
+            units (str): Unit system — ``"imperial"`` converts wave heights to feet,
+                         ``"metric"`` (default) keeps metres.
 
         Returns:
             str | None: Formatted marine forecast string when wave data is available,
                         or ``None`` if the coordinates are on land, the API returns no
                         data, or the request fails.
 
-                        Current example:
+                        Current example (metric):
                             ``"🌊 Sea State: Waves 1.5m (8.0s) 185°"``
+                        Current example (imperial):
+                            ``"🌊 Sea State: Waves 4.9ft (8.0s) 185°"``
                         Hourly example:
-                            ``"🌊 Waves: Now 1.5m | +3h 1.8m | +6h 2.1m | +12h 1.9m"``
+                            ``"🌊 Waves: Now 1.5m (8.0s) 185° | +3h 1.8m (8.2s) 190°"``
                         Daily example:
                             ``"🌊 Waves: Mon 1.5m (8.0s) 185° | Tue …"``
         """
@@ -133,21 +138,21 @@ class Plugin(BasePlugin):
                     f"https://marine-api.open-meteo.com/v1/marine?"
                     f"latitude={latitude}&longitude={longitude}&"
                     f"daily=wave_height_max,wave_direction_dominant,wave_period_max&"
-                    f"timezone=auto"
+                    f"timezone=auto&length_unit={units}"
                 )
             elif mode_key == WEATHER_MODE_CURRENT:
                 url = (
                     f"https://marine-api.open-meteo.com/v1/marine?"
                     f"latitude={latitude}&longitude={longitude}&"
                     f"current=wave_height,wave_direction,wave_period&"
-                    f"timezone=auto"
+                    f"timezone=auto&length_unit={units}"
                 )
             else:
                 url = (
                     f"https://marine-api.open-meteo.com/v1/marine?"
                     f"latitude={latitude}&longitude={longitude}&"
                     f"hourly=wave_height,wave_direction,wave_period&"
-                    f"timezone=auto"
+                    f"timezone=auto&length_unit={units}"
                 )
 
             response = requests.get(url, timeout=WEATHER_API_TIMEOUT_SECONDS)
@@ -155,9 +160,9 @@ class Plugin(BasePlugin):
             data = response.json()
 
             if mode_key == WEATHER_MODE_DAILY:
-                return self._format_daily_marine(data)
+                return self._format_daily_marine(data, units)
             if mode_key == WEATHER_MODE_CURRENT:
-                return self._format_current_marine(data)
+                return self._format_current_marine(data, units)
 
             # Hourly mode: anchor to the current hour using datetime.now()
             now = datetime.now()
@@ -175,7 +180,7 @@ class Plugin(BasePlugin):
             mode_offsets = HOURLY_CONFIG.get(mode_key, HOURLY_CONFIG[WEATHER_MODE_CURRENT])
             offsets = [o for o in mode_offsets.get("offsets", ()) if isinstance(o, int)]
 
-            return self._format_hourly_marine(data, base_index, offsets)
+            return self._format_hourly_marine(data, base_index, offsets, units)
 
         except requests.exceptions.RequestException:
             self.logger.debug(
@@ -185,8 +190,8 @@ class Plugin(BasePlugin):
             )
             return None
 
-    def _format_current_marine(self, data: dict) -> str | None:
-        """Format current/hourly marine API response into a single-line string."""
+    def _format_current_marine(self, data: dict, units: str = "metric") -> str | None:
+        """Format current marine API response into a single-line string."""
         current = data.get("current", {})
         wave_height = current.get("wave_height")
         wave_dir = current.get("wave_direction")
@@ -195,7 +200,8 @@ class Plugin(BasePlugin):
         if wave_height is None:
             return None
 
-        parts = [f"🌊 Sea State: Waves {round(wave_height, 1)}m"]
+        height_unit = "ft" if units == WEATHER_UNITS_IMPERIAL else "m"
+        parts = [f"🌊 Sea State: Waves {round(wave_height, 1)}{height_unit}"]
         if wave_period is not None:
             parts[0] += f" ({round(wave_period, 1)}s)"
         if wave_dir is not None:
@@ -203,7 +209,7 @@ class Plugin(BasePlugin):
 
         return " ".join(parts)
 
-    def _format_daily_marine(self, data: dict) -> str | None:
+    def _format_daily_marine(self, data: dict, units: str = "metric") -> str | None:
         """Format daily marine API response into a multi-day single-line string."""
         daily = data.get("daily", {})
         heights = daily.get("wave_height_max") or []
@@ -214,6 +220,7 @@ class Plugin(BasePlugin):
         if not heights:
             return None
 
+        height_unit = "ft" if units == WEATHER_UNITS_IMPERIAL else "m"
         day_parts = []
         for i, height in enumerate(heights):
             if height is None:
@@ -223,7 +230,7 @@ class Plugin(BasePlugin):
             except (IndexError, ValueError):
                 label = f"D{i}"
 
-            part = f"{label} {round(height, 1)}m"
+            part = f"{label} {round(height, 1)}{height_unit}"
             period = periods[i] if i < len(periods) else None
             direction = directions[i] if i < len(directions) else None
             if period is not None:
@@ -238,16 +245,13 @@ class Plugin(BasePlugin):
         return self._trim_to_max_bytes("🌊 Waves: " + " | ".join(day_parts))
 
     def _format_hourly_marine(
-        self, data: dict, base_index: int, offsets: list[int]
+        self, data: dict, base_index: int, offsets: list[int], units: str = "metric"
     ) -> str | None:
-        """Format hourly marine API response into a multi-slot single-line string.
-
-        Uses the ``base_index`` and ``offsets`` already calculated by
-        ``generate_forecast`` — the same values used for the terrestrial hourly
-        forecast — so no additional time-parsing is needed here.
-        """
+        """Format hourly marine API response into a multi-slot single-line string."""
         hourly = data.get("hourly", {})
         heights = hourly.get("wave_height") or []
+        directions = hourly.get("wave_direction") or []
+        periods = hourly.get("wave_period") or []
 
         if not heights:
             return None
@@ -256,12 +260,28 @@ class Plugin(BasePlugin):
         if now_height is None:
             return None
 
-        slot_parts = [f"Now {round(now_height, 1)}m"]
-        for offset in offsets:
-            idx = min(base_index + offset, len(heights) - 1)
-            h = heights[idx]
-            if h is not None:
-                slot_parts.append(f"+{offset}h {round(h, 1)}m")
+        height_unit = "ft" if units == WEATHER_UNITS_IMPERIAL else "m"
+
+        def _fmt_slot(label: str, idx: int) -> str | None:
+            h = heights[idx] if idx < len(heights) else None
+            if h is None:
+                return None
+            part = f"{label} {round(h, 1)}{height_unit}"
+            p = periods[idx] if idx < len(periods) else None
+            d = directions[idx] if idx < len(directions) else None
+            if p is not None:
+                part += f" ({round(p, 1)}s)"
+            if d is not None:
+                part += f" {round(d)}{DEGREE_SYMBOL}"
+            return part
+
+        slot_parts = [s for s in [
+            _fmt_slot("Now", base_index),
+            *[_fmt_slot(f"+{o}h", min(base_index + o, len(heights) - 1)) for o in offsets],
+        ] if s is not None]
+
+        if not slot_parts:
+            return None
 
         return self._trim_to_max_bytes("🌊 Waves: " + " | ".join(slot_parts))
 
@@ -800,11 +820,20 @@ class Plugin(BasePlugin):
 
         # Fetch marine data and send as a separate message (Meshtastic has ~200 byte limit)
         if coords:
+            raw_units = self.config.get("units", WEATHER_UNITS_METRIC)
+            units = (
+                raw_units.strip().lower()
+                if isinstance(raw_units, str)
+                else WEATHER_UNITS_METRIC
+            )
+            if units not in {WEATHER_UNITS_METRIC, WEATHER_UNITS_IMPERIAL}:
+                units = WEATHER_UNITS_METRIC
             marine = await asyncio.to_thread(
                 self.generate_marine_forecast,
                 coords[0],
                 coords[1],
                 mode,
+                units,
             )
             if marine:
                 await asyncio.sleep(self.get_response_delay())
@@ -894,11 +923,20 @@ class Plugin(BasePlugin):
             longitude=coords[1],
             mode=parsed_command,
         )
+        raw_units = self.config.get("units", WEATHER_UNITS_METRIC)
+        units = (
+            raw_units.strip().lower()
+            if isinstance(raw_units, str)
+            else WEATHER_UNITS_METRIC
+        )
+        if units not in {WEATHER_UNITS_METRIC, WEATHER_UNITS_IMPERIAL}:
+            units = WEATHER_UNITS_METRIC
         marine = await asyncio.to_thread(
             self.generate_marine_forecast,
             coords[0],
             coords[1],
             parsed_command,
+            units,
         )
         if marine:
             full_forecast = self._trim_to_max_bytes(f"{terrestrial} | {marine}")

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -85,11 +85,106 @@ class Plugin(BasePlugin):
             return cmd
         return CANONICAL_WEATHER_MODE
 
+    def _is_in_ocean(self, latitude: float, longitude: float) -> bool:
+        """
+        Determine if coordinates are located in the ocean using elevation data.
+
+        Uses the Open-Elevation API to check if the location has negative elevation,
+        which indicates a position at or below sea level.
+
+        Parameters:
+            latitude (float): Latitude in decimal degrees.
+            longitude (float): Longitude in decimal degrees.
+
+        Returns:
+            bool: True if coordinates appear to be at sea (negative or zero elevation),
+                  False if on land, elevation data is unavailable, or API request fails.
+        """
+        try:
+            url = f"https://api.open-elevation.com/api/v1/lookup?locations={latitude},{longitude}"
+            response = requests.get(url, timeout=WEATHER_API_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            data = response.json()
+            if data.get("results"):
+                elevation = data["results"][0].get("elevation", 1)
+                return elevation <= 0
+        except requests.exceptions.RequestException:
+            self.logger.debug(
+                "Could not determine elevation for coordinates %f, %f",
+                latitude,
+                longitude,
+            )
+        return False
+
+    def _get_marine_forecast(self, latitude: float, longitude: float) -> str:
+        """
+        Fetch marine weather data (wave height, period, and direction) for given coordinates.
+
+        Queries the Open-Meteo marine weather API to retrieve current wave conditions.
+        Returns a formatted string with sea state information or an error message.
+
+        Parameters:
+            latitude (float): Latitude in decimal degrees.
+            longitude (float): Longitude in decimal degrees.
+
+        Returns:
+            str: Formatted marine forecast string (e.g., "🌊 Sea State: Waves 1.5m (8.0s) 185°"),
+                 or an error message if data is unavailable.
+        """
+        try:
+            url = (
+                f"https://marine-api.open-meteo.com/v1/marine?"
+                f"latitude={latitude}&longitude={longitude}&"
+                f"hourly=wave_height,wave_direction,wave_period&"
+                f"timezone=auto"
+            )
+            response = requests.get(url, timeout=WEATHER_API_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            data = response.json()
+
+            # Extract marine data
+            hourly = data.get("hourly", {})
+            wave_heights = hourly.get("wave_height", [])
+            wave_dirs = hourly.get("wave_direction", [])
+            wave_periods = hourly.get("wave_period", [])
+
+            if not wave_heights:
+                return "Marine data unavailable."
+
+            # Get current values (index 0 is the most recent)
+            current_wave_height = wave_heights[0] if wave_heights else None
+            current_wave_dir = wave_dirs[0] if wave_dirs else None
+            current_wave_period = wave_periods[0] if wave_periods else None
+
+            if current_wave_height is None:
+                return "Marine data unavailable."
+
+            marine_parts = [f"🌊 Sea State: Waves {round(current_wave_height, 1)}m"]
+
+            if current_wave_period is not None:
+                marine_parts[0] += f" ({round(current_wave_period, 1)}s)"
+
+            if current_wave_dir is not None:
+                marine_parts.append(f"{round(current_wave_dir)}{DEGREE_SYMBOL}")
+
+            return " ".join(marine_parts)
+
+        except requests.exceptions.RequestException:
+            self.logger.debug(
+                "Error fetching marine weather data for coordinates %f, %f",
+                latitude,
+                longitude,
+            )
+            return "Marine data unavailable."
+
     def generate_forecast(
         self, latitude: float, longitude: float, mode: str = CANONICAL_WEATHER_MODE
     ) -> str:
         """
         Generate a concise one-line weather forecast for the given GPS coordinates and requested mode.
+
+        If coordinates are detected to be at sea, marine weather data is automatically appended
+        to the terrestrial forecast including wave height, period, and direction.
 
         Parameters:
             latitude (float): Latitude in decimal degrees.
@@ -148,9 +243,14 @@ class Plugin(BasePlugin):
 
             # Daily fast-path - check before parsing current/hourly data
             if mode_key == WEATHER_MODE_DAILY:
-                return self._build_daily_forecast(
+                terrestrial_forecast = self._build_daily_forecast(
                     data, units, temperature_unit, daily_days
                 )
+                # Append marine data if location is at sea
+                if self._is_in_ocean(latitude, longitude):
+                    marine_data = self._get_marine_forecast(latitude, longitude)
+                    return self._trim_to_max_bytes(f"{terrestrial_forecast} | {marine_data}")
+                return terrestrial_forecast
 
             # Extract relevant weather data
             current_temp = data["current_weather"]["temperature"]
@@ -306,7 +406,15 @@ class Plugin(BasePlugin):
                     parts.append(wind_part)
                 if precip_now is not None:
                     parts.append(f"Precip {precip_now}%")
-                return self._trim_to_max_bytes(" | ".join(parts))
+
+                terrestrial_forecast = self._trim_to_max_bytes(" | ".join(parts))
+
+                # Append marine data if location is at sea
+                if self._is_in_ocean(latitude, longitude):
+                    marine_data = self._get_marine_forecast(latitude, longitude)
+                    return self._trim_to_max_bytes(f"{terrestrial_forecast} | {marine_data}")
+
+                return terrestrial_forecast
 
             slots = [
                 slot
@@ -315,7 +423,7 @@ class Plugin(BasePlugin):
                 ).get("slots", ())
                 if isinstance(slot, str)
             ]
-            return self._build_hourly_forecast(
+            terrestrial_forecast = self._build_hourly_forecast(
                 current_temp,
                 current_weather_code,
                 is_day,
@@ -323,6 +431,13 @@ class Plugin(BasePlugin):
                 temperature_unit,
                 slots,
             )
+
+            # Append marine data if location is at sea
+            if self._is_in_ocean(latitude, longitude):
+                marine_data = self._get_marine_forecast(latitude, longitude)
+                return self._trim_to_max_bytes(f"{terrestrial_forecast} | {marine_data}")
+
+            return terrestrial_forecast
 
         except (KeyError, IndexError, TypeError, ValueError, AttributeError):
             self.logger.exception("Malformed weather data")

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -135,7 +135,7 @@ class Plugin(BasePlugin):
             url = (
                 f"https://marine-api.open-meteo.com/v1/marine?"
                 f"latitude={latitude}&longitude={longitude}&"
-                f"hourly=wave_height,wave_direction,wave_period&"
+                f"current=wave_height,wave_direction,wave_period&"
                 f"timezone=auto"
             )
             response = requests.get(url, timeout=WEATHER_API_TIMEOUT_SECONDS)
@@ -143,29 +143,21 @@ class Plugin(BasePlugin):
             data = response.json()
 
             # Extract marine data
-            hourly = data.get("hourly", {})
-            wave_heights = hourly.get("wave_height", [])
-            wave_dirs = hourly.get("wave_direction", [])
-            wave_periods = hourly.get("wave_period", [])
+            current = data.get("current", {})
+            wave_height = current.get("wave_height")
+            wave_dir = current.get("wave_direction")
+            wave_period = current.get("wave_period")
 
-            if not wave_heights:
+            if wave_height is None:
                 return "Marine data unavailable."
 
-            # Get current values (index 0 is the most recent)
-            current_wave_height = wave_heights[0] if wave_heights else None
-            current_wave_dir = wave_dirs[0] if wave_dirs else None
-            current_wave_period = wave_periods[0] if wave_periods else None
+            marine_parts = [f"🌊 Sea State: Waves {round(wave_height, 1)}m"]
 
-            if current_wave_height is None:
-                return "Marine data unavailable."
+            if wave_period is not None:
+                marine_parts[0] += f" ({round(wave_period, 1)}s)"
 
-            marine_parts = [f"🌊 Sea State: Waves {round(current_wave_height, 1)}m"]
-
-            if current_wave_period is not None:
-                marine_parts[0] += f" ({round(current_wave_period, 1)}s)"
-
-            if current_wave_dir is not None:
-                marine_parts.append(f"{round(current_wave_dir)}{DEGREE_SYMBOL}")
+            if wave_dir is not None:
+                marine_parts.append(f"{round(wave_dir)}{DEGREE_SYMBOL}")
 
             return " ".join(marine_parts)
 

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -85,51 +85,24 @@ class Plugin(BasePlugin):
             return cmd
         return CANONICAL_WEATHER_MODE
 
-    def _is_in_ocean(self, latitude: float, longitude: float) -> bool:
-        """
-        Determine if coordinates are located in the ocean using elevation data.
-
-        Uses the Open-Elevation API to check if the location has negative elevation,
-        which indicates a position at or below sea level.
-
-        Parameters:
-            latitude (float): Latitude in decimal degrees.
-            longitude (float): Longitude in decimal degrees.
-
-        Returns:
-            bool: True if coordinates appear to be at sea (negative or zero elevation),
-                  False if on land, elevation data is unavailable, or API request fails.
-        """
-        try:
-            url = f"https://api.open-elevation.com/api/v1/lookup?locations={latitude},{longitude}"
-            response = requests.get(url, timeout=WEATHER_API_TIMEOUT_SECONDS)
-            response.raise_for_status()
-            data = response.json()
-            if data.get("results"):
-                elevation = data["results"][0].get("elevation", 1)
-                return elevation <= 0
-        except requests.exceptions.RequestException:
-            self.logger.debug(
-                "Could not determine elevation for coordinates %f, %f",
-                latitude,
-                longitude,
-            )
-        return False
-
-    def _get_marine_forecast(self, latitude: float, longitude: float) -> str:
+    def _get_marine_forecast(
+        self, latitude: float, longitude: float
+    ) -> str | None:
         """
         Fetch marine weather data (wave height, period, and direction) for given coordinates.
 
         Queries the Open-Meteo marine weather API to retrieve current wave conditions.
-        Returns a formatted string with sea state information or an error message.
+        The API returns no data for land coordinates, so a ``None`` return value naturally
+        indicates that the location is not at sea (or that the data is unavailable).
 
         Parameters:
             latitude (float): Latitude in decimal degrees.
             longitude (float): Longitude in decimal degrees.
 
         Returns:
-            str: Formatted marine forecast string (e.g., "🌊 Sea State: Waves 1.5m (8.0s) 185°"),
-                 or an error message if data is unavailable.
+            str | None: Formatted marine forecast string (e.g., "🌊 Sea State: Waves 1.5m (8.0s) 185°")
+                        when wave data is available, or ``None`` if the coordinates are on land,
+                        the API returns no data, or the request fails.
         """
         try:
             url = (
@@ -142,14 +115,13 @@ class Plugin(BasePlugin):
             response.raise_for_status()
             data = response.json()
 
-            # Extract marine data
             current = data.get("current", {})
             wave_height = current.get("wave_height")
             wave_dir = current.get("wave_direction")
             wave_period = current.get("wave_period")
 
             if wave_height is None:
-                return "Marine data unavailable."
+                return None
 
             marine_parts = [f"🌊 Sea State: Waves {round(wave_height, 1)}m"]
 
@@ -167,7 +139,31 @@ class Plugin(BasePlugin):
                 latitude,
                 longitude,
             )
-            return "Marine data unavailable."
+            return None
+
+    def _append_marine_forecast(
+        self, terrestrial: str, latitude: float, longitude: float
+    ) -> str:
+        """
+        Append marine weather data to a terrestrial forecast string if available.
+
+        Calls the marine API and, when wave data is returned (i.e. coordinates are at
+        sea), appends it to ``terrestrial`` separated by `` | `` and trims the result
+        to the message byte limit.  If no marine data is available the original
+        ``terrestrial`` string is returned unchanged.
+
+        Parameters:
+            terrestrial (str): Already-formatted terrestrial forecast string.
+            latitude (float): Latitude in decimal degrees.
+            longitude (float): Longitude in decimal degrees.
+
+        Returns:
+            str: The terrestrial forecast, optionally extended with sea-state data.
+        """
+        marine_data = self._get_marine_forecast(latitude, longitude)
+        if marine_data:
+            return self._trim_to_max_bytes(f"{terrestrial} | {marine_data}")
+        return terrestrial
 
     def generate_forecast(
         self, latitude: float, longitude: float, mode: str = CANONICAL_WEATHER_MODE
@@ -175,8 +171,8 @@ class Plugin(BasePlugin):
         """
         Generate a concise one-line weather forecast for the given GPS coordinates and requested mode.
 
-        If coordinates are detected to be at sea, marine weather data is automatically appended
-        to the terrestrial forecast including wave height, period, and direction.
+        Marine weather data is automatically requested and, when the coordinates are at sea,
+        appended to the terrestrial forecast with wave height, period, and direction.
 
         Parameters:
             latitude (float): Latitude in decimal degrees.
@@ -238,11 +234,9 @@ class Plugin(BasePlugin):
                 terrestrial_forecast = self._build_daily_forecast(
                     data, units, temperature_unit, daily_days
                 )
-                # Append marine data if location is at sea
-                if self._is_in_ocean(latitude, longitude):
-                    marine_data = self._get_marine_forecast(latitude, longitude)
-                    return self._trim_to_max_bytes(f"{terrestrial_forecast} | {marine_data}")
-                return terrestrial_forecast
+                return self._append_marine_forecast(
+                    terrestrial_forecast, latitude, longitude
+                )
 
             # Extract relevant weather data
             current_temp = data["current_weather"]["temperature"]
@@ -400,13 +394,9 @@ class Plugin(BasePlugin):
                     parts.append(f"Precip {precip_now}%")
 
                 terrestrial_forecast = self._trim_to_max_bytes(" | ".join(parts))
-
-                # Append marine data if location is at sea
-                if self._is_in_ocean(latitude, longitude):
-                    marine_data = self._get_marine_forecast(latitude, longitude)
-                    return self._trim_to_max_bytes(f"{terrestrial_forecast} | {marine_data}")
-
-                return terrestrial_forecast
+                return self._append_marine_forecast(
+                    terrestrial_forecast, latitude, longitude
+                )
 
             slots = [
                 slot
@@ -424,12 +414,9 @@ class Plugin(BasePlugin):
                 slots,
             )
 
-            # Append marine data if location is at sea
-            if self._is_in_ocean(latitude, longitude):
-                marine_data = self._get_marine_forecast(latitude, longitude)
-                return self._trim_to_max_bytes(f"{terrestrial_forecast} | {marine_data}")
-
-            return terrestrial_forecast
+            return self._append_marine_forecast(
+                terrestrial_forecast, latitude, longitude
+            )
 
         except (KeyError, IndexError, TypeError, ValueError, AttributeError):
             self.logger.exception("Malformed weather data")

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -95,6 +95,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         # Mock the get_response_delay method
         self.plugin.get_response_delay = MagicMock(return_value=1.0)
 
+        # Default: marine returns no data (land coordinates)
+        self.plugin.generate_marine_forecast = MagicMock(return_value=None)
+
         # Sample weather API response for 2 days (48 hours)
         # Current time is set to 10:00
         self.sample_weather_data = {
@@ -371,10 +374,10 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
         forecast = self.plugin.generate_forecast(TEST_LAT_NYC, TEST_LON_NYC)
 
-        # Should make two API requests: one for weather, one for marine data
-        self.assertEqual(mock_get.call_count, 2)
+        # Should make one API request for weather data
+        self.assertEqual(mock_get.call_count, 1)
         # Ensure HTTP errors would surface (called once per request)
-        self.assertEqual(mock_response.raise_for_status.call_count, 2)
+        self.assertEqual(mock_response.raise_for_status.call_count, 1)
 
         # First call must be to the main Open-Meteo forecast API
         first_call_args, first_call_kwargs = mock_get.call_args_list[0]
@@ -411,10 +414,6 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
             ):
                 self.assertIn("hourly=", url)  # ensure param present
                 self.assertIn(field, url)
-
-        # Second call must be to the marine API
-        second_call_args, _ = mock_get.call_args_list[1]
-        self.assertIn("marine-api.open-meteo.com", second_call_args[0])
 
         # Verify timeout is set on the first (forecast) call
         self.assertEqual(first_call_kwargs.get("timeout"), 10)
@@ -1585,8 +1584,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     # Marine forecast tests
     # ------------------------------------------------------------------
 
-    def test_get_marine_forecast_returns_formatted_string(self):
+    def test_generate_marine_forecast_returns_formatted_string(self):
         """Marine API with valid data should return a formatted sea-state string."""
+        del self.plugin.generate_marine_forecast  # restore real method for direct testing
         marine_payload = {
             "current": {
                 "wave_height": 1.5,
@@ -1596,14 +1596,14 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         }
         with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
             mock_get.return_value = _make_ok_response(marine_payload)
-            result = self.plugin._get_marine_forecast(40.0, -10.0)
+            result = self.plugin.generate_marine_forecast(40.0, -10.0)
         self.assertIsNotNone(result)
         self.assertIn("🌊", result)
         self.assertIn("1.5m", result)
         self.assertIn("8.0s", result)
         self.assertIn("185°", result)
 
-    def test_get_marine_forecast_returns_none_for_land(self):
+    def test_generate_marine_forecast_returns_none_for_land(self):
         """Marine API returning null wave_height (land coords) should yield None."""
         marine_payload = {
             "current": {
@@ -1614,20 +1614,21 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         }
         with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
             mock_get.return_value = _make_ok_response(marine_payload)
-            result = self.plugin._get_marine_forecast(40.7128, -74.006)
+            result = self.plugin.generate_marine_forecast(40.7128, -74.006)
         self.assertIsNone(result)
 
-    def test_get_marine_forecast_returns_none_on_request_error(self):
+    def test_generate_marine_forecast_returns_none_on_request_error(self):
         """A network error fetching marine data should return None, not raise."""
         import requests as req
 
         with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
             mock_get.side_effect = req.exceptions.ConnectionError("timeout")
-            result = self.plugin._get_marine_forecast(40.0, -10.0)
+            result = self.plugin.generate_marine_forecast(40.0, -10.0)
         self.assertIsNone(result)
 
-    def test_get_marine_forecast_without_period_and_direction(self):
+    def test_generate_marine_forecast_without_period_and_direction(self):
         """Marine forecast with only wave_height should omit period and direction."""
+        del self.plugin.generate_marine_forecast  # restore real method for direct testing
         marine_payload = {
             "current": {
                 "wave_height": 2.3,
@@ -1637,102 +1638,170 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         }
         with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
             mock_get.return_value = _make_ok_response(marine_payload)
-            result = self.plugin._get_marine_forecast(40.0, -10.0)
+            result = self.plugin.generate_marine_forecast(40.0, -10.0)
         self.assertIsNotNone(result)
         self.assertIn("2.3m", result)
         self.assertNotIn("(", result)  # no period
         self.assertNotIn("°", result)  # no direction
 
-    @patch("mmrelay.plugins.weather_plugin.requests.get")
-    def test_generate_forecast_appends_marine_data_at_sea(self, mock_get):
-        """generate_forecast should append marine data when marine API returns data."""
+    def test_generate_marine_forecast_daily_mode_uses_daily_endpoint(self):
+        """Daily mode should request daily marine fields, not current."""
+        del self.plugin.generate_marine_forecast  # restore real method for direct testing
         marine_payload = {
-            "current": {
-                "wave_height": 1.2,
-                "wave_direction": 270.0,
-                "wave_period": 7.5,
-            }
-        }
-
-        def side_effect(url, **kwargs):
-            if "marine-api" in url:
-                return _make_ok_response(marine_payload)
-            return _make_ok_response(self.sample_weather_data)
-
-        mock_get.side_effect = side_effect
-        result = self.plugin.generate_forecast(40.0, -10.0)
-        self.assertIn("🌊", result)
-        self.assertIn("1.2m", result)
-
-    @patch("mmrelay.plugins.weather_plugin.requests.get")
-    def test_generate_forecast_no_marine_data_on_land(self, mock_get):
-        """generate_forecast should not append marine section when marine API returns None."""
-        marine_payload = {"current": {"wave_height": None}}
-
-        def side_effect(url, **kwargs):
-            if "marine-api" in url:
-                return _make_ok_response(marine_payload)
-            return _make_ok_response(self.sample_weather_data)
-
-        mock_get.side_effect = side_effect
-        result = self.plugin.generate_forecast(TEST_LAT_NYC, TEST_LON_NYC)
-        self.assertNotIn("🌊", result)
-
-    @patch("mmrelay.plugins.weather_plugin.requests.get")
-    def test_generate_forecast_daily_appends_marine_data(self, mock_get):
-        """Daily forecast at sea should include marine data."""
-        daily_data = {
-            "current_weather": {
-                "temperature": 20.0,
-                "weathercode": 0,
-                "is_day": 1,
-                "time": "2023-08-20T10:00",
-            },
-            "hourly": {
-                "time": [],
-                "temperature_2m": [],
-                "precipitation_probability": [],
-            },
             "daily": {
-                "weathercode": [0, 1],
-                "temperature_2m_max": [25.0, 27.0],
-                "temperature_2m_min": [15.0, 17.0],
+                "wave_height_max": [1.0, 1.5],
+                "wave_direction_dominant": [180.0, 200.0],
+                "wave_period_max": [7.0, 8.0],
                 "time": ["2023-08-20", "2023-08-21"],
-            },
-        }
-        marine_payload = {
-            "current": {
-                "wave_height": 0.8,
-                "wave_direction": 90.0,
-                "wave_period": 5.0,
             }
         }
+        with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
+            mock_get.return_value = _make_ok_response(marine_payload)
+            result = self.plugin.generate_marine_forecast(40.0, -10.0, mode="daily")
+            called_url = mock_get.call_args.args[0]
 
-        def side_effect(url, **kwargs):
-            if "marine-api" in url:
-                return _make_ok_response(marine_payload)
-            return _make_ok_response(daily_data)
-
-        mock_get.side_effect = side_effect
-        result = self.plugin.generate_forecast(40.0, -10.0, mode="daily")
+        self.assertIn("daily=", called_url)
+        self.assertNotIn("current=", called_url)
+        self.assertIsNotNone(result)
         self.assertIn("🌊", result)
-        self.assertIn("0.8m", result)
+        self.assertIn("1.0m", result)
 
-    def test_append_marine_forecast_with_data(self):
-        """_append_marine_forecast should append marine string when available."""
-        with patch.object(
-            self.plugin, "_get_marine_forecast", return_value="🌊 Sea State: Waves 1.0m"
-        ):
-            result = self.plugin._append_marine_forecast("Now: Clear - 20°C", 40.0, -10.0)
+    def test_generate_marine_forecast_current_mode_uses_current_endpoint(self):
+        """Current (default) mode should request current marine fields."""
+        del self.plugin.generate_marine_forecast  # restore real method for direct testing
+        marine_payload = {
+            "current": {"wave_height": 1.0, "wave_direction": 90.0, "wave_period": 6.0}
+        }
+        with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
+            mock_get.return_value = _make_ok_response(marine_payload)
+            self.plugin.generate_marine_forecast(40.0, -10.0, mode="weather")
+            called_url = mock_get.call_args.args[0]
+
+        self.assertIn("current=", called_url)
+        self.assertNotIn("daily=", called_url)
+        self.assertNotIn("hourly=", called_url)
+
+    def test_generate_marine_forecast_hourly_mode_uses_hourly_endpoint(self):
+        """Hourly mode should request hourly marine fields only (no current block)."""
+        del self.plugin.generate_marine_forecast  # restore real method for direct testing
+        hourly_times = [f"2023-08-20T{h:02d}:00" for h in range(24)]
+        marine_payload = {
+            "hourly": {
+                "time": hourly_times,
+                "wave_height": [1.0 + i * 0.1 for i in range(24)],
+                "wave_direction": [180.0] * 24,
+                "wave_period": [7.0] * 24,
+            },
+        }
+        with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
+            mock_get.return_value = _make_ok_response(marine_payload)
+            result = self.plugin.generate_marine_forecast(40.0, -10.0, mode="hourly")
+            called_url = mock_get.call_args.args[0]
+
+        self.assertIn("hourly=", called_url)
+        self.assertNotIn("daily=", called_url)
+        self.assertNotIn("current=", called_url)
+        self.assertIsNotNone(result)
         self.assertIn("🌊", result)
-        self.assertIn("Now: Clear - 20°C", result)
-        self.assertIn(" | ", result)
+        self.assertIn("Now", result)
 
-    def test_append_marine_forecast_without_data(self):
-        """_append_marine_forecast should return terrestrial unchanged when no marine data."""
-        with patch.object(self.plugin, "_get_marine_forecast", return_value=None):
-            result = self.plugin._append_marine_forecast("Now: Clear - 20°C", 40.0, -10.0)
-        self.assertEqual(result, "Now: Clear - 20°C")
+    def test_format_hourly_marine_returns_none_when_no_heights(self):
+        """_format_hourly_marine returns None when hourly array is empty."""
+        data = {"hourly": {"time": [], "wave_height": []}}
+        result = self.plugin._format_hourly_marine(data, base_index=0, offsets=[3, 6, 12])
+        self.assertIsNone(result)
+
+    def test_format_hourly_marine_returns_none_when_base_height_is_none(self):
+        """_format_hourly_marine returns None when height at base_index is None."""
+        data = {
+            "hourly": {
+                "time": [f"2023-08-20T{h:02d}:00" for h in range(24)],
+                "wave_height": [None] * 24,
+            }
+        }
+        result = self.plugin._format_hourly_marine(data, base_index=0, offsets=[3, 6, 12])
+        self.assertIsNone(result)
+
+    def test_format_daily_marine_returns_none_when_no_data(self):
+        """_format_daily_marine should return None when daily heights are empty."""
+        result = self.plugin._format_daily_marine({"daily": {"wave_height_max": []}})
+        self.assertIsNone(result)
+
+    def test_format_daily_marine_skips_none_heights(self):
+        """_format_daily_marine should skip days with None wave height."""
+        data = {
+            "daily": {
+                "wave_height_max": [None, 1.5],
+                "wave_direction_dominant": [90.0, 180.0],
+                "wave_period_max": [5.0, 7.0],
+                "time": ["2023-08-20", "2023-08-21"],
+            }
+        }
+        result = self.plugin._format_daily_marine(data)
+        self.assertIsNotNone(result)
+        self.assertNotIn("None", result)
+        self.assertIn("1.5m", result)
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    async def test_handle_meshtastic_message_sends_marine_separately(
+        self, mock_get, mock_connect
+    ):
+        """When marine data is available, Meshtastic handler sends it as a second message."""
+        mock_get.return_value = _make_ok_response(self.sample_weather_data)
+
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = TEST_NODE_NUM
+        mock_client.nodes = {
+            TEST_MESHTASTIC_ID: {
+                "position": {"latitude": 40.0, "longitude": -10.0}
+            }
+        }
+        mock_connect.return_value = mock_client
+
+        self.plugin.send_message = MagicMock()
+        # Override marine mock to return data
+        self.plugin.generate_marine_forecast = MagicMock(return_value="🌊 Waves: 1.2m 7.5s 270°")
+
+        packet = {
+            "decoded": {"portnum": PORTNUM_TEXT_MESSAGE_APP, "text": "!weather"},
+            "channel": 0,
+            "fromId": TEST_MESHTASTIC_ID,
+            "to": BROADCAST_NUM,
+        }
+
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted", "longname", "meshnet"
+        )
+        self.assertTrue(result)
+        # Should send two messages: terrestrial + marine
+        self.assertEqual(self.plugin.send_message.call_count, 2)
+        call_texts = [c.kwargs["text"] for c in self.plugin.send_message.call_args_list]
+        self.assertTrue(any("🌊" in t for t in call_texts))
+        self.assertTrue(any("Now:" in t for t in call_texts))
+
+    async def test_handle_room_message_appends_marine_data(self):
+        """Matrix handler combines terrestrial and marine forecasts in one message."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_require_bot_mention = MagicMock(return_value=False)
+        self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.generate_forecast = MagicMock(return_value="Now: ☀️ Clear - 22°C")
+        self.plugin.generate_marine_forecast = MagicMock(return_value="🌊 Waves: 1.5m 8s 180°")
+
+        mock_event = MagicMock()
+        mock_event.body = "!weather 40.0 -10.0"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        result = await self.plugin.handle_room_message(
+            MagicMock(room_id="!r"), mock_event, "!weather 40.0 -10.0"
+        )
+        self.assertTrue(result)
+        self.plugin.send_matrix_message.assert_called_once()
+        sent_text = self.plugin.send_matrix_message.call_args.args[1]
+        self.assertIn("Now:", sent_text)
+        self.assertIn("🌊", sent_text)
+        self.assertIn("|", sent_text)
 
 
 if __name__ == "__main__":

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -371,15 +371,15 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
         forecast = self.plugin.generate_forecast(TEST_LAT_NYC, TEST_LON_NYC)
 
-        # Should make API request with correct parameters
-        mock_get.assert_called_once()
-        # Ensure HTTP errors would surface
-        mock_response.raise_for_status.assert_called_once()
+        # Should make two API requests: one for weather, one for marine data
+        self.assertEqual(mock_get.call_count, 2)
+        # Ensure HTTP errors would surface (called once per request)
+        self.assertEqual(mock_response.raise_for_status.call_count, 2)
 
-        # Accept both styles: URL with querystring or kwargs["params"]
-        args, kwargs = mock_get.call_args
-        url = args[0]
-        params = kwargs.get("params")
+        # First call must be to the main Open-Meteo forecast API
+        first_call_args, first_call_kwargs = mock_get.call_args_list[0]
+        url = first_call_args[0]
+        params = first_call_kwargs.get("params")
         self.assertIn("api.open-meteo.com", url)
         if params:
             self.assertEqual(float(params.get("latitude")), TEST_LAT_NYC)
@@ -412,8 +412,12 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
                 self.assertIn("hourly=", url)  # ensure param present
                 self.assertIn(field, url)
 
-        # Verify timeout is set
-        self.assertEqual(mock_get.call_args.kwargs.get("timeout"), 10)
+        # Second call must be to the marine API
+        second_call_args, _ = mock_get.call_args_list[1]
+        self.assertIn("marine-api.open-meteo.com", second_call_args[0])
+
+        # Verify timeout is set on the first (forecast) call
+        self.assertEqual(first_call_kwargs.get("timeout"), 10)
 
         # Should contain current weather details only
         self.assertIn(
@@ -1576,6 +1580,159 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         with patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None):
             result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
         self.assertTrue(result)
+
+    # ------------------------------------------------------------------
+    # Marine forecast tests
+    # ------------------------------------------------------------------
+
+    def test_get_marine_forecast_returns_formatted_string(self):
+        """Marine API with valid data should return a formatted sea-state string."""
+        marine_payload = {
+            "current": {
+                "wave_height": 1.5,
+                "wave_direction": 185.0,
+                "wave_period": 8.0,
+            }
+        }
+        with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
+            mock_get.return_value = _make_ok_response(marine_payload)
+            result = self.plugin._get_marine_forecast(40.0, -10.0)
+        self.assertIsNotNone(result)
+        self.assertIn("🌊", result)
+        self.assertIn("1.5m", result)
+        self.assertIn("8.0s", result)
+        self.assertIn("185°", result)
+
+    def test_get_marine_forecast_returns_none_for_land(self):
+        """Marine API returning null wave_height (land coords) should yield None."""
+        marine_payload = {
+            "current": {
+                "wave_height": None,
+                "wave_direction": None,
+                "wave_period": None,
+            }
+        }
+        with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
+            mock_get.return_value = _make_ok_response(marine_payload)
+            result = self.plugin._get_marine_forecast(40.7128, -74.006)
+        self.assertIsNone(result)
+
+    def test_get_marine_forecast_returns_none_on_request_error(self):
+        """A network error fetching marine data should return None, not raise."""
+        import requests as req
+
+        with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
+            mock_get.side_effect = req.exceptions.ConnectionError("timeout")
+            result = self.plugin._get_marine_forecast(40.0, -10.0)
+        self.assertIsNone(result)
+
+    def test_get_marine_forecast_without_period_and_direction(self):
+        """Marine forecast with only wave_height should omit period and direction."""
+        marine_payload = {
+            "current": {
+                "wave_height": 2.3,
+                "wave_direction": None,
+                "wave_period": None,
+            }
+        }
+        with patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get:
+            mock_get.return_value = _make_ok_response(marine_payload)
+            result = self.plugin._get_marine_forecast(40.0, -10.0)
+        self.assertIsNotNone(result)
+        self.assertIn("2.3m", result)
+        self.assertNotIn("(", result)  # no period
+        self.assertNotIn("°", result)  # no direction
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_generate_forecast_appends_marine_data_at_sea(self, mock_get):
+        """generate_forecast should append marine data when marine API returns data."""
+        marine_payload = {
+            "current": {
+                "wave_height": 1.2,
+                "wave_direction": 270.0,
+                "wave_period": 7.5,
+            }
+        }
+
+        def side_effect(url, **kwargs):
+            if "marine-api" in url:
+                return _make_ok_response(marine_payload)
+            return _make_ok_response(self.sample_weather_data)
+
+        mock_get.side_effect = side_effect
+        result = self.plugin.generate_forecast(40.0, -10.0)
+        self.assertIn("🌊", result)
+        self.assertIn("1.2m", result)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_generate_forecast_no_marine_data_on_land(self, mock_get):
+        """generate_forecast should not append marine section when marine API returns None."""
+        marine_payload = {"current": {"wave_height": None}}
+
+        def side_effect(url, **kwargs):
+            if "marine-api" in url:
+                return _make_ok_response(marine_payload)
+            return _make_ok_response(self.sample_weather_data)
+
+        mock_get.side_effect = side_effect
+        result = self.plugin.generate_forecast(TEST_LAT_NYC, TEST_LON_NYC)
+        self.assertNotIn("🌊", result)
+
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    def test_generate_forecast_daily_appends_marine_data(self, mock_get):
+        """Daily forecast at sea should include marine data."""
+        daily_data = {
+            "current_weather": {
+                "temperature": 20.0,
+                "weathercode": 0,
+                "is_day": 1,
+                "time": "2023-08-20T10:00",
+            },
+            "hourly": {
+                "time": [],
+                "temperature_2m": [],
+                "precipitation_probability": [],
+            },
+            "daily": {
+                "weathercode": [0, 1],
+                "temperature_2m_max": [25.0, 27.0],
+                "temperature_2m_min": [15.0, 17.0],
+                "time": ["2023-08-20", "2023-08-21"],
+            },
+        }
+        marine_payload = {
+            "current": {
+                "wave_height": 0.8,
+                "wave_direction": 90.0,
+                "wave_period": 5.0,
+            }
+        }
+
+        def side_effect(url, **kwargs):
+            if "marine-api" in url:
+                return _make_ok_response(marine_payload)
+            return _make_ok_response(daily_data)
+
+        mock_get.side_effect = side_effect
+        result = self.plugin.generate_forecast(40.0, -10.0, mode="daily")
+        self.assertIn("🌊", result)
+        self.assertIn("0.8m", result)
+
+    def test_append_marine_forecast_with_data(self):
+        """_append_marine_forecast should append marine string when available."""
+        with patch.object(
+            self.plugin, "_get_marine_forecast", return_value="🌊 Sea State: Waves 1.0m"
+        ):
+            result = self.plugin._append_marine_forecast("Now: Clear - 20°C", 40.0, -10.0)
+        self.assertIn("🌊", result)
+        self.assertIn("Now: Clear - 20°C", result)
+        self.assertIn(" | ", result)
+
+    def test_append_marine_forecast_without_data(self):
+        """_append_marine_forecast should return terrestrial unchanged when no marine data."""
+        with patch.object(self.plugin, "_get_marine_forecast", return_value=None):
+            result = self.plugin._append_marine_forecast("Now: Clear - 20°C", 40.0, -10.0)
+        self.assertEqual(result, "Now: Clear - 20°C")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Detect ocean locations using elevation API
- Fetch marine data (wave height, period, direction) from Open-Meteo
- Automatically append marine forecast to terrestrial data
- Gracefully handle missing data and API failures

Of course, feel free to tweak whatever you want or use a different method to determine whether the coordinates are in the sea or not (my idea was to use Open-Meteo for everything).

Other options would be:
- Don’t check anything and always request the sea state forecast (if it returns nothing, you’re on land).
- Use [global-land-mask](https://github.com/toddkarin/global-land-mask), which I initially ruled out because I didn’t want to introduce more dependencies into your code.

If you want to use `global-land-mask`, the code couldn't be simpler:
```python
from global_land_mask import globe
is_on_land = globe.is_land(40.4168, -3.7038) # Returns True or False
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request adds marine weather forecasting capability to the weather plugin. When a forecast location corresponds to ocean/sea coordinates, the plugin now fetches supplementary marine data from Open-Meteo (wave height, period, and direction) and appends this information to the terrestrial forecast output. The implementation uses a straightforward approach: always request marine data and treat absence of valid wave measurements as an indicator that the location is on land.

## Key Changes

**Features**
- Added `_get_marine_forecast(latitude, longitude)` helper method that queries Open-Meteo's marine API and formats wave data into a human-readable "🌊 Sea State …" string; returns `None` if no valid wave data is available or if the request fails
- Added `_append_marine_forecast(terrestrial, latitude, longitude)` helper to conditionally append marine data to an existing terrestrial forecast with a " | " separator, respecting the configured byte-limit trim

**Refactors**
- Modified `generate_forecast()` control flow to first compute a terrestrial forecast, then call `_append_marine_forecast()` to potentially augment it with marine data
- Applied marine forecast appending consistently across both daily and current/hourly forecast modes
- Removed the elevation API-based ocean detection layer in favor of relying on Open-Meteo's marine endpoint response directly

**Tests**
- Updated existing forecast test to expect two HTTP `requests.get` calls: one to the forecast endpoint and one to the marine endpoint
- Added dedicated tests for `_get_marine_forecast()` covering successful formatting, null-field handling (omits period/direction substrings when unavailable), exception handling, and wave data absence
- Added tests for `_append_marine_forecast()` verifying correct appending behavior and passthrough when no marine data is available
- Added integration tests verifying that marine sections are appended in daily mode and current-condition scenarios

## Breaking Changes

None. The changes are internal to the plugin and do not affect the public API or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->