### PR TITLE
Add marine weather forecast integration and improve response handling

### DIFF
--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -599,7 +599,11 @@ class BasePlugin(ABC):
         return toId == myId
 
     def send_message(
-        self, text: str, channel: int = 0, destination_id: int | None = None
+        self,
+        text: str,
+        channel: int = 0,
+        destination_id: int | None = None,
+        reply_id: int | None = None,
     ) -> bool:
         """
         Queue a text message for broadcast or direct delivery on the Meshtastic network.
@@ -608,6 +612,8 @@ class BasePlugin(ABC):
             text: Message content to send.
             channel: Channel index to send the message on (defaults to 0).
             destination_id: Destination node ID for a direct message; if omitted the message is broadcast.
+            reply_id: Meshtastic message ID to reply to; when provided the outgoing packet
+                      includes a ``reply_id`` field so clients render it as a threaded reply.
 
         Returns:
             `true` if the message was queued successfully, `false` otherwise.
@@ -620,6 +626,21 @@ class BasePlugin(ABC):
             return False
 
         description = f"Plugin {self.plugin_name}: {text[:DEFAULT_TEXT_TRUNCATION_LENGTH]}{'...' if len(text) > DEFAULT_TEXT_TRUNCATION_LENGTH else ''}"
+
+        if reply_id is not None:
+            from meshtastic.mesh_interface import BROADCAST_NUM
+
+            from mmrelay.meshtastic.messaging import send_text_reply
+
+            return queue_message(
+                send_text_reply,
+                description=description,
+                interface=meshtastic_client,
+                text=text,
+                reply_id=reply_id,
+                destinationId=destination_id if destination_id is not None else BROADCAST_NUM,
+                channelIndex=channel,
+            )
 
         send_kwargs: dict[str, Any] = {
             "text": text,
@@ -686,7 +707,7 @@ class BasePlugin(ABC):
         return None
 
     async def send_matrix_message(
-        self, room_id: str, message: str, formatted: bool = True
+        self, room_id: str, message: str, formatted: bool = True, reply_to_event_id: str | None = None
     ) -> RoomSendResponse | RoomSendError | None:
         """
         Send a message to a Matrix room, optionally converting Markdown to HTML.
@@ -695,6 +716,8 @@ class BasePlugin(ABC):
             room_id: Matrix room identifier.
             message: Message content to send.
             formatted: If True, convert `message` from Markdown to HTML and include it as formatted content; otherwise send plain text only.
+            reply_to_event_id: When provided, the outgoing event includes an ``m.relates_to``
+                               relation so Matrix clients render it as a threaded reply to that event.
 
         Returns:
             The Matrix client's `room_send` response (`RoomSendResponse` or `RoomSendError`), or `None` if the Matrix client could not be obtained.
@@ -714,6 +737,10 @@ class BasePlugin(ABC):
         if formatted:
             content["format"] = "org.matrix.custom.html"
             content["formatted_body"] = markdown.markdown(message)
+        if reply_to_event_id:
+            content["m.relates_to"] = {
+                "m.in_reply_to": {"event_id": reply_to_event_id}
+            }
         return await matrix_client.room_send(
             room_id=room_id,
             message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -152,7 +152,7 @@ class Plugin(BasePlugin):
                     f"https://marine-api.open-meteo.com/v1/marine?"
                     f"latitude={latitude}&longitude={longitude}&"
                     f"hourly=wave_height,wave_direction,wave_period&"
-                    f"current=time&"
+                    f"current=wave_height&"
                     f"timezone=auto&length_unit={units}"
                 )
 

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -794,6 +794,7 @@ class Plugin(BasePlugin):
 
         weather_notice = "Cannot determine location"
         mode = parsed_command
+        reply_id = packet.get("id")
         if coords:
             weather_notice = await asyncio.to_thread(
                 self.generate_forecast,
@@ -810,12 +811,14 @@ class Plugin(BasePlugin):
             self.send_message(
                 text=weather_notice,
                 destination_id=fromId,
+                reply_id=reply_id,
             )
         else:
             # Respond in the same channel (broadcast)
             self.send_message(
                 text=weather_notice,
                 channel=channel,
+                reply_id=reply_id,
             )
 
         # Fetch marine data and send as a separate message (Meshtastic has ~200 byte limit)
@@ -841,11 +844,13 @@ class Plugin(BasePlugin):
                     self.send_message(
                         text=marine,
                         destination_id=fromId,
+                        reply_id=reply_id,
                     )
                 else:
                     self.send_message(
                         text=marine,
                         channel=channel,
+                        reply_id=reply_id,
                     )
 
         return True
@@ -914,6 +919,7 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot determine location",
                 formatted=False,
+                reply_to_event_id=event.event_id,
             )
             return True
 
@@ -942,7 +948,7 @@ class Plugin(BasePlugin):
             full_forecast = self._trim_to_max_bytes(f"{terrestrial} | {marine}")
         else:
             full_forecast = terrestrial
-        await self.send_matrix_message(room.room_id, full_forecast, formatted=False)
+        await self.send_matrix_message(room.room_id, full_forecast, formatted=False, reply_to_event_id=event.event_id)
         return True
 
     async def _resolve_location_from_args(

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -152,6 +152,7 @@ class Plugin(BasePlugin):
                     f"https://marine-api.open-meteo.com/v1/marine?"
                     f"latitude={latitude}&longitude={longitude}&"
                     f"hourly=wave_height,wave_direction,wave_period&"
+                    f"current=time&"
                     f"timezone=auto&length_unit={units}"
                 )
 
@@ -164,18 +165,24 @@ class Plugin(BasePlugin):
             if mode_key == WEATHER_MODE_CURRENT:
                 return self._format_current_marine(data, units)
 
-            # Hourly mode: anchor to the current hour using datetime.now()
-            now = datetime.now()
-            base_index = now.hour
-            hourly_times = data.get("hourly", {}).get("time", [])
-            if hourly_times:
+            # Hourly mode: anchor to the current hour using the API's own current time
+            # (in the location's timezone via timezone=auto) rather than the server's
+            # local time, which may differ from the queried location.
+            current_time_str = data.get("current", {}).get("time")
+            base_index = 0
+            if current_time_str:
                 try:
-                    base_key = now.replace(
+                    current_time = datetime.fromisoformat(
+                        current_time_str.replace("Z", "+00:00")
+                    )
+                    base_key = current_time.replace(
                         minute=0, second=0, microsecond=0
                     ).strftime("%Y-%m-%dT%H:00")
-                    base_index = hourly_times.index(base_key)
-                except ValueError:
-                    pass
+                    hourly_times = data.get("hourly", {}).get("time", [])
+                    if hourly_times:
+                        base_index = hourly_times.index(base_key)
+                except (ValueError, AttributeError):
+                    base_index = datetime.now().hour
 
             mode_offsets = HOURLY_CONFIG.get(mode_key, HOURLY_CONFIG[WEATHER_MODE_CURRENT])
             offsets = [o for o in mode_offsets.get("offsets", ()) if isinstance(o, int)]
@@ -185,6 +192,13 @@ class Plugin(BasePlugin):
         except requests.exceptions.RequestException:
             self.logger.debug(
                 "Error fetching marine weather data for coordinates %f, %f",
+                latitude,
+                longitude,
+            )
+            return None
+        except Exception:
+            self.logger.exception(
+                "Unexpected error processing marine weather data for coordinates %f, %f",
                 latitude,
                 longitude,
             )
@@ -945,7 +959,7 @@ class Plugin(BasePlugin):
             units,
         )
         if marine:
-            full_forecast = self._trim_to_max_bytes(f"{terrestrial} | {marine}")
+            full_forecast = f"{terrestrial} | {marine}"
         else:
             full_forecast = terrestrial
         await self.send_matrix_message(room.room_id, full_forecast, formatted=False, reply_to_event_id=event.event_id)

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -752,6 +752,27 @@ class TestBasePlugin(unittest.TestCase):
         self.assertIn("text", call_args[1])  # kwargs should contain text
         self.assertEqual(call_args[1]["text"], "Test message")
 
+    @patch("mmrelay.plugins.base_plugin.queue_message")
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    def test_send_message_reply_uses_send_text_reply(
+        self, mock_connect_meshtastic, mock_queue_message
+    ):
+        """send_message should route reply messages through send_text_reply."""
+        plugin = MockPlugin()
+        mock_client = MagicMock()
+        mock_connect_meshtastic.return_value = mock_client
+        mock_queue_message.return_value = True
+
+        result = plugin.send_message("Reply text", channel=2, reply_id=12345)
+
+        self.assertTrue(result)
+        mock_queue_message.assert_called_once()
+        call_args = mock_queue_message.call_args
+        self.assertEqual(call_args.kwargs["reply_id"], 12345)
+        self.assertEqual(call_args.kwargs["channelIndex"], 2)
+        self.assertIn("destinationId", call_args.kwargs)
+        self.assertEqual(call_args.args[0].__name__, "send_text_reply")
+
     def test_get_matrix_commands_default(self):
         """
         Test that get_matrix_commands returns a list containing the plugin name by default.
@@ -1487,6 +1508,27 @@ class TestBasePlugin(unittest.TestCase):
             call_kwargs = mock_client.room_send.call_args.kwargs
             self.assertIn("formatted_body", call_kwargs["content"])
             self.assertIn("format", call_kwargs["content"])
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_send_matrix_message_includes_reply_relation(self, mock_connect):
+        """send_matrix_message should attach m.relates_to when replying."""
+        mock_client = AsyncMock()
+        mock_connect.return_value = mock_client
+
+        async def run_test():
+            plugin = MockPlugin()
+            await plugin.send_matrix_message(
+                "!room:matrix.org",
+                "reply body",
+                formatted=False,
+                reply_to_event_id="$event123",
+            )
+            content = mock_client.room_send.call_args.kwargs["content"]
+            self.assertEqual(
+                content["m.relates_to"]["m.in_reply_to"]["event_id"], "$event123"
+            )
 
         asyncio.run(run_test())
 

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1581,6 +1581,88 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result)
 
     # ------------------------------------------------------------------
+    # Reply support tests
+    # ------------------------------------------------------------------
+
+    async def test_handle_room_message_replies_to_event(self):
+        """handle_room_message should pass event.event_id as reply_to_event_id."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
+
+        mock_client = MagicMock()
+        mock_client.nodes = {
+            "n1": {"position": {"latitude": 10.0, "longitude": 20.0}},
+        }
+
+        mock_event = MagicMock()
+        mock_event.event_id = "$test_event_123"
+        mock_event.body = "!weather"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        with patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client):
+            result = await self.plugin.handle_room_message(
+                MagicMock(room_id="!r"), mock_event, "!weather"
+            )
+
+        self.assertTrue(result)
+        call_kwargs = self.plugin.send_matrix_message.call_args.kwargs
+        self.assertEqual(call_kwargs.get("reply_to_event_id"), "$test_event_123")
+
+    async def test_handle_room_message_no_location_replies_to_event(self):
+        """'Cannot determine location' should also be sent as a reply."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.send_matrix_message = AsyncMock()
+
+        mock_event = MagicMock()
+        mock_event.event_id = "$no_loc_event"
+        mock_event.body = "!weather"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        with patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None):
+            await self.plugin.handle_room_message(
+                MagicMock(room_id="!r"), mock_event, "!weather"
+            )
+
+        call_kwargs = self.plugin.send_matrix_message.call_args.kwargs
+        self.assertEqual(call_kwargs.get("reply_to_event_id"), "$no_loc_event")
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    async def test_handle_meshtastic_message_reply_id_passed(self, mock_get, mock_connect):
+        """handle_meshtastic_message should pass packet['id'] as reply_id to send_message."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_weather_data
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = TEST_NODE_NUM
+        mock_client.nodes = {
+            TEST_MESHTASTIC_ID: {
+                "position": {"latitude": TEST_LAT_NYC, "longitude": TEST_LON_NYC}
+            }
+        }
+        mock_connect.return_value = mock_client
+
+        self.plugin.send_message = MagicMock()
+
+        packet = {
+            "decoded": {"portnum": PORTNUM_TEXT_MESSAGE_APP, "text": "!weather"},
+            "channel": 0,
+            "fromId": TEST_MESHTASTIC_ID,
+            "to": BROADCAST_NUM,
+            "id": 42,
+        }
+
+        await self.plugin.handle_meshtastic_message(packet, "f", "longname", "mesh")
+
+        call_kwargs = self.plugin.send_message.call_args.kwargs
+        self.assertEqual(call_kwargs.get("reply_id"), 42)
+
+    # ------------------------------------------------------------------
     # Marine forecast tests
     # ------------------------------------------------------------------
 

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1601,7 +1601,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         mock_event.body = "!weather"
         mock_event.source = {"content": {"formatted_body": ""}}
 
-        with patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client):
+        with patch(
+            "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+        ):
             result = await self.plugin.handle_room_message(
                 MagicMock(room_id="!r"), mock_event, "!weather"
             )
@@ -1631,7 +1633,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("mmrelay.plugins.weather_plugin.requests.get")
-    async def test_handle_meshtastic_message_reply_id_passed(self, mock_get, mock_connect):
+    async def test_handle_meshtastic_message_reply_id_passed(
+        self, mock_get, mock_connect
+    ):
         """handle_meshtastic_message should pass packet['id'] as reply_id to send_message."""
         mock_response = MagicMock()
         mock_response.json.return_value = self.sample_weather_data
@@ -1668,7 +1672,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     def test_generate_marine_forecast_returns_formatted_string(self):
         """Marine API with valid data should return a formatted sea-state string."""
-        del self.plugin.generate_marine_forecast  # restore real method for direct testing
+        del (
+            self.plugin.generate_marine_forecast
+        )  # restore real method for direct testing
         marine_payload = {
             "current": {
                 "wave_height": 1.5,
@@ -1708,9 +1714,54 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
             result = self.plugin.generate_marine_forecast(40.0, -10.0)
         self.assertIsNone(result)
 
+    def test_generate_marine_forecast_hourly_invalid_current_time_uses_now_hour(self):
+        """Hourly marine forecast should fall back to datetime.now().hour on parse errors."""
+        del (
+            self.plugin.generate_marine_forecast
+        )  # restore real method for direct testing
+        marine_payload = {
+            "current": {"time": "not-an-iso-time"},
+            "hourly": {
+                "time": [f"2023-08-20T{h:02d}:00" for h in range(24)],
+                "wave_height": [1.0 + i * 0.1 for i in range(24)],
+                "wave_direction": [180.0] * 24,
+                "wave_period": [7.0] * 24,
+            },
+        }
+
+        with (
+            patch("mmrelay.plugins.weather_plugin.requests.get") as mock_get,
+            patch("mmrelay.plugins.weather_plugin.datetime") as mock_datetime,
+            patch.object(
+                self.plugin, "_format_hourly_marine", return_value="🌊 fallback"
+            ) as mock_format,
+        ):
+            mock_get.return_value = _make_ok_response(marine_payload)
+            mock_datetime.fromisoformat.side_effect = ValueError("bad current time")
+            mock_datetime.now.return_value = MagicMock(hour=7)
+
+            result = self.plugin.generate_marine_forecast(40.0, -10.0, mode="hourly")
+
+        self.assertEqual(result, "🌊 fallback")
+        self.assertEqual(mock_format.call_args.args[1], 7)
+
+    def test_generate_marine_forecast_returns_none_on_unexpected_error(self):
+        """Unexpected processing errors should be logged and return None."""
+        del (
+            self.plugin.generate_marine_forecast
+        )  # restore real method for direct testing
+        self.plugin._normalize_mode = MagicMock(side_effect=RuntimeError("boom"))
+
+        result = self.plugin.generate_marine_forecast(40.0, -10.0, mode="hourly")
+
+        self.assertIsNone(result)
+        self.plugin.logger.exception.assert_called_once()
+
     def test_generate_marine_forecast_without_period_and_direction(self):
         """Marine forecast with only wave_height should omit period and direction."""
-        del self.plugin.generate_marine_forecast  # restore real method for direct testing
+        del (
+            self.plugin.generate_marine_forecast
+        )  # restore real method for direct testing
         marine_payload = {
             "current": {
                 "wave_height": 2.3,
@@ -1728,7 +1779,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     def test_generate_marine_forecast_daily_mode_uses_daily_endpoint(self):
         """Daily mode should request daily marine fields, not current."""
-        del self.plugin.generate_marine_forecast  # restore real method for direct testing
+        del (
+            self.plugin.generate_marine_forecast
+        )  # restore real method for direct testing
         marine_payload = {
             "daily": {
                 "wave_height_max": [1.0, 1.5],
@@ -1750,7 +1803,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     def test_generate_marine_forecast_current_mode_uses_current_endpoint(self):
         """Current (default) mode should request current marine fields."""
-        del self.plugin.generate_marine_forecast  # restore real method for direct testing
+        del (
+            self.plugin.generate_marine_forecast
+        )  # restore real method for direct testing
         marine_payload = {
             "current": {"wave_height": 1.0, "wave_direction": 90.0, "wave_period": 6.0}
         }
@@ -1765,7 +1820,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     def test_generate_marine_forecast_hourly_mode_uses_hourly_endpoint(self):
         """Hourly mode should request hourly marine fields and current=wave_height for anchoring."""
-        del self.plugin.generate_marine_forecast  # restore real method for direct testing
+        del (
+            self.plugin.generate_marine_forecast
+        )  # restore real method for direct testing
         hourly_times = [f"2023-08-20T{h:02d}:00" for h in range(24)]
         marine_payload = {
             "current": {"time": "2023-08-20T10:00"},
@@ -1791,7 +1848,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     def test_format_hourly_marine_returns_none_when_no_heights(self):
         """_format_hourly_marine returns None when hourly array is empty."""
         data = {"hourly": {"time": [], "wave_height": []}}
-        result = self.plugin._format_hourly_marine(data, base_index=0, offsets=[3, 6, 12])
+        result = self.plugin._format_hourly_marine(
+            data, base_index=0, offsets=[3, 6, 12]
+        )
         self.assertIsNone(result)
 
     def test_format_hourly_marine_returns_none_when_base_height_is_none(self):
@@ -1802,7 +1861,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
                 "wave_height": [None] * 24,
             }
         }
-        result = self.plugin._format_hourly_marine(data, base_index=0, offsets=[3, 6, 12])
+        result = self.plugin._format_hourly_marine(
+            data, base_index=0, offsets=[3, 6, 12]
+        )
         self.assertIsNone(result)
 
     def test_format_daily_marine_returns_none_when_no_data(self):
@@ -1836,15 +1897,15 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = TEST_NODE_NUM
         mock_client.nodes = {
-            TEST_MESHTASTIC_ID: {
-                "position": {"latitude": 40.0, "longitude": -10.0}
-            }
+            TEST_MESHTASTIC_ID: {"position": {"latitude": 40.0, "longitude": -10.0}}
         }
         mock_connect.return_value = mock_client
 
         self.plugin.send_message = MagicMock()
         # Override marine mock to return data
-        self.plugin.generate_marine_forecast = MagicMock(return_value="🌊 Waves: 1.2m 7.5s 270°")
+        self.plugin.generate_marine_forecast = MagicMock(
+            return_value="🌊 Waves: 1.2m 7.5s 270°"
+        )
 
         packet = {
             "decoded": {"portnum": PORTNUM_TEXT_MESSAGE_APP, "text": "!weather"},
@@ -1870,7 +1931,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.generate_forecast = MagicMock(return_value="Now: ☀️ Clear - 22°C")
-        self.plugin.generate_marine_forecast = MagicMock(return_value="🌊 Waves: 1.5m 8s 180°")
+        self.plugin.generate_marine_forecast = MagicMock(
+            return_value="🌊 Waves: 1.5m 8s 180°"
+        )
 
         mock_event = MagicMock()
         mock_event.body = "!weather 40.0 -10.0"

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1764,7 +1764,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("hourly=", called_url)
 
     def test_generate_marine_forecast_hourly_mode_uses_hourly_endpoint(self):
-        """Hourly mode should request hourly marine fields and current=time for anchoring."""
+        """Hourly mode should request hourly marine fields and current=wave_height for anchoring."""
         del self.plugin.generate_marine_forecast  # restore real method for direct testing
         hourly_times = [f"2023-08-20T{h:02d}:00" for h in range(24)]
         marine_payload = {
@@ -1782,7 +1782,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
             called_url = mock_get.call_args.args[0]
 
         self.assertIn("hourly=", called_url)
-        self.assertIn("current=time", called_url)
+        self.assertIn("current=wave_height", called_url)
         self.assertNotIn("daily=", called_url)
         self.assertIsNotNone(result)
         self.assertIn("🌊", result)

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1764,10 +1764,11 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("hourly=", called_url)
 
     def test_generate_marine_forecast_hourly_mode_uses_hourly_endpoint(self):
-        """Hourly mode should request hourly marine fields only (no current block)."""
+        """Hourly mode should request hourly marine fields and current=time for anchoring."""
         del self.plugin.generate_marine_forecast  # restore real method for direct testing
         hourly_times = [f"2023-08-20T{h:02d}:00" for h in range(24)]
         marine_payload = {
+            "current": {"time": "2023-08-20T10:00"},
             "hourly": {
                 "time": hourly_times,
                 "wave_height": [1.0 + i * 0.1 for i in range(24)],
@@ -1781,8 +1782,8 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
             called_url = mock_get.call_args.args[0]
 
         self.assertIn("hourly=", called_url)
+        self.assertIn("current=time", called_url)
         self.assertNotIn("daily=", called_url)
-        self.assertNotIn("current=", called_url)
         self.assertIsNotNone(result)
         self.assertIn("🌊", result)
         self.assertIn("Now", result)


### PR DESCRIPTION
This PR builds on the previous one #525 but implements what we discussed in #526. I chose to create a separate PR because it affects more than just the weather plugin.