### PR TITLE
Standardize Meshtastic reply handling & use reactions to signal success/failure for Matrix-facing plugins

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build installer
         # Intentionally using a SHA-pinned action that supports `filepath` + `options`.
         # Keep this pinned to control supply-chain risk and avoid interface drift.
-        uses: sharktide/iscc-cli@6f80e2e08ffc0606116be38199a77902d266b09a # v1.0.0
+        uses: sharktide/iscc-cli@c94f2cbc0fc82dede0efad402dca3dfa3a1ede2a # v1.0.0
         with:
           filepath: ./scripts/mmrelay.iss
           options: "/DAppVersion=${{ env.FILE_VERSION }}"

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -67,7 +67,7 @@ jobs:
         # Keep this pinned to control supply-chain risk and avoid interface drift.
         uses: sharktide/iscc-cli@6f80e2e08ffc0606116be38199a77902d266b09a # v1.0.0
         with:
-          filepath: "./scripts/mmrelay.iss"
+          filepath: ./scripts/mmrelay.iss
           options: "/DAppVersion=${{ env.FILE_VERSION }}"
 
       - name: Upload installer as artifact

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,11 +18,11 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.112.1
+    - renovate@43.129.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - mypy@1.20.1
-    - pyright@1.1.408
+    - pyright@1.1.409
     - dotenv-linter@4.0.0
     - hadolint@2.14.0
     - taplo@0.10.0
@@ -34,8 +34,8 @@ lint:
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
-    - prettier@3.8.2
-    - ruff@0.15.10
+    - prettier@3.8.3
+    - ruff@0.15.11
     - trufflehog@3.94.3
     - yamllint@1.38.0
   definitions:

--- a/src/mmrelay/cli_utils.py
+++ b/src/mmrelay/cli_utils.py
@@ -777,6 +777,9 @@ async def logout_matrix_bot(password: str) -> bool:
         # Create a temporary client to verify the password
         # We'll try to login with the password to verify it's correct
         ssl_param = cast(Any, ssl_context)
+        if AsyncClient is None:
+            _get_logger().error("Matrix AsyncClient not available")
+            return False
         temp_client = AsyncClient(homeserver_str, user_id_str, ssl=ssl_param)
 
         try:
@@ -835,6 +838,9 @@ async def logout_matrix_bot(password: str) -> bool:
         print("🚪 Logging out from Matrix server...")
         main_client = None
         try:
+            if AsyncClient is None:
+                _get_logger().error("Matrix AsyncClient not available")
+                return False
             main_client = AsyncClient(homeserver_str, user_id_str, ssl=ssl_param)
             main_client.restore_login(
                 user_id=user_id_str,

--- a/src/mmrelay/matrix/media.py
+++ b/src/mmrelay/matrix/media.py
@@ -1,6 +1,7 @@
 import io
 import os
 from types import SimpleNamespace
+from typing import Any
 
 from nio import RoomSendError, UploadError, UploadResponse
 from PIL import Image
@@ -90,6 +91,7 @@ async def send_room_image(
     room_id: str,
     upload_response: UploadResponse | UploadError | SimpleNamespace | None,
     filename: str = "image.png",
+    reply_to_event_id: str | None = None,
 ) -> None:
     """
     Send an uploaded image to a Matrix room.
@@ -101,20 +103,24 @@ async def send_room_image(
         room_id (str): Target Matrix room ID.
         upload_response (UploadResponse | UploadError | SimpleNamespace | None): Result from an upload operation; must provide a `content_uri` attribute on success.
         filename (str): Filename to include as the message body (defaults to "image.png").
+        reply_to_event_id (str | None): Optional event ID to reply to.
 
     Raises:
         ImageUploadError: If `upload_response` does not contain a `content_uri`.
     """
     content_uri = getattr(upload_response, "content_uri", None)
     if content_uri:
+        content: dict[str, Any] = {
+            "msgtype": "m.image",
+            "url": content_uri,
+            "body": filename,
+        }
+        if reply_to_event_id:
+            content["m.relates_to"] = {"m.in_reply_to": {"event_id": reply_to_event_id}}
         send_response = await client.room_send(
             room_id=room_id,
             message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,
-            content={
-                "msgtype": "m.image",
-                "url": content_uri,
-                "body": filename,
-            },
+            content=content,
         )
         if isinstance(send_response, RoomSendError):
             facade.logger.error(
@@ -140,16 +146,24 @@ async def send_image(
     room_id: str,
     image: Image.Image,
     filename: str = "image.png",
+    reply_to_event_id: str | None = None,
 ) -> None:
     """
     Upload a Pillow Image to the Matrix content repository and send it to a room.
 
     Uploads the provided PIL Image, stores it in the client's content repository, and sends it to the specified room as an `m.image` message using the given filename.
 
+    Parameters:
+        reply_to_event_id (str | None): Optional event ID to reply to.
+
     Raises:
         ImageUploadError: If the upload or send operation fails.
     """
     response = await facade.upload_image(client=client, image=image, filename=filename)
     await facade.send_room_image(
-        client, room_id, upload_response=response, filename=filename
+        client,
+        room_id,
+        upload_response=response,
+        filename=filename,
+        reply_to_event_id=reply_to_event_id,
     )

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1107,8 +1107,14 @@ def _connect_meshtastic_impl(
                 facade.logger.error(f"Unknown connection type: {connection_type}")
                 return None
 
-            # All connection paths above either returned None or assigned client
-            assert client is not None
+            if client is None:
+                facade.logger.error(
+                    "Meshtastic %s connection path completed without a client.",
+                    connection_type,
+                )
+                raise ConnectionError(
+                    f"Meshtastic {connection_type} connection completed without a client."
+                )
 
             successful = True
 

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1107,6 +1107,9 @@ def _connect_meshtastic_impl(
                 facade.logger.error(f"Unknown connection type: {connection_type}")
                 return None
 
+            # All connection paths above either returned None or assigned client
+            assert client is not None
+
             successful = True
 
             # Acquire lock only for the final setup and subscription

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -39,6 +39,7 @@ __all__ = [
     "_get_connect_time_probe_settings",
     "_rollback_connect_attempt_state",
     "_schedule_connect_time_calibration_probe",
+    "ConnectionCompletedWithoutClientError",
     "connect_meshtastic",
     "serial_port_exists",
 ]
@@ -46,6 +47,17 @@ __all__ = [
 
 class BLEDiscoveryTransientError(Exception):
     """Retryable BLE discovery/setup failure that should not consume timeout budget."""
+
+
+class ConnectionCompletedWithoutClientError(ConnectionError):
+    """Connection path returned without producing a usable client."""
+
+
+def _raise_no_client(connection_type: str) -> None:
+    """Raise ConnectionCompletedWithoutClientError for the given connection type."""
+    raise ConnectionCompletedWithoutClientError(
+        f"Meshtastic {connection_type} connection completed without a client."
+    )
 
 
 def serial_port_exists(port_name: str) -> bool:
@@ -1112,9 +1124,7 @@ def _connect_meshtastic_impl(
                     "Meshtastic %s connection path completed without a client.",
                     connection_type,
                 )
-                raise ConnectionError(
-                    f"Meshtastic {connection_type} connection completed without a client."
-                )
+                _raise_no_client(connection_type)
 
             successful = True
 

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -613,7 +613,7 @@ class BasePlugin(ABC):
             channel: Channel index to send the message on (defaults to 0).
             destination_id: Destination node ID for a direct message; if omitted the message is broadcast.
             reply_id: Meshtastic message ID to reply to; when provided the outgoing packet
-                      includes a ``reply_id`` field so clients render it as a threaded reply.
+                      includes a ``reply_id`` field so clients render it as a reply.
 
         Returns:
             `true` if the message was queued successfully, `false` otherwise.
@@ -638,7 +638,9 @@ class BasePlugin(ABC):
                 interface=meshtastic_client,
                 text=text,
                 reply_id=reply_id,
-                destinationId=destination_id if destination_id is not None else BROADCAST_NUM,
+                destinationId=(
+                    destination_id if destination_id is not None else BROADCAST_NUM
+                ),
                 channelIndex=channel,
             )
 
@@ -707,7 +709,11 @@ class BasePlugin(ABC):
         return None
 
     async def send_matrix_message(
-        self, room_id: str, message: str, formatted: bool = True, reply_to_event_id: str | None = None
+        self,
+        room_id: str,
+        message: str,
+        formatted: bool = True,
+        reply_to_event_id: str | None = None,
     ) -> RoomSendResponse | RoomSendError | None:
         """
         Send a message to a Matrix room, optionally converting Markdown to HTML.
@@ -717,7 +723,7 @@ class BasePlugin(ABC):
             message: Message content to send.
             formatted: If True, convert `message` from Markdown to HTML and include it as formatted content; otherwise send plain text only.
             reply_to_event_id: When provided, the outgoing event includes an ``m.relates_to``
-                               relation so Matrix clients render it as a threaded reply to that event.
+                               relation so Matrix clients render it as a reply to that event.
 
         Returns:
             The Matrix client's `room_send` response (`RoomSendResponse` or `RoomSendError`), or `None` if the Matrix client could not be obtained.
@@ -738,9 +744,7 @@ class BasePlugin(ABC):
             content["format"] = "org.matrix.custom.html"
             content["formatted_body"] = markdown.markdown(message)
         if reply_to_event_id:
-            content["m.relates_to"] = {
-                "m.in_reply_to": {"event_id": reply_to_event_id}
-            }
+            content["m.relates_to"] = {"m.in_reply_to": {"event_id": reply_to_event_id}}
         return await matrix_client.room_send(
             room_id=room_id,
             message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -648,7 +648,7 @@ class BasePlugin(ABC):
             "text": text,
             "channelIndex": channel,
         }
-        if destination_id:
+        if destination_id is not None:
             send_kwargs["destinationId"] = destination_id
 
         return queue_message(

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -751,6 +751,41 @@ class BasePlugin(ABC):
             content=content,
         )
 
+    async def send_matrix_reaction(
+        self, room_id: str, event_id: str, emoji: str
+    ) -> None:
+        """
+        Send a reaction (emoji annotation) to a Matrix event.
+
+        Parameters:
+            room_id: Matrix room identifier.
+            event_id: The Matrix event ID to react to.
+            emoji: The emoji to send as a reaction (e.g. "✅").
+        """
+        from mmrelay.matrix_utils import connect_matrix
+
+        matrix_client = await connect_matrix()
+        if matrix_client is None:
+            self.logger.error("Failed to connect to Matrix client")
+            return
+
+        content: dict[str, Any] = {
+            "m.relates_to": {
+                "rel_type": "m.annotation",
+                "event_id": event_id,
+                "key": emoji,
+            }
+        }
+        try:
+            await matrix_client.room_send(
+                room_id=room_id,
+                message_type="m.reaction",
+                content=content,
+                ignore_unverified_devices=True,
+            )
+        except Exception:
+            self.logger.warning("Failed to send reaction", exc_info=True)
+
     def get_mesh_commands(self) -> list[str]:
         """
         List mesh/radio command names this plugin handles.

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -602,7 +602,7 @@ class BasePlugin(ABC):
         self,
         text: str,
         channel: int = 0,
-        destination_id: int | None = None,
+        destination_id: str | int | None = None,
         reply_id: int | None = None,
     ) -> bool:
         """
@@ -611,7 +611,7 @@ class BasePlugin(ABC):
         Parameters:
             text: Message content to send.
             channel: Channel index to send the message on (defaults to 0).
-            destination_id: Destination node ID for a direct message; if omitted the message is broadcast.
+            destination_id: Destination node ID (string Meshtastic ID or integer) for a direct message; if omitted the message is broadcast.
             reply_id: Meshtastic message ID to reply to; when provided the outgoing packet
                       includes a ``reply_id`` field so clients render it as a reply.
 

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -736,7 +736,7 @@ class BasePlugin(ABC):
             self.logger.error("Failed to connect to Matrix client")
             return None
 
-        content = {
+        content: dict[str, Any] = {
             "msgtype": "m.text",
             "body": message,
         }

--- a/src/mmrelay/plugins/drop_plugin.py
+++ b/src/mmrelay/plugins/drop_plugin.py
@@ -109,10 +109,9 @@ class Plugin(BasePlugin):
                     if distance_km <= radius_km:
                         target_node = from_id
                         self.logger.debug(f"Sending dropped message to {target_node}")
-                        await asyncio.to_thread(
-                            meshtastic_client.sendText,
+                        self.send_message(
                             text=message["text"],
-                            destinationId=target_node,
+                            destination_id=target_node,
                         )
                     else:
                         unsent_messages.append(message)

--- a/src/mmrelay/plugins/health_plugin.py
+++ b/src/mmrelay/plugins/health_plugin.py
@@ -165,8 +165,12 @@ class Plugin(BasePlugin):
             return False
         _ = full_message
 
+        try:
+            response = await asyncio.to_thread(self.generate_response)
+            await self.send_matrix_message(room.room_id, response, formatted=False)
+        except Exception:
+            self.logger.exception("Error handling health command")
+            await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+            return True
         await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
-        response = await asyncio.to_thread(self.generate_response)
-        await self.send_matrix_message(room.room_id, response, formatted=False)
-
         return True

--- a/src/mmrelay/plugins/health_plugin.py
+++ b/src/mmrelay/plugins/health_plugin.py
@@ -166,6 +166,8 @@ class Plugin(BasePlugin):
         _ = full_message
 
         response = await asyncio.to_thread(self.generate_response)
-        await self.send_matrix_message(room.room_id, response, formatted=False)
+        await self.send_matrix_message(
+            room.room_id, response, formatted=False, reply_to_event_id=event.event_id
+        )
 
         return True

--- a/src/mmrelay/plugins/health_plugin.py
+++ b/src/mmrelay/plugins/health_plugin.py
@@ -165,9 +165,8 @@ class Plugin(BasePlugin):
             return False
         _ = full_message
 
+        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
         response = await asyncio.to_thread(self.generate_response)
-        await self.send_matrix_message(
-            room.room_id, response, formatted=False, reply_to_event_id=event.event_id
-        )
+        await self.send_matrix_message(room.room_id, response, formatted=False)
 
         return True

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -127,6 +127,11 @@ class Plugin(BasePlugin):
             ]
             reply = MSG_AVAILABLE_COMMANDS_PREFIX + ", ".join(sorted(set(commands)))
 
+        try:
+            await self.send_matrix_message(room.room_id, reply)
+        except Exception:
+            self.logger.exception("Error handling help command")
+            await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+            return True
         await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
-        await self.send_matrix_message(room.room_id, reply)
         return True

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -127,5 +127,7 @@ class Plugin(BasePlugin):
             ]
             reply = MSG_AVAILABLE_COMMANDS_PREFIX + ", ".join(sorted(set(commands)))
 
-        await self.send_matrix_message(room.room_id, reply)
+        await self.send_matrix_message(
+            room.room_id, reply, reply_to_event_id=event.event_id
+        )
         return True

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -127,7 +127,6 @@ class Plugin(BasePlugin):
             ]
             reply = MSG_AVAILABLE_COMMANDS_PREFIX + ", ".join(sorted(set(commands)))
 
-        await self.send_matrix_message(
-            room.room_id, reply, reply_to_event_id=event.event_id
-        )
+        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+        await self.send_matrix_message(room.room_id, reply)
         return True

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -525,11 +525,12 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
+        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+
         args = self.extract_command_args("map", full_message)
         if args is None:
             return False
 
-        # Accept zoom/size in any order, but reject unknown tokens
         token_pattern = r"(?:\s*(?:zoom=\d+|size=\d+,\s*\d+))*\s*$"
         if args and not re.fullmatch(token_pattern, args, flags=re.IGNORECASE):
             return False
@@ -562,11 +563,11 @@ class Plugin(BasePlugin):
             try:
                 width = int(self.config.get("image_width", 1000))
             except (TypeError, ValueError):
-                pass  # keep default
+                pass
             try:
                 height = int(self.config.get("image_height", 1000))
             except (TypeError, ValueError):
-                pass  # keep default
+                pass
             image_size = (width, height)
 
         width = max(1, min(image_size[0], MAX_MAP_IMAGE_SIZE))
@@ -586,7 +587,6 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot generate map: Matrix client unavailable.",
                 formatted=False,
-                reply_to_event_id=event.event_id,
             )
             return True
         meshtastic_client = await _connect_meshtastic_async()
@@ -599,7 +599,6 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot generate map: Meshtastic client unavailable.",
                 formatted=False,
-                reply_to_event_id=event.event_id,
             )
             return True
 
@@ -628,11 +627,9 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot generate map: No nodes with location data found.",
                 formatted=False,
-                reply_to_event_id=event.event_id,
             )
             return True
 
-        # Offload CPU-bound rendering to keep the event loop responsive.
         pillow_image = await asyncio.to_thread(
             get_map,
             locations=locations,
@@ -644,7 +641,7 @@ class Plugin(BasePlugin):
 
         try:
             await send_image(
-                matrix_client, room.room_id, pillow_image, MAP_IMAGE_FILENAME, reply_to_event_id=event.event_id
+                matrix_client, room.room_id, pillow_image, MAP_IMAGE_FILENAME
             )
         except ImageUploadError:
             self.logger.exception("Failed to send map image")

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -525,8 +525,6 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
-
         args = self.extract_command_args("map", full_message)
         if args is None:
             return False
@@ -580,79 +578,100 @@ class Plugin(BasePlugin):
             send_image,
         )
 
-        matrix_client = await connect_matrix()
-        if matrix_client is None:
-            logger.error("Failed to connect to Matrix client; cannot generate map")
-            await self.send_matrix_message(
-                room.room_id,
-                "Cannot generate map: Matrix client unavailable.",
-                formatted=False,
-            )
-            return True
-        meshtastic_client = await _connect_meshtastic_async()
-
-        has_nodes = getattr(meshtastic_client, "nodes", None) is not None
-
-        if not meshtastic_client or not has_nodes:
-            self.logger.error("Meshtastic client unavailable; cannot generate map")
-            await self.send_matrix_message(
-                room.room_id,
-                "Cannot generate map: Meshtastic client unavailable.",
-                formatted=False,
-            )
-            return True
-
-        locations = []
-        for _node, info in meshtastic_client.nodes.items():  # type: ignore[attr-defined]
-            pos = info.get("position") if isinstance(info, dict) else None
-            user = info.get("user") if isinstance(info, dict) else None
-            if (
-                isinstance(pos, dict)
-                and "latitude" in pos
-                and "longitude" in pos
-                and isinstance(user, dict)
-                and "shortName" in user
-            ):
-                locations.append(
-                    {
-                        "lat": pos["latitude"],
-                        "lon": pos["longitude"],
-                        "precisionBits": pos.get("precisionBits"),
-                        "label": user["shortName"],
-                    }
-                )
-
-        if not locations:
-            await self.send_matrix_message(
-                room.room_id,
-                "Cannot generate map: No nodes with location data found.",
-                formatted=False,
-            )
-            return True
-
-        pillow_image = await asyncio.to_thread(
-            get_map,
-            locations=locations,
-            zoom=zoom,
-            image_size=image_size,
-            _anonymize=False,
-            _radius=0,
-        )
-
         try:
-            await send_image(
-                matrix_client, room.room_id, pillow_image, MAP_IMAGE_FILENAME
+            matrix_client = await connect_matrix()
+            if matrix_client is None:
+                logger.error("Failed to connect to Matrix client; cannot generate map")
+                await self.send_matrix_message(
+                    room.room_id,
+                    "Cannot generate map: Matrix client unavailable.",
+                    formatted=False,
+                )
+                await self.send_matrix_reaction(
+                    room.room_id, event.event_id, "❌"
+                )
+                return True
+            meshtastic_client = await _connect_meshtastic_async()
+
+            has_nodes = getattr(meshtastic_client, "nodes", None) is not None
+
+            if not meshtastic_client or not has_nodes:
+                self.logger.error("Meshtastic client unavailable; cannot generate map")
+                await self.send_matrix_message(
+                    room.room_id,
+                    "Cannot generate map: Meshtastic client unavailable.",
+                    formatted=False,
+                )
+                await self.send_matrix_reaction(
+                    room.room_id, event.event_id, "❌"
+                )
+                return True
+
+            locations = []
+            for _node, info in meshtastic_client.nodes.items():  # type: ignore[attr-defined]
+                pos = info.get("position") if isinstance(info, dict) else None
+                user = info.get("user") if isinstance(info, dict) else None
+                if (
+                    isinstance(pos, dict)
+                    and "latitude" in pos
+                    and "longitude" in pos
+                    and isinstance(user, dict)
+                    and "shortName" in user
+                ):
+                    locations.append(
+                        {
+                            "lat": pos["latitude"],
+                            "lon": pos["longitude"],
+                            "precisionBits": pos.get("precisionBits"),
+                            "label": user["shortName"],
+                        }
+                    )
+
+            if not locations:
+                await self.send_matrix_message(
+                    room.room_id,
+                    "Cannot generate map: No nodes with location data found.",
+                    formatted=False,
+                )
+                await self.send_matrix_reaction(
+                    room.room_id, event.event_id, "✅"
+                )
+                return True
+
+            pillow_image = await asyncio.to_thread(
+                get_map,
+                locations=locations,
+                zoom=zoom,
+                image_size=image_size,
+                _anonymize=False,
+                _radius=0,
             )
-        except ImageUploadError:
-            self.logger.exception("Failed to send map image")
-            await matrix_client.room_send(
-                room_id=room.room_id,
-                message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,
-                content={
-                    "msgtype": "m.notice",
-                    "body": "Failed to generate map: Image upload failed.",
-                },
+
+            try:
+                await send_image(
+                    matrix_client, room.room_id, pillow_image, MAP_IMAGE_FILENAME
+                )
+            except ImageUploadError:
+                self.logger.exception("Failed to send map image")
+                await matrix_client.room_send(
+                    room_id=room.room_id,
+                    message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,
+                    content={
+                        "msgtype": "m.notice",
+                        "body": "Failed to generate map: Image upload failed.",
+                    },
+                )
+                await self.send_matrix_reaction(
+                    room.room_id, event.event_id, "❌"
+                )
+                return True
+            await self.send_matrix_reaction(
+                room.room_id, event.event_id, "✅"
             )
             return True
-
-        return True
+        except Exception:
+            self.logger.exception("Error handling map command")
+            await self.send_matrix_reaction(
+                room.room_id, event.event_id, "❌"
+            )
+            return True

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -582,14 +582,6 @@ class Plugin(BasePlugin):
             matrix_client = await connect_matrix()
             if matrix_client is None:
                 logger.error("Failed to connect to Matrix client; cannot generate map")
-                await self.send_matrix_message(
-                    room.room_id,
-                    "Cannot generate map: Matrix client unavailable.",
-                    formatted=False,
-                )
-                await self.send_matrix_reaction(
-                    room.room_id, event.event_id, "❌"
-                )
                 return True
             meshtastic_client = await _connect_meshtastic_async()
 
@@ -634,7 +626,7 @@ class Plugin(BasePlugin):
                     formatted=False,
                 )
                 await self.send_matrix_reaction(
-                    room.room_id, event.event_id, "✅"
+                    room.room_id, event.event_id, "❌"
                 )
                 return True
 

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -586,6 +586,7 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot generate map: Matrix client unavailable.",
                 formatted=False,
+                reply_to_event_id=event.event_id,
             )
             return True
         meshtastic_client = await _connect_meshtastic_async()
@@ -598,6 +599,7 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot generate map: Meshtastic client unavailable.",
                 formatted=False,
+                reply_to_event_id=event.event_id,
             )
             return True
 
@@ -626,6 +628,7 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot generate map: No nodes with location data found.",
                 formatted=False,
+                reply_to_event_id=event.event_id,
             )
             return True
 
@@ -641,7 +644,7 @@ class Plugin(BasePlugin):
 
         try:
             await send_image(
-                matrix_client, room.room_id, pillow_image, MAP_IMAGE_FILENAME
+                matrix_client, room.room_id, pillow_image, MAP_IMAGE_FILENAME, reply_to_event_id=event.event_id
             )
         except ImageUploadError:
             self.logger.exception("Failed to send map image")

--- a/src/mmrelay/plugins/nodes_plugin.py
+++ b/src/mmrelay/plugins/nodes_plugin.py
@@ -214,12 +214,16 @@ $shortname $longname / $devicemodel / $battery $voltage / $snr / $hops / $lastse
             return False
         _ = full_message
 
+        try:
+            response = await asyncio.to_thread(self.generate_response)
+            await self.send_matrix_message(
+                room_id=room.room_id,
+                message=response,
+                formatted=False,
+            )
+        except Exception:
+            self.logger.exception("Error handling nodes command")
+            await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+            return True
         await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
-        response = await asyncio.to_thread(self.generate_response)
-        await self.send_matrix_message(
-            room_id=room.room_id,
-            message=response,
-            formatted=False,
-        )
-
         return True

--- a/src/mmrelay/plugins/nodes_plugin.py
+++ b/src/mmrelay/plugins/nodes_plugin.py
@@ -216,7 +216,10 @@ $shortname $longname / $devicemodel / $battery $voltage / $snr / $hops / $lastse
 
         response = await asyncio.to_thread(self.generate_response)
         await self.send_matrix_message(
-            room_id=room.room_id, message=response, formatted=False
+            room_id=room.room_id,
+            message=response,
+            formatted=False,
+            reply_to_event_id=event.event_id,
         )
 
         return True

--- a/src/mmrelay/plugins/nodes_plugin.py
+++ b/src/mmrelay/plugins/nodes_plugin.py
@@ -214,12 +214,12 @@ $shortname $longname / $devicemodel / $battery $voltage / $snr / $hops / $lastse
             return False
         _ = full_message
 
+        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
         response = await asyncio.to_thread(self.generate_response)
         await self.send_matrix_message(
             room_id=room.room_id,
             message=response,
             formatted=False,
-            reply_to_event_id=event.event_id,
         )
 
         return True

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -164,18 +164,14 @@ class Plugin(BasePlugin):
 
         await asyncio.sleep(self.get_response_delay())
 
+        reply_id = packet.get("id")
+
         if is_direct_message:
-            await asyncio.to_thread(
-                meshtastic_client.sendText,
-                text=reply_message,
-                destinationId=from_id,
+            self.send_message(
+                text=reply_message, destination_id=from_id, reply_id=reply_id
             )
         else:
-            await asyncio.to_thread(
-                meshtastic_client.sendText,
-                text=reply_message,
-                channelIndex=channel,
-            )
+            self.send_message(text=reply_message, channel=channel, reply_id=reply_id)
         return True
 
     def get_matrix_commands(self) -> list[str]:
@@ -222,5 +218,7 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        await self.send_matrix_message(room.room_id, PING_RESPONSE)
+        await self.send_matrix_message(
+            room.room_id, PING_RESPONSE, reply_to_event_id=event.event_id
+        )
         return True

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -168,7 +168,10 @@ class Plugin(BasePlugin):
 
         if is_direct_message:
             self.send_message(
-                text=reply_message, destination_id=from_id, reply_id=reply_id
+                text=reply_message,
+                channel=channel,
+                destination_id=from_id,
+                reply_id=reply_id,
             )
         else:
             self.send_message(text=reply_message, channel=channel, reply_id=reply_id)

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -218,7 +218,6 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        await self.send_matrix_message(
-            room.room_id, PING_RESPONSE, reply_to_event_id=event.event_id
-        )
+        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+        await self.send_matrix_message(room.room_id, PING_RESPONSE)
         return True

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -221,6 +221,11 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
+        try:
+            await self.send_matrix_message(room.room_id, PING_RESPONSE)
+        except Exception:
+            self.logger.exception("Error handling ping command")
+            await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+            return True
         await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
-        await self.send_matrix_message(room.room_id, PING_RESPONSE)
         return True

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -183,8 +183,6 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
-
         parsed_command = self.get_matching_matrix_command(event)
         if not parsed_command:
             return False
@@ -196,115 +194,124 @@ class Plugin(BasePlugin):
         hourly_intervals = self._generate_timeperiods()
         from mmrelay.matrix_utils import connect_matrix
 
-        matrix_client = await connect_matrix()
-        if matrix_client is None:
-            self.logger.warning(
-                "Matrix client unavailable; skipping telemetry graph generation"
-            )
-            return False
-
-        hourly_averages: dict[int, list[float]] = {}
-
-        def calculate_averages(node_data_rows: list[dict[str, Any]]) -> None:
-            """
-            Accumulate per-record telemetry values into hourly bins keyed by indices of the outer `hourly_intervals`.
-
-            Parameters:
-                node_data_rows (list[dict[str, Any]]): Records containing a "time" POSIX timestamp (seconds) and a telemetry value under the key named by the enclosing `telemetry_option`; values are appended to the outer `hourly_averages` dictionary for the matching hourly interval.
-            """
-            for record in node_data_rows:
-                if not isinstance(record, dict):
-                    continue
-                timestamp = record.get("time")
-                telemetry_value = record.get(telemetry_option)
-                if timestamp is None or telemetry_value is None:
-                    continue
-                try:
-                    record_time = datetime.fromtimestamp(timestamp)
-                    value = float(telemetry_value)
-                    if not math.isfinite(value):
-                        continue
-                except (TypeError, ValueError, OSError, OverflowError):
-                    continue
-                for i in range(len(hourly_intervals) - 1):
-                    if hourly_intervals[i] <= record_time < hourly_intervals[i + 1]:
-                        if i not in hourly_averages:
-                            hourly_averages[i] = []
-                        hourly_averages[i].append(value)
-                        break
-
-        if node:
-            node_data_rows = self.get_node_data(node)
-            if node_data_rows:
-                calculate_averages(
-                    node_data_rows
-                    if isinstance(node_data_rows, list)
-                    else [node_data_rows]
-                )
-            else:
-                await self.send_matrix_message(
-                    room.room_id,
-                    f"No telemetry data found for node '{node}'.",
-                    formatted=False,
-                )
-                return True
-        else:
-            for node_data_json in self.get_data():
-                node_data_rows = json.loads(node_data_json[0])
-                calculate_averages(node_data_rows)
-
-        final_averages = {}
-        for i, interval in enumerate(hourly_intervals[:-1]):
-            if i in hourly_averages:
-                final_averages[interval] = sum(hourly_averages[i]) / len(
-                    hourly_averages[i]
-                )
-            else:
-                final_averages[interval] = 0.0
-
-        hourly_intervals = list(final_averages.keys())
-        average_values = list(final_averages.values())
-
-        hourly_strings = [hour.strftime(HOUR_FORMAT) for hour in hourly_intervals]
-
-        fig, ax = plt.subplots()
-        ax.plot(hourly_strings, average_values)
-
-        if node:
-            title = f"{node} Hourly {telemetry_option} Averages"
-        else:
-            title = f"Network Hourly {telemetry_option} Averages"
-        ax.set_title(title)
-        ax.set_xlabel("Hour")
-        ax.set_ylabel(f"{telemetry_option}")
-
-        plt.xticks(rotation=GRAPH_XLABEL_ROTATION_DEGREES)
-
-        buf = io.BytesIO()
-        fig.savefig(buf, format=GRAPH_IMAGE_FORMAT, bbox_inches="tight")
-        plt.close(fig)
-        buf.seek(0)
-        with Image.open(buf) as img:
-            pil_image = img.copy() if img.mode == "RGBA" else img.convert("RGBA")
-
-        from mmrelay.matrix_utils import ImageUploadError, send_image
-
         try:
-            await send_image(
-                matrix_client,
-                room.room_id,
-                pil_image,
-                TELEMETRY_GRAPH_FILENAME,
-            )
-        except ImageUploadError:
-            self.logger.exception("Failed to send telemetry graph")
-            await matrix_client.room_send(
-                room_id=room.room_id,
-                message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,
-                content={
-                    "msgtype": "m.notice",
-                    "body": MSG_GRAPH_UPLOAD_FAILED,
-                },
-            )
+            matrix_client = await connect_matrix()
+            if matrix_client is None:
+                self.logger.warning(
+                    "Matrix client unavailable; skipping telemetry graph generation"
+                )
+                await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+                return False
+
+            hourly_averages: dict[int, list[float]] = {}
+
+            def calculate_averages(node_data_rows: list[dict[str, Any]]) -> None:
+                """
+                Accumulate per-record telemetry values into hourly bins keyed by indices of the outer `hourly_intervals`.
+
+                Parameters:
+                    node_data_rows (list[dict[str, Any]]): Records containing a "time" POSIX timestamp (seconds) and a telemetry value under the key named by the enclosing `telemetry_option`; values are appended to the outer `hourly_averages` dictionary for the matching hourly interval.
+                """
+                for record in node_data_rows:
+                    if not isinstance(record, dict):
+                        continue
+                    timestamp = record.get("time")
+                    telemetry_value = record.get(telemetry_option)
+                    if timestamp is None or telemetry_value is None:
+                        continue
+                    try:
+                        record_time = datetime.fromtimestamp(timestamp)
+                        value = float(telemetry_value)
+                        if not math.isfinite(value):
+                            continue
+                    except (TypeError, ValueError, OSError, OverflowError):
+                        continue
+                    for i in range(len(hourly_intervals) - 1):
+                        if hourly_intervals[i] <= record_time < hourly_intervals[i + 1]:
+                            if i not in hourly_averages:
+                                hourly_averages[i] = []
+                            hourly_averages[i].append(value)
+                            break
+
+            if node:
+                node_data_rows = self.get_node_data(node)
+                if node_data_rows:
+                    calculate_averages(
+                        node_data_rows
+                        if isinstance(node_data_rows, list)
+                        else [node_data_rows]
+                    )
+                else:
+                    await self.send_matrix_message(
+                        room.room_id,
+                        f"No telemetry data found for node '{node}'.",
+                        formatted=False,
+                    )
+                    await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+                    return True
+            else:
+                for node_data_json in self.get_data():
+                    node_data_rows = json.loads(node_data_json[0])
+                    calculate_averages(node_data_rows)
+
+            final_averages = {}
+            for i, interval in enumerate(hourly_intervals[:-1]):
+                if i in hourly_averages:
+                    final_averages[interval] = sum(hourly_averages[i]) / len(
+                        hourly_averages[i]
+                    )
+                else:
+                    final_averages[interval] = 0.0
+
+            hourly_intervals = list(final_averages.keys())
+            average_values = list(final_averages.values())
+
+            hourly_strings = [hour.strftime(HOUR_FORMAT) for hour in hourly_intervals]
+
+            fig, ax = plt.subplots()
+            ax.plot(hourly_strings, average_values)
+
+            if node:
+                title = f"{node} Hourly {telemetry_option} Averages"
+            else:
+                title = f"Network Hourly {telemetry_option} Averages"
+            ax.set_title(title)
+            ax.set_xlabel("Hour")
+            ax.set_ylabel(f"{telemetry_option}")
+
+            plt.xticks(rotation=GRAPH_XLABEL_ROTATION_DEGREES)
+
+            buf = io.BytesIO()
+            fig.savefig(buf, format=GRAPH_IMAGE_FORMAT, bbox_inches="tight")
+            plt.close(fig)
+            buf.seek(0)
+            with Image.open(buf) as img:
+                pil_image = img.copy() if img.mode == "RGBA" else img.convert("RGBA")
+
+            from mmrelay.matrix_utils import ImageUploadError, send_image
+
+            try:
+                await send_image(
+                    matrix_client,
+                    room.room_id,
+                    pil_image,
+                    TELEMETRY_GRAPH_FILENAME,
+                )
+            except ImageUploadError:
+                self.logger.exception("Failed to send telemetry graph")
+                await matrix_client.room_send(
+                    room_id=room.room_id,
+                    message_type=MATRIX_EVENT_TYPE_ROOM_MESSAGE,
+                    content={
+                        "msgtype": "m.notice",
+                        "body": MSG_GRAPH_UPLOAD_FAILED,
+                    },
+                )
+                await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+                return True
+            await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
             return True
-        return True
+        except Exception:
+            self.logger.exception("Error handling telemetry command")
+            await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+            return True

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -183,6 +183,8 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
+        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+
         parsed_command = self.get_matching_matrix_command(event)
         if not parsed_command:
             return False
@@ -201,7 +203,6 @@ class Plugin(BasePlugin):
             )
             return False
 
-        # Compute the hourly averages for each node
         hourly_averages: dict[int, list[float]] = {}
 
         def calculate_averages(node_data_rows: list[dict[str, Any]]) -> None:
@@ -245,7 +246,6 @@ class Plugin(BasePlugin):
                     room.room_id,
                     f"No telemetry data found for node '{node}'.",
                     formatted=False,
-                    reply_to_event_id=event.event_id,
                 )
                 return True
         else:
@@ -253,7 +253,6 @@ class Plugin(BasePlugin):
                 node_data_rows = json.loads(node_data_json[0])
                 calculate_averages(node_data_rows)
 
-        # Compute the final hourly averages
         final_averages = {}
         for i, interval in enumerate(hourly_intervals[:-1]):
             if i in hourly_averages:
@@ -263,18 +262,14 @@ class Plugin(BasePlugin):
             else:
                 final_averages[interval] = 0.0
 
-        # Extract the hourly intervals and average values into separate lists
         hourly_intervals = list(final_averages.keys())
         average_values = list(final_averages.values())
 
-        # Convert the hourly intervals to strings
         hourly_strings = [hour.strftime(HOUR_FORMAT) for hour in hourly_intervals]
 
-        # Create the plot
         fig, ax = plt.subplots()
         ax.plot(hourly_strings, average_values)
 
-        # Set the plot title and axis labels
         if node:
             title = f"{node} Hourly {telemetry_option} Averages"
         else:
@@ -283,10 +278,8 @@ class Plugin(BasePlugin):
         ax.set_xlabel("Hour")
         ax.set_ylabel(f"{telemetry_option}")
 
-        # Rotate the x-axis labels for readability
         plt.xticks(rotation=GRAPH_XLABEL_ROTATION_DEGREES)
 
-        # Save the plot as a PIL image
         buf = io.BytesIO()
         fig.savefig(buf, format=GRAPH_IMAGE_FORMAT, bbox_inches="tight")
         plt.close(fig)
@@ -302,7 +295,6 @@ class Plugin(BasePlugin):
                 room.room_id,
                 pil_image,
                 TELEMETRY_GRAPH_FILENAME,
-                reply_to_event_id=event.event_id,
             )
         except ImageUploadError:
             self.logger.exception("Failed to send telemetry graph")

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -200,8 +200,7 @@ class Plugin(BasePlugin):
                 self.logger.warning(
                     "Matrix client unavailable; skipping telemetry graph generation"
                 )
-                await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
-                return False
+                return True
 
             hourly_averages: dict[int, list[float]] = {}
 
@@ -247,7 +246,7 @@ class Plugin(BasePlugin):
                         f"No telemetry data found for node '{node}'.",
                         formatted=False,
                     )
-                    await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+                    await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
                     return True
             else:
                 for node_data_json in self.get_data():

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -245,6 +245,7 @@ class Plugin(BasePlugin):
                     room.room_id,
                     f"No telemetry data found for node '{node}'.",
                     formatted=False,
+                    reply_to_event_id=event.event_id,
                 )
                 return True
         else:
@@ -297,7 +298,11 @@ class Plugin(BasePlugin):
 
         try:
             await send_image(
-                matrix_client, room.room_id, pil_image, TELEMETRY_GRAPH_FILENAME
+                matrix_client,
+                room.room_id,
+                pil_image,
+                TELEMETRY_GRAPH_FILENAME,
+                reply_to_event_id=event.event_id,
             )
         except ImageUploadError:
             self.logger.exception("Failed to send telemetry graph")

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -909,66 +909,71 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
-
         parsed_command = self.get_matching_matrix_command(event)
         if not parsed_command:
             return False
         args_text = self.extract_command_args(parsed_command, full_message) or ""
 
-        coords = await self._resolve_location_from_args(args_text)
+        try:
+            coords = await self._resolve_location_from_args(args_text)
 
-        if coords is None:
-            from mmrelay.meshtastic_utils import connect_meshtastic
+            if coords is None:
+                from mmrelay.meshtastic_utils import connect_meshtastic
 
-            meshtastic_client = await asyncio.to_thread(connect_meshtastic)
-            if meshtastic_client is None:
-                self.logger.error(
-                    "Meshtastic client unavailable; cannot determine mesh location."
+                meshtastic_client = await asyncio.to_thread(connect_meshtastic)
+                if meshtastic_client is None:
+                    self.logger.error(
+                        "Meshtastic client unavailable; cannot determine mesh location."
+                    )
+                    coords = None
+                else:
+                    coords = self._determine_mesh_location(meshtastic_client)
+
+            if coords is None:
+                await self.send_matrix_message(
+                    room.room_id,
+                    "Cannot determine location",
+                    formatted=False,
                 )
-                coords = None
-            else:
-                coords = self._determine_mesh_location(meshtastic_client)
+                await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+                return True
 
-        if coords is None:
+            terrestrial = await asyncio.to_thread(
+                self.generate_forecast,
+                latitude=coords[0],
+                longitude=coords[1],
+                mode=parsed_command,
+            )
+            raw_units = self.config.get("units", WEATHER_UNITS_METRIC)
+            units = (
+                raw_units.strip().lower()
+                if isinstance(raw_units, str)
+                else WEATHER_UNITS_METRIC
+            )
+            if units not in {WEATHER_UNITS_METRIC, WEATHER_UNITS_IMPERIAL}:
+                units = WEATHER_UNITS_METRIC
+            marine = await asyncio.to_thread(
+                self.generate_marine_forecast,
+                coords[0],
+                coords[1],
+                parsed_command,
+                units,
+            )
+            if marine:
+                full_forecast = f"{terrestrial} | {marine}"
+            else:
+                full_forecast = terrestrial
             await self.send_matrix_message(
                 room.room_id,
-                "Cannot determine location",
+                full_forecast,
                 formatted=False,
             )
+            await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
             return True
-
-        terrestrial = await asyncio.to_thread(
-            self.generate_forecast,
-            latitude=coords[0],
-            longitude=coords[1],
-            mode=parsed_command,
-        )
-        raw_units = self.config.get("units", WEATHER_UNITS_METRIC)
-        units = (
-            raw_units.strip().lower()
-            if isinstance(raw_units, str)
-            else WEATHER_UNITS_METRIC
-        )
-        if units not in {WEATHER_UNITS_METRIC, WEATHER_UNITS_IMPERIAL}:
-            units = WEATHER_UNITS_METRIC
-        marine = await asyncio.to_thread(
-            self.generate_marine_forecast,
-            coords[0],
-            coords[1],
-            parsed_command,
-            units,
-        )
-        if marine:
-            full_forecast = f"{terrestrial} | {marine}"
-        else:
-            full_forecast = terrestrial
-        await self.send_matrix_message(
-            room.room_id,
-            full_forecast,
-            formatted=False,
-        )
-        return True
+        except Exception:
+            self.logger.exception("Error handling weather command")
+            await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
+            return True
 
     async def _resolve_location_from_args(
         self, arg_text: str | None

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -850,7 +850,9 @@ class Plugin(BasePlugin):
 
         def _send(text: str) -> None:
             if is_direct_message:
-                self.send_message(text=text, destination_id=fromId, reply_id=reply_id)
+                self.send_message(
+                    text=text, channel=channel, destination_id=fromId, reply_id=reply_id
+                )
             else:
                 self.send_message(text=text, channel=channel, reply_id=reply_id)
 

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -935,7 +935,7 @@ class Plugin(BasePlugin):
                     "Cannot determine location",
                     formatted=False,
                 )
-                await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+                await self.send_matrix_reaction(room.room_id, event.event_id, "❌")
                 return True
 
             terrestrial = await asyncio.to_thread(

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -184,7 +184,9 @@ class Plugin(BasePlugin):
                 except (ValueError, AttributeError):
                     base_index = datetime.now().hour
 
-            mode_offsets = HOURLY_CONFIG.get(mode_key, HOURLY_CONFIG[WEATHER_MODE_CURRENT])
+            mode_offsets = HOURLY_CONFIG.get(
+                mode_key, HOURLY_CONFIG[WEATHER_MODE_CURRENT]
+            )
             offsets = [o for o in mode_offsets.get("offsets", ()) if isinstance(o, int)]
 
             return self._format_hourly_marine(data, base_index, offsets, units)
@@ -289,10 +291,17 @@ class Plugin(BasePlugin):
                 part += f" {round(d)}{DEGREE_SYMBOL}"
             return part
 
-        slot_parts = [s for s in [
-            _fmt_slot("Now", base_index),
-            *[_fmt_slot(f"+{o}h", min(base_index + o, len(heights) - 1)) for o in offsets],
-        ] if s is not None]
+        slot_parts = [
+            s
+            for s in [
+                _fmt_slot("Now", base_index),
+                *[
+                    _fmt_slot(f"+{o}h", min(base_index + o, len(heights) - 1))
+                    for o in offsets
+                ],
+            ]
+            if s is not None
+        ]
 
         if not slot_parts:
             return None
@@ -951,7 +960,12 @@ class Plugin(BasePlugin):
             full_forecast = f"{terrestrial} | {marine}"
         else:
             full_forecast = terrestrial
-        await self.send_matrix_message(room.room_id, full_forecast, formatted=False, reply_to_event_id=event.event_id)
+        await self.send_matrix_message(
+            room.room_id,
+            full_forecast,
+            formatted=False,
+            reply_to_event_id=event.event_id,
+        )
         return True
 
     async def _resolve_location_from_args(

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -907,6 +907,8 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
+        await self.send_matrix_reaction(room.room_id, event.event_id, "✅")
+
         parsed_command = self.get_matching_matrix_command(event)
         if not parsed_command:
             return False
@@ -931,7 +933,6 @@ class Plugin(BasePlugin):
                 room.room_id,
                 "Cannot determine location",
                 formatted=False,
-                reply_to_event_id=event.event_id,
             )
             return True
 
@@ -964,7 +965,6 @@ class Plugin(BasePlugin):
             room.room_id,
             full_forecast,
             formatted=False,
-            reply_to_event_id=event.event_id,
         )
         return True
 

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -671,7 +671,7 @@ class TestBasePlugin(unittest.TestCase):
         mock_matrix_client = AsyncMock()
         mock_connect_matrix.return_value = mock_matrix_client
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that sending a Matrix message via the plugin calls the Matrix client's room_send method with the correct parameters.
             """
@@ -1021,7 +1021,7 @@ class TestBasePlugin(unittest.TestCase):
         plugin = MockPlugin()
         mock_connect_matrix.side_effect = RuntimeError("Connection failed")
 
-        async def run_test():
+        async def run_test() -> None:
             with self.assertRaises(RuntimeError):
                 await plugin.send_matrix_message("!room:matrix.org", "Test message")
 
@@ -1035,7 +1035,7 @@ class TestBasePlugin(unittest.TestCase):
         mock_client.room_send.side_effect = RuntimeError("Send failed")
         mock_connect_matrix.return_value = mock_client
 
-        async def run_test():
+        async def run_test() -> None:
             # Should raise an exception due to send failure
             with self.assertRaises(RuntimeError):
                 await plugin.send_matrix_message("!room:matrix.org", "Test message")
@@ -1488,7 +1488,7 @@ class TestBasePlugin(unittest.TestCase):
         """send_matrix_message should return None when Matrix client is unavailable."""
         mock_connect.return_value = None
 
-        async def run_test():
+        async def run_test() -> None:
             result = await MockPlugin().send_matrix_message("!room:matrix.org", "test")
             self.assertIsNone(result)
 
@@ -1500,7 +1500,7 @@ class TestBasePlugin(unittest.TestCase):
         mock_client = AsyncMock()
         mock_connect.return_value = mock_client
 
-        async def run_test():
+        async def run_test() -> None:
             plugin = MockPlugin()
             await plugin.send_matrix_message(
                 "!room:matrix.org", "**bold**", formatted=True
@@ -1517,7 +1517,7 @@ class TestBasePlugin(unittest.TestCase):
         mock_client = AsyncMock()
         mock_connect.return_value = mock_client
 
-        async def run_test():
+        async def run_test() -> None:
             plugin = MockPlugin()
             await plugin.send_matrix_message(
                 "!room:matrix.org",
@@ -1651,7 +1651,7 @@ class TestBasePlugin(unittest.TestCase):
         mock_client = AsyncMock()
         mock_connect.return_value = mock_client
 
-        async def run_test():
+        async def run_test() -> None:
             await plugin.send_matrix_reaction("!room:matrix.org", "$event_id", "✅")
             mock_client.room_send.assert_called_once()
             call_kwargs = mock_client.room_send.call_args.kwargs
@@ -1671,7 +1671,7 @@ class TestBasePlugin(unittest.TestCase):
         plugin.logger = MagicMock()
         mock_connect.return_value = None
 
-        async def run_test():
+        async def run_test() -> None:
             await plugin.send_matrix_reaction("!room", "$event", "✅")
             plugin.logger.error.assert_called_once_with(
                 "Failed to connect to Matrix client"
@@ -1688,7 +1688,7 @@ class TestBasePlugin(unittest.TestCase):
         mock_client.room_send.side_effect = RuntimeError("send failed")
         mock_connect.return_value = mock_client
 
-        async def run_test():
+        async def run_test() -> None:
             await plugin.send_matrix_reaction("!room", "$event", "✅")
             plugin.logger.warning.assert_called_once_with(
                 "Failed to send reaction", exc_info=True

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1643,6 +1643,59 @@ class TestBasePlugin(unittest.TestCase):
         self.assertIsNone(plugin.parse_mesh_bang_command(12345, ("weather",)))
         self.assertIsNone(plugin.parse_mesh_bang_command("!weather", ()))
 
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_send_matrix_reaction_success(self, mock_connect):
+        """Test send_matrix_reaction sends reaction when client available (lines 768-785)."""
+        plugin = MockPlugin()
+        plugin.logger = MagicMock()
+        mock_client = AsyncMock()
+        mock_connect.return_value = mock_client
+
+        async def run_test():
+            await plugin.send_matrix_reaction("!room:matrix.org", "$event_id", "✅")
+            mock_client.room_send.assert_called_once()
+            call_kwargs = mock_client.room_send.call_args.kwargs
+            self.assertEqual(call_kwargs["room_id"], "!room:matrix.org")
+            self.assertEqual(call_kwargs["message_type"], "m.reaction")
+            self.assertEqual(
+                call_kwargs["content"]["m.relates_to"]["event_id"], "$event_id"
+            )
+            self.assertEqual(call_kwargs["content"]["m.relates_to"]["key"], "✅")
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_send_matrix_reaction_no_client(self, mock_connect):
+        """Test send_matrix_reaction logs error when client is None (lines 768-770)."""
+        plugin = MockPlugin()
+        plugin.logger = MagicMock()
+        mock_connect.return_value = None
+
+        async def run_test():
+            await plugin.send_matrix_reaction("!room", "$event", "✅")
+            plugin.logger.error.assert_called_once_with(
+                "Failed to connect to Matrix client"
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_send_matrix_reaction_send_exception(self, mock_connect):
+        """Test send_matrix_reaction catches send exception (lines 786-787)."""
+        plugin = MockPlugin()
+        plugin.logger = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.room_send.side_effect = RuntimeError("send failed")
+        mock_connect.return_value = mock_client
+
+        async def run_test():
+            await plugin.send_matrix_reaction("!room", "$event", "✅")
+            plugin.logger.warning.assert_called_once_with(
+                "Failed to send reaction", exc_info=True
+            )
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -767,8 +767,8 @@ class TestLogoutMatrixBot:
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        test_password = "test_password"
-        result = await logout_matrix_bot(password=test_password)
+        dummy_input = "value"
+        result = await logout_matrix_bot(password=dummy_input)
 
         assert result is False
         mock_logger.error.assert_called_once_with(
@@ -1683,7 +1683,7 @@ class TestLogoutMatrixBot:
                 cli_mod.AsyncClient = original_ac
 
             assert result is False
-            mock_logger.error.assert_called()
+            mock_logger.error.assert_called_with("Matrix AsyncClient not available")
 
     @pytest.mark.asyncio
     async def test_logout_matrix_bot_main_logout_async_client_becomes_none(
@@ -1723,4 +1723,4 @@ class TestLogoutMatrixBot:
             result = await logout_matrix_bot(password="test_password")
 
             assert result is False
-            mock_logger.error.assert_called()
+            mock_logger.error.assert_called_with("Matrix AsyncClient not available")

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -767,10 +767,13 @@ class TestLogoutMatrixBot:
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        result = await logout_matrix_bot(password="test_password")
+        test_password = "test_password"
+        result = await logout_matrix_bot(password=test_password)
 
         assert result is False
-        mock_logger.error.assert_called_once()
+        mock_logger.error.assert_called_once_with(
+            "Matrix-nio library not available. Cannot perform logout."
+        )
         mock_print.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1637,3 +1637,87 @@ class TestLogoutMatrixBot:
             result = await logout_matrix_bot(password="test_password")
             assert result is False
             mock_print.assert_any_call("⚠️  Logout completed with some errors.")
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_password_verify_async_client_becomes_none(
+        self, mock_credentials
+    ):
+        """Test logout when AsyncClient becomes None during password verification (lines 780-782)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+        mock_async_client = MagicMock()
+
+        def make_ssl_and_nullify_client():
+            import mmrelay.cli_utils as mod
+
+            mod.AsyncClient = None
+            return MagicMock()
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch(
+                "mmrelay.cli_utils._create_ssl_context",
+                side_effect=make_ssl_and_nullify_client,
+            ),
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=False),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+            patch("builtins.print"),
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+
+            import mmrelay.cli_utils as cli_mod
+
+            original_ac = cli_mod.AsyncClient
+            cli_mod.AsyncClient = mock_async_client
+            try:
+                result = await logout_matrix_bot(password="test_password")
+            finally:
+                cli_mod.AsyncClient = original_ac
+
+            assert result is False
+            mock_logger.error.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_logout_matrix_bot_main_logout_async_client_becomes_none(
+        self, mock_credentials
+    ):
+        """Test logout when AsyncClient becomes None before main session logout (lines 841-843)."""
+        from mmrelay.cli_utils import logout_matrix_bot
+
+        mock_creds = mock_credentials(user_id="@test:matrix.org")
+
+        mock_temp_client = AsyncMock()
+        mock_temp_client.login.return_value = MagicMock(access_token="temp_token")
+        mock_temp_client.logout = AsyncMock()
+
+        def close_and_nullify():
+            import mmrelay.cli_utils as mod
+
+            mod.AsyncClient = None
+
+        mock_temp_client.close = AsyncMock(side_effect=close_and_nullify)
+
+        with (
+            patch(
+                "mmrelay.config.async_load_credentials",
+                new=AsyncMock(return_value=mock_creds),
+            ),
+            patch("mmrelay.cli_utils.AsyncClient") as mock_async_client,
+            patch("mmrelay.cli_utils._create_ssl_context", return_value=MagicMock()),
+            patch("mmrelay.cli_utils._cleanup_local_session_data", return_value=False),
+            patch("mmrelay.cli_utils._get_logger") as mock_get_logger,
+            patch("builtins.print"),
+        ):
+            mock_logger = MagicMock()
+            mock_get_logger.return_value = mock_logger
+            mock_async_client.side_effect = [mock_temp_client]
+
+            result = await logout_matrix_bot(password="test_password")
+
+            assert result is False
+            mock_logger.error.assert_called()

--- a/tests/test_drop_plugin.py
+++ b/tests/test_drop_plugin.py
@@ -71,6 +71,7 @@ class TestDropPlugin(unittest.TestCase):
         self.plugin.store_node_data = MagicMock()
         self.plugin.get_node_data = MagicMock(return_value=[])
         self.plugin.set_node_data = MagicMock()
+        self.plugin.send_message = MagicMock()
 
         # Mock meshtastic client
         self.mock_meshtastic_client = MagicMock()
@@ -310,8 +311,8 @@ class TestDropPlugin(unittest.TestCase):
             )
 
             # Should send the message to the node
-            self.mock_meshtastic_client.sendText.assert_called_once_with(
-                text="Pickup this message", destinationId="!12345678"
+            self.plugin.send_message.assert_called_once_with(
+                text="Pickup this message", destination_id="!12345678"
             )
 
             # Should clear the messages (empty list)
@@ -358,8 +359,7 @@ class TestDropPlugin(unittest.TestCase):
                 packet, "formatted_message", "longname", "meshnet_name"
             )
 
-            # Should not send the message
-            self.mock_meshtastic_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
             # Should keep the message in storage
             self.plugin.set_node_data.assert_called_once_with(
@@ -408,8 +408,7 @@ class TestDropPlugin(unittest.TestCase):
                 packet, "formatted_message", "longname", "meshnet_name"
             )
 
-            # Should not send the message
-            self.mock_meshtastic_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
             # Should keep the message in storage (can't pick up own messages)
             self.plugin.set_node_data.assert_called_once_with(
@@ -457,8 +456,7 @@ class TestDropPlugin(unittest.TestCase):
                 packet, "formatted_message", "longname", "meshnet_name"
             )
 
-            # Should not send the message (distance defaults to 1000km, out of range)
-            self.mock_meshtastic_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
             # Should keep the message in storage
             self.plugin.set_node_data.assert_called_once_with(

--- a/tests/test_health_plugin.py
+++ b/tests/test_health_plugin.py
@@ -346,6 +346,27 @@ class TestHealthPlugin(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    def test_handle_room_message_exception_handler(self):
+        """Test exception handler in handle_room_message (lines 171-174)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.generate_response = MagicMock(side_effect=RuntimeError("boom"))
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertTrue(result)
+            self.plugin.logger.exception.assert_called_once_with(
+                "Error handling health command"
+            )
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "❌"
+            )
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_health_plugin.py
+++ b/tests/test_health_plugin.py
@@ -251,7 +251,7 @@ class TestHealthPlugin(unittest.TestCase):
         Test that handle_meshtastic_message consistently returns False regardless of input.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that the plugin's handle_meshtastic_message method returns False when called with sample input.
             """
@@ -271,7 +271,7 @@ class TestHealthPlugin(unittest.TestCase):
         room = MagicMock()
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that `handle_room_message` returns False when the event does not match and ensures no Matrix message is sent.
             """
@@ -322,7 +322,7 @@ class TestHealthPlugin(unittest.TestCase):
         room.room_id = "!test:matrix.org"
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that a Matrix room message event matching the plugin triggers a health summary message to be sent.
 

--- a/tests/test_health_plugin.py
+++ b/tests/test_health_plugin.py
@@ -37,6 +37,7 @@ class TestHealthPlugin(unittest.TestCase):
 
         # Mock Matrix client methods
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
 
         # Create sample node data for testing
         self.sample_nodes = {
@@ -278,6 +279,7 @@ class TestHealthPlugin(unittest.TestCase):
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_not_called()
+            self.plugin.send_matrix_reaction.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -337,6 +339,10 @@ class TestHealthPlugin(unittest.TestCase):
             self.assertEqual(call_args[0][0], "!test:matrix.org")  # room_id
             self.assertIn("Nodes: 5", call_args[0][1])  # message content
             self.assertEqual(call_args.kwargs["formatted"], False)
+
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
 
         asyncio.run(run_test())
 

--- a/tests/test_health_plugin.py
+++ b/tests/test_health_plugin.py
@@ -355,7 +355,7 @@ class TestHealthPlugin(unittest.TestCase):
         room.room_id = "!test:matrix.org"
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertTrue(result)
             self.plugin.logger.exception.assert_called_once_with(

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -416,6 +416,33 @@ class TestHelpPlugin(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    @patch("mmrelay.plugins.help_plugin.load_plugins")
+    def test_handle_room_message_send_exception(self, mock_load_plugins):
+        """Test exception handler in handle_room_message (lines 132-135)."""
+        mock_load_plugins.return_value = []
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.send_matrix_message.side_effect = RuntimeError("send failed")
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        full_message = "!help"
+        event = MagicMock()
+        event.body = full_message
+        event.source = {"content": {"formatted_body": ""}}
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, full_message)
+
+            self.assertTrue(result)
+            self.plugin.logger.exception.assert_called_once_with(
+                "Error handling help command"
+            )
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "❌"
+            )
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -47,6 +47,7 @@ class TestHelpPlugin(unittest.TestCase):
 
         # Mock Matrix client methods
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
 
         # Create mock plugins for testing
         self.mock_plugin1 = MagicMock()
@@ -133,6 +134,7 @@ class TestHelpPlugin(unittest.TestCase):
                 )
                 self.assertFalse(result)
                 self.plugin.send_matrix_message.assert_not_called()
+                self.plugin.send_matrix_reaction.assert_not_called()
 
             asyncio.run(run_test())
 
@@ -168,6 +170,9 @@ class TestHelpPlugin(unittest.TestCase):
             self.assertTrue(result)
             self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_called_once()
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
 
             # Check the call arguments
             call_args = self.plugin.send_matrix_message.call_args
@@ -214,6 +219,9 @@ class TestHelpPlugin(unittest.TestCase):
 
             self.assertTrue(result)
             self.plugin.send_matrix_message.assert_called_once()
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
 
             # Check the call arguments
             call_args = self.plugin.send_matrix_message.call_args
@@ -260,6 +268,9 @@ class TestHelpPlugin(unittest.TestCase):
 
             self.assertTrue(result)
             self.plugin.send_matrix_message.assert_called_once()
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
 
             # Check the call arguments
             call_args = self.plugin.send_matrix_message.call_args
@@ -308,6 +319,10 @@ class TestHelpPlugin(unittest.TestCase):
             self.assertIn("cmd3", message)
             self.assertIn("weather", message)
 
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
+
         asyncio.run(run_test())
 
     @patch("mmrelay.plugins.help_plugin.load_plugins")
@@ -352,6 +367,10 @@ class TestHelpPlugin(unittest.TestCase):
                 message,
             )
 
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
+
         asyncio.run(run_test())
 
     def test_get_matrix_commands_none_name(self):
@@ -390,6 +409,10 @@ class TestHelpPlugin(unittest.TestCase):
 
             # Should show empty command list
             self.assertEqual(message, MSG_AVAILABLE_COMMANDS_PREFIX)
+
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
 
         asyncio.run(run_test())
 

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -94,7 +94,7 @@ class TestHelpPlugin(unittest.TestCase):
         Test that handle_meshtastic_message always returns False, regardless of input.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that handle_meshtastic_message always returns False for the help plugin.
             """
@@ -121,7 +121,7 @@ class TestHelpPlugin(unittest.TestCase):
             patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
         ):
 
-            async def run_test():
+            async def run_test() -> None:
                 """
                 Verify that handle_room_message returns False and does not send a Matrix message when the event does not match the help command.
 
@@ -159,7 +159,7 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = full_message
         event.source = {"content": {"formatted_body": ""}}
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Run assertions that handling a general "!help" room message results in a command list being sent.
 
@@ -209,7 +209,7 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = full_message
         event.source = {"content": {"formatted_body": ""}}
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Run the test that requesting help for a specific command results in a single sent message containing the command and its description.
 
@@ -258,7 +258,7 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = full_message
         event.source = {"content": {"formatted_body": ""}}
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that requesting help for a nonexistent command returns an appropriate error message.
 
@@ -303,7 +303,7 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = full_message
         event.source = {"content": {"formatted_body": ""}}
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that the help plugin's room message handler returns True and sends a message containing all available commands from loaded plugins.
             """
@@ -349,7 +349,7 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = full_message
         event.source = {"content": {"formatted_body": ""}}
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Runs an asynchronous test to verify that requesting help for a specific command returns the correct help message, including the command and its plugin description.
             """
@@ -395,7 +395,7 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = full_message
         event.source = {"content": {"formatted_body": ""}}
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Run the asynchronous test that verifies the help plugin reports no commands when no plugins are loaded.
 
@@ -430,7 +430,7 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = full_message
         event.source = {"content": {"formatted_body": ""}}
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_room_message(room, event, full_message)
 
             self.assertTrue(result)

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -343,6 +343,7 @@ class TestMapPlugin(unittest.TestCase):
         Initializes the Plugin and assigns test-specific configuration values for zoom, image size, anonymization, and radius.
         """
         self.plugin = Plugin()
+        self.plugin.send_matrix_reaction = AsyncMock()
         self.plugin.config = {
             "zoom": 10,
             "image_width": 800,
@@ -467,6 +468,9 @@ class TestMapPlugin(unittest.TestCase):
                 mock_room.room_id,
                 mock_image,
                 "location.png",
+            )
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:example.com", mock_event.event_id, "✅"
             )
 
         asyncio.run(run_test())
@@ -841,6 +845,9 @@ class TestMapPlugin(unittest.TestCase):
             self.plugin.send_matrix_message.assert_awaited_once()
             mock_get_map.assert_not_called()
             _mock_send_image.assert_not_called()
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:example.com", mock_event.event_id, "✅"
+            )
 
         asyncio.run(run_test())
 
@@ -900,6 +907,9 @@ class TestMapPlugin(unittest.TestCase):
             )
             self.assertIsNotNone(error_call)
             self.assertEqual(error_call.kwargs["room_id"], mock_room.room_id)
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:example.com", mock_event.event_id, "❌"
+            )
 
         asyncio.run(run_test())
 
@@ -994,6 +1004,7 @@ class TestGetMapEdgeCases(unittest.TestCase):
 class TestMapPluginHandleRoomMessage(unittest.TestCase):
     def setUp(self):
         self.plugin = Plugin()
+        self.plugin.send_matrix_reaction = AsyncMock()
         self.plugin.config = {
             "zoom": 10,
             "image_width": 800,
@@ -1127,6 +1138,9 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
             self.assertTrue(result)
             self.plugin.send_matrix_message.assert_awaited_once()
             mock_get_map.assert_not_called()
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:example.com", mock_event.event_id, "❌"
+            )
 
         asyncio.run(run_test())
 
@@ -1158,6 +1172,9 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
             self.assertTrue(result)
             self.plugin.send_matrix_message.assert_awaited_once()
             mock_get_map.assert_not_called()
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:example.com", mock_event.event_id, "❌"
+            )
 
         asyncio.run(run_test())
 

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -1040,6 +1040,31 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
     @patch("mmrelay.plugins.map_plugin.get_map")
     @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
     @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_extract_args_returns_none(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        """Test that extract_command_args returning None causes early return (lines 529-530)."""
+
+        async def run_test():
+            self.plugin.matches = MagicMock(return_value=True)
+            self.plugin.extract_command_args = MagicMock(return_value=None)
+
+            mock_room = MagicMock()
+            mock_room.room_id = "!test:example.com"
+            mock_event = MagicMock()
+            mock_event.body = "!map"
+
+            result = await self.plugin.handle_room_message(
+                mock_room, mock_event, "!map"
+            )
+            self.assertFalse(result)
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
     def test_handle_room_message_config_zoom_out_of_range(
         self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
     ):
@@ -1207,6 +1232,34 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
             self.plugin.send_matrix_message.assert_awaited_once()
 
         asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.send_image")
+    @patch("mmrelay.plugins.map_plugin.get_map")
+    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    def test_handle_room_message_generic_exception(
+        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
+    ):
+        """Test generic exception handler in handle_room_message (lines 664-669)."""
+        mock_connect_matrix.side_effect = RuntimeError("unexpected boom")
+
+        mock_room = MagicMock()
+        mock_room.room_id = "!test:example.com"
+        mock_event = MagicMock()
+        mock_event.body = "!map"
+
+        with patch.object(self.plugin, "matches", return_value=True):
+
+            async def run_test():
+                result = await self.plugin.handle_room_message(
+                    mock_room, mock_event, "!map"
+                )
+                self.assertTrue(result)
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!test:example.com", mock_event.event_id, "❌"
+                )
+
+            asyncio.run(run_test())
 
 
 if __name__ == "__main__":

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -467,7 +467,6 @@ class TestMapPlugin(unittest.TestCase):
                 mock_room.room_id,
                 mock_image,
                 "location.png",
-                reply_to_event_id=mock_event.event_id,
             )
 
         asyncio.run(run_test())
@@ -889,10 +888,18 @@ class TestMapPlugin(unittest.TestCase):
                 )
 
             self.assertTrue(result)
-            mock_matrix_client.room_send.assert_awaited_once()
-            call_kwargs = mock_matrix_client.room_send.call_args.kwargs
-            self.assertEqual(call_kwargs["room_id"], mock_room.room_id)
-            self.assertIn("failed", call_kwargs["content"]["body"].lower())
+            self.assertGreaterEqual(mock_matrix_client.room_send.await_count, 1)
+            calls = mock_matrix_client.room_send.call_args_list
+            error_call = next(
+                (
+                    c
+                    for c in calls
+                    if "failed" in c.kwargs.get("content", {}).get("body", "").lower()
+                ),
+                None,
+            )
+            self.assertIsNotNone(error_call)
+            self.assertEqual(error_call.kwargs["room_id"], mock_room.room_id)
 
         asyncio.run(run_test())
 

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -251,7 +251,7 @@ class TestImageUploadAndSend(unittest.TestCase):
         Asynchronously tests that the image upload function saves an image to a buffer, uploads it via the client, and returns the correct upload response.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             # Mock image save
             """
             Execute an asynchronous test that verifies upload_image uploads image bytes and returns the upload response.
@@ -278,7 +278,7 @@ class TestImageUploadAndSend(unittest.TestCase):
         Asynchronously verifies that an image message is sent to the specified Matrix room with the correct content using the client.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             room_id = "!test:example.com"
 
             await send_room_image(
@@ -306,7 +306,7 @@ class TestImageUploadAndSend(unittest.TestCase):
         Calls send_image with a mock client, room ID, image, and filename; asserts that upload_image is awaited with the client, image, and filename, and that send_room_image is awaited with the client, room ID, upload response, and filename.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Verify that send_image uploads the provided image and then sends the resulting upload response to the specified Matrix room.
 
@@ -381,7 +381,7 @@ class TestMapPlugin(unittest.TestCase):
         Tests that handle_meshtastic_message returns False when called with a Meshtastic message.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that the plugin's `handle_meshtastic_message` method returns False when invoked with a sample message.
             """
@@ -426,7 +426,7 @@ class TestMapPlugin(unittest.TestCase):
         Asserts that when the plugin matches a "!map" command it calls get_map once and calls send_image with the Matrix client, the originating room ID, the generated image, and the filename "location.png".
         """
 
-        async def run_test():
+        async def run_test() -> None:
             # Setup mocks
             """
             Asynchronously tests that the plugin processes a "!map" room message by generating a map image and sending it to the Matrix room.
@@ -492,7 +492,7 @@ class TestMapPlugin(unittest.TestCase):
         Mocks Matrix and Meshtastic clients and a map image; asserts get_map was called with zoom=15 and the plugin handler returned True.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Verify the plugin handles a "!map zoom=15" room message and forwards zoom=15 to the map generator.
 
@@ -555,7 +555,7 @@ class TestMapPlugin(unittest.TestCase):
         This test verifies that when a user specifies an image size (e.g., "!map size=500,400"), the map generation function receives the correct `image_size` parameter and the plugin returns True.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Verify that a "!map size=500,400" room command produces a map request using the specified image size.
 
@@ -607,7 +607,7 @@ class TestMapPlugin(unittest.TestCase):
         Verifies that the plugin's handle_room_message method returns False if the incoming message does not correspond to the map command.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that the plugin's handle_room_message method returns False when the message does not match the plugin command.
             """
@@ -642,7 +642,7 @@ class TestMapPlugin(unittest.TestCase):
         and verifies get_map was invoked with zoom set to configured value 10.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Verify invalid zoom input falls back to plugin-configured zoom.
 
@@ -701,7 +701,7 @@ class TestMapPlugin(unittest.TestCase):
     ):
         """Invalid configured zoom should fall back to default when no zoom arg is provided."""
 
-        async def run_test():
+        async def run_test() -> None:
             self.plugin.config["zoom"] = "bad-zoom"
 
             mock_room = MagicMock()
@@ -754,7 +754,7 @@ class TestMapPlugin(unittest.TestCase):
         Asserts that the plugin processes the command successfully and calls get_map with image_size set to (1000, 1000).
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Verify that handling a room "!map" command caps oversized image size parameters to the configured maximum.
 
@@ -814,7 +814,7 @@ class TestMapPlugin(unittest.TestCase):
         Ensure a friendly notice is sent when no nodes contain location data.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Execute the plugin's room-message handler for a "!map" command when no node locations are available.
 
@@ -864,7 +864,7 @@ class TestMapPlugin(unittest.TestCase):
     ):
         """Image upload errors should send a notice and return True."""
 
-        async def run_test():
+        async def run_test() -> None:
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
             mock_event = MagicMock()
@@ -1015,14 +1015,8 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
         self.plugin.plugin_name = None
         self.assertEqual(self.plugin.get_matrix_commands(), [])
 
-    @patch("mmrelay.matrix_utils.send_image")
-    @patch("mmrelay.plugins.map_plugin.get_map")
-    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
-    @patch("mmrelay.matrix_utils.connect_matrix")
-    def test_handle_room_message_invalid_args(
-        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
-    ):
-        async def run_test():
+    def test_handle_room_message_invalid_args(self):
+        async def run_test() -> None:
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
             mock_event = MagicMock()
@@ -1036,16 +1030,10 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
 
         asyncio.run(run_test())
 
-    @patch("mmrelay.matrix_utils.send_image")
-    @patch("mmrelay.plugins.map_plugin.get_map")
-    @patch("mmrelay.plugins.map_plugin._connect_meshtastic_async")
-    @patch("mmrelay.matrix_utils.connect_matrix")
-    def test_handle_room_message_extract_args_returns_none(
-        self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
-    ):
+    def test_handle_room_message_extract_args_returns_none(self):
         """Test that extract_command_args returning None causes early return (lines 529-530)."""
 
-        async def run_test():
+        async def run_test() -> None:
             self.plugin.matches = MagicMock(return_value=True)
             self.plugin.extract_command_args = MagicMock(return_value=None)
 
@@ -1068,7 +1056,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
     def test_handle_room_message_config_zoom_out_of_range(
         self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
     ):
-        async def run_test():
+        async def run_test() -> None:
             self.plugin.config["zoom"] = 50
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"
@@ -1106,7 +1094,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
     def test_handle_room_message_image_size_config_fallback(
         self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
     ):
-        async def run_test():
+        async def run_test() -> None:
             self.plugin.config["image_width"] = "bad"
             self.plugin.config["image_height"] = "bad"
             mock_room = MagicMock()
@@ -1146,7 +1134,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
     def test_handle_room_message_matrix_unavailable(
         self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
     ):
-        async def run_test():
+        async def run_test() -> None:
             mock_connect_matrix.return_value = None
             self.plugin.send_matrix_message = AsyncMock()
 
@@ -1174,7 +1162,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
     def test_handle_room_message_meshtastic_unavailable(
         self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
     ):
-        async def run_test():
+        async def run_test() -> None:
             mock_matrix_client = MagicMock()
             mock_matrix_client.room_send = AsyncMock()
             mock_connect_matrix.return_value = mock_matrix_client
@@ -1208,7 +1196,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
     def test_handle_room_message_meshtastic_no_nodes(
         self, mock_connect_matrix, mock_connect_mesh, mock_get_map, mock_send_image
     ):
-        async def run_test():
+        async def run_test() -> None:
             mock_matrix_client = MagicMock()
             mock_matrix_client.room_send = AsyncMock()
             mock_connect_matrix.return_value = mock_matrix_client
@@ -1250,7 +1238,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
 
         with patch.object(self.plugin, "matches", return_value=True):
 
-            async def run_test():
+            async def run_test() -> None:
                 result = await self.plugin.handle_room_message(
                     mock_room, mock_event, "!map"
                 )

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -846,7 +846,7 @@ class TestMapPlugin(unittest.TestCase):
             mock_get_map.assert_not_called()
             _mock_send_image.assert_not_called()
             self.plugin.send_matrix_reaction.assert_called_once_with(
-                "!test:example.com", mock_event.event_id, "✅"
+                "!test:example.com", mock_event.event_id, "❌"
             )
 
         asyncio.run(run_test())
@@ -1136,11 +1136,9 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
                 )
 
             self.assertTrue(result)
-            self.plugin.send_matrix_message.assert_awaited_once()
+            self.plugin.send_matrix_message.assert_not_awaited()
+            self.plugin.send_matrix_reaction.assert_not_called()
             mock_get_map.assert_not_called()
-            self.plugin.send_matrix_reaction.assert_called_once_with(
-                "!test:example.com", mock_event.event_id, "❌"
-            )
 
         asyncio.run(run_test())
 

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -327,6 +327,7 @@ class TestImageUploadAndSend(unittest.TestCase):
                 room_id,
                 upload_response=self.mock_upload_response,
                 filename="test.png",
+                reply_to_event_id=None,
             )
 
         asyncio.run(run_test())
@@ -462,7 +463,11 @@ class TestMapPlugin(unittest.TestCase):
             self.assertTrue(result)
             mock_get_map.assert_called_once()
             _mock_send_image.assert_called_once_with(
-                mock_matrix_client, mock_room.room_id, mock_image, "location.png"
+                mock_matrix_client,
+                mock_room.room_id,
+                mock_image,
+                "location.png",
+                reply_to_event_id=mock_event.event_id,
             )
 
         asyncio.run(run_test())

--- a/tests/test_matrix_utils_media.py
+++ b/tests/test_matrix_utils_media.py
@@ -124,6 +124,7 @@ async def test_send_image():
                 "!room:matrix.org",
                 upload_response=mock_upload_response,
                 filename="test.png",
+                reply_to_event_id=None,
             )
 
 

--- a/tests/test_matrix_utils_media.py
+++ b/tests/test_matrix_utils_media.py
@@ -95,6 +95,34 @@ async def test_send_room_image_raises_on_missing_content_uri():
         )
 
 
+async def test_send_room_image_with_reply_to_event_id():
+    """
+    Test that send_room_image includes m.relates_to in-reply-to when reply_to_event_id is provided.
+    """
+    mock_client = MagicMock()
+    mock_client.room_send = AsyncMock()
+    mock_upload_response = MagicMock()
+    mock_upload_response.content_uri = "mxc://matrix.org/test123"
+
+    await send_room_image(
+        mock_client,
+        "!room:matrix.org",
+        mock_upload_response,
+        "test.png",
+        reply_to_event_id="$event",
+    )
+
+    mock_client.room_send.assert_called_once()
+    call_args = mock_client.room_send.call_args
+    assert call_args[1]["room_id"] == "!room:matrix.org"
+    assert call_args[1]["message_type"] == MATRIX_EVENT_TYPE_ROOM_MESSAGE
+    content = call_args[1]["content"]
+    assert content["msgtype"] == "m.image"
+    assert content["url"] == "mxc://matrix.org/test123"
+    assert content["body"] == "test.png"
+    assert content["m.relates_to"] == {"m.in_reply_to": {"event_id": "$event"}}
+
+
 async def test_send_image():
     """
     Test that send_image combines upload_image and send_room_image correctly.

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -297,7 +297,13 @@ class TestConnectMeshtastic:
                 "TCPInterface",
                 return_value=None,
             ),
-            patch.object(mu, "time"),
+            patch.object(mu.time, "sleep"),
+            patch.object(mu, "logger") as mock_logger,
         ):
             result = _connect_meshtastic_impl()
             assert result is None
+            mock_logger.error.assert_any_call(
+                "Meshtastic %s connection path completed without a client.",
+                "tcp",
+            )
+            assert mu.meshtastic_client is None

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -275,3 +275,29 @@ class TestConnectMeshtastic:
         mu.meshtastic_iface = None
         result = _connect_meshtastic_impl()
         assert result is existing
+
+    def test_tcp_connection_returns_none_client_raises_connection_error(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        mu.config = {
+            "meshtastic": {
+                "connection_type": "tcp",
+                "host": "192.168.1.1",
+                "retries": 1,
+            }
+        }
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        mu.meshtastic_iface = None
+
+        with (
+            patch.object(
+                mu.meshtastic.tcp_interface,
+                "TCPInterface",
+                return_value=None,
+            ),
+            patch.object(mu, "time"),
+        ):
+            result = _connect_meshtastic_impl()
+            assert result is None

--- a/tests/test_nodes_plugin.py
+++ b/tests/test_nodes_plugin.py
@@ -163,6 +163,7 @@ class TestNodesPlugin(unittest.TestCase):
 
         # Mock Matrix client methods
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
 
         # Mock meshtastic client with sample node data
         self.mock_meshtastic_client = MagicMock()
@@ -448,6 +449,7 @@ class TestNodesPlugin(unittest.TestCase):
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_not_called()
+            self.plugin.send_matrix_reaction.assert_not_called()
 
         import asyncio
 
@@ -483,6 +485,10 @@ class TestNodesPlugin(unittest.TestCase):
             self.assertEqual(call_args.kwargs["room_id"], "!test:matrix.org")
             self.assertIn("Nodes: 3", call_args.kwargs["message"])
             self.assertEqual(call_args.kwargs["formatted"], False)
+
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
 
         import asyncio
 

--- a/tests/test_nodes_plugin.py
+++ b/tests/test_nodes_plugin.py
@@ -417,7 +417,7 @@ class TestNodesPlugin(unittest.TestCase):
         Test that handle_meshtastic_message always returns False regardless of input.
         """
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that handle_meshtastic_message always returns False.
             """
@@ -439,7 +439,7 @@ class TestNodesPlugin(unittest.TestCase):
         room = MagicMock()
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that handle_room_message returns False and does not send a Matrix message when the event does not match.
 
@@ -467,7 +467,7 @@ class TestNodesPlugin(unittest.TestCase):
         room.room_id = "!test:matrix.org"
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that a room message matching the plugin's criteria triggers a Matrix message with correct node information.
 
@@ -694,7 +694,7 @@ class TestNodesPlugin(unittest.TestCase):
         room.room_id = "!test:matrix.org"
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_room_message(room, event, "full_message")
             self.assertTrue(result)
             self.plugin.logger.exception.assert_called_once_with(

--- a/tests/test_nodes_plugin.py
+++ b/tests/test_nodes_plugin.py
@@ -685,6 +685,29 @@ class TestNodesPlugin(unittest.TestCase):
         # Should have two instances of "? hops away"
         self.assertEqual(response.count("? hops away"), 2)
 
+    def test_handle_room_message_exception_handler(self):
+        """Test exception handler in handle_room_message (lines 224-227)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.generate_response = MagicMock(side_effect=RuntimeError("boom"))
+
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+
+        async def run_test():
+            result = await self.plugin.handle_room_message(room, event, "full_message")
+            self.assertTrue(result)
+            self.plugin.logger.exception.assert_called_once_with(
+                "Error handling nodes command"
+            )
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "❌"
+            )
+
+        import asyncio
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -60,6 +60,7 @@ class TestPingPlugin(unittest.TestCase):
         self.plugin.is_channel_enabled = MagicMock(return_value=True)
         self.plugin.get_response_delay = MagicMock(return_value=1.0)
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_message = MagicMock()
 
     def test_plugin_name(self):
         self.assertEqual(self.plugin.plugin_name, "ping")
@@ -120,7 +121,7 @@ class TestPingPlugin(unittest.TestCase):
             self.plugin.logger.warning.assert_called_once_with(
                 "Meshtastic client myInfo unavailable; skipping ping"
             )
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -147,8 +148,8 @@ class TestPingPlugin(unittest.TestCase):
                 0, is_direct_message=False
             )
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text=PING_RESPONSE, channelIndex=0
+            self.plugin.send_message.assert_called_once_with(
+                text=PING_RESPONSE, channel=0, reply_id=None
             )
             self.plugin.logger.info.assert_called_once()
 
@@ -177,8 +178,8 @@ class TestPingPlugin(unittest.TestCase):
                 1, is_direct_message=True
             )
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text=PING_RESPONSE, destinationId="!12345678"
+            self.plugin.send_message.assert_called_once_with(
+                text=PING_RESPONSE, destination_id="!12345678", reply_id=None
             )
 
         asyncio.run(run_test())
@@ -205,8 +206,8 @@ class TestPingPlugin(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text=PING_RESPONSE, channelIndex=0
+            self.plugin.send_message.assert_called_once_with(
+                text=PING_RESPONSE, channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -229,7 +230,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -251,7 +252,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -273,7 +274,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -295,7 +296,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -319,7 +320,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -342,7 +343,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -367,8 +368,8 @@ class TestPingPlugin(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text=PING_RESPONSE, channelIndex=0
+            self.plugin.send_message.assert_called_once_with(
+                text=PING_RESPONSE, channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -391,7 +392,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -414,7 +415,7 @@ class TestPingPlugin(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -485,6 +486,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
         self.plugin.is_channel_enabled = MagicMock(return_value=True)
         self.plugin.get_response_delay = MagicMock(return_value=1.0)
         self.plugin.config = {"mimic_mode": True}
+        self.plugin.send_message = MagicMock()
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
@@ -506,7 +508,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="pong", channelIndex=0)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong", channel=0, reply_id=None
+            )
 
         asyncio.run(run_test())
 
@@ -533,11 +537,11 @@ class TestPingPluginMimicMode(unittest.TestCase):
                     )
                     self.assertTrue(result)
                     mock_sleep.assert_called_once_with(1.0)
-                    mock_client.sendText.assert_called_once_with(
-                        text=expected_response, channelIndex=0
+                    self.plugin.send_message.assert_called_once_with(
+                        text=expected_response, channel=0, reply_id=None
                     )
                     mock_sleep.reset_mock()
-                    mock_client.sendText.reset_mock()
+                    self.plugin.send_message.reset_mock()
 
         asyncio.run(run_test())
 
@@ -561,7 +565,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="PONG", channelIndex=0)
+            self.plugin.send_message.assert_called_once_with(
+                text="PONG", channel=0, reply_id=None
+            )
 
         asyncio.run(run_test())
 
@@ -585,7 +591,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="Pong", channelIndex=0)
+            self.plugin.send_message.assert_called_once_with(
+                text="Pong", channel=0, reply_id=None
+            )
 
         asyncio.run(run_test())
 
@@ -609,7 +617,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="!pong!", channelIndex=0)
+            self.plugin.send_message.assert_called_once_with(
+                text="!pong!", channel=0, reply_id=None
+            )
 
         asyncio.run(run_test())
 
@@ -635,8 +645,8 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text="!!!pong!!!", channelIndex=0
+            self.plugin.send_message.assert_called_once_with(
+                text="!!!pong!!!", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -661,8 +671,8 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text="!!!!!pong", channelIndex=0
+            self.plugin.send_message.assert_called_once_with(
+                text="!!!!!pong", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -687,8 +697,8 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text="!!!!!Pong?????", channelIndex=0
+            self.plugin.send_message.assert_called_once_with(
+                text="!!!!!Pong?????", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -713,7 +723,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="PoNg!?!", channelIndex=0)
+            self.plugin.send_message.assert_called_once_with(
+                text="PoNg!?!", channel=0, reply_id=None
+            )
 
         asyncio.run(run_test())
 
@@ -735,7 +747,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -763,8 +775,8 @@ class TestPingPluginMimicMode(unittest.TestCase):
                         packet, "formatted_message", "TestNode", "TestMesh"
                     )
                     self.assertFalse(result)
-                    mock_client.sendText.assert_not_called()
-                    mock_client.sendText.reset_mock()
+                    self.plugin.send_message.assert_not_called()
+                    self.plugin.send_message.reset_mock()
 
         asyncio.run(run_test())
 
@@ -786,7 +798,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
                 packet, "formatted_message", "TestNode", "TestMesh"
             )
             self.assertFalse(result)
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -812,7 +824,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertFalse(result)
             mock_sleep.assert_not_called()
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -838,7 +850,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertFalse(result)
             mock_sleep.assert_not_called()
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -862,7 +874,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
+            self.plugin.send_message.assert_called_once_with(
+                text="Pong...", channel=0, reply_id=None
+            )
 
         asyncio.run(run_test())
 
@@ -886,7 +900,9 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(text="Pong...", channelIndex=0)
+            self.plugin.send_message.assert_called_once_with(
+                text="Pong...", channel=0, reply_id=None
+            )
 
         asyncio.run(run_test())
 
@@ -913,8 +929,8 @@ class TestPingPluginMimicMode(unittest.TestCase):
                 1, is_direct_message=True
             )
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text="pong", destinationId="!12345678"
+            self.plugin.send_message.assert_called_once_with(
+                text="pong", destination_id="!12345678", reply_id=None
             )
 
         asyncio.run(run_test())
@@ -950,7 +966,7 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
             self.assertTrue(result)
             self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_called_once_with(
-                "!test:matrix.org", PING_RESPONSE
+                "!test:matrix.org", PING_RESPONSE, reply_to_event_id=event.event_id
             )
 
         asyncio.run(run_test())
@@ -962,6 +978,7 @@ class TestPingPluginEdgeCases(unittest.TestCase):
         self.plugin.logger = MagicMock()
         self.plugin.is_channel_enabled = MagicMock(return_value=True)
         self.plugin.get_response_delay = MagicMock(return_value=1.0)
+        self.plugin.send_message = MagicMock()
 
     def test_handle_meshtastic_message_no_decoded(self):
         packet = {"channel": 0, "fromId": "!12345678", "to": BROADCAST_NUM}
@@ -1010,8 +1027,8 @@ class TestPingPluginEdgeCases(unittest.TestCase):
             )
             self.assertTrue(result)
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
-                text=PING_RESPONSE, channelIndex=0
+            self.plugin.send_message.assert_called_once_with(
+                text=PING_RESPONSE, channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -1035,7 +1052,7 @@ class TestPingPluginEdgeCases(unittest.TestCase):
                 )
                 self.assertTrue(result)
                 mock_sleep.assert_not_called()
-                mock_client.sendText.assert_not_called()
+                self.plugin.send_message.assert_not_called()
                 self.plugin.logger.warning.assert_called_once_with(
                     "Direct message missing fromId; cannot reply"
                 )
@@ -1061,7 +1078,7 @@ class TestPingPluginEdgeCases(unittest.TestCase):
             )
             self.assertFalse(result)
             self.plugin.is_channel_enabled.assert_not_called()
-            mock_client.sendText.assert_not_called()
+            self.plugin.send_message.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -1088,9 +1105,10 @@ class TestPingPluginEdgeCases(unittest.TestCase):
                 DEFAULT_CHANNEL, is_direct_message=False
             )
             mock_sleep.assert_called_once_with(1.0)
-            mock_client.sendText.assert_called_once_with(
+            self.plugin.send_message.assert_called_once_with(
                 text=PING_RESPONSE,
-                channelIndex=DEFAULT_CHANNEL,
+                channel=DEFAULT_CHANNEL,
+                reply_id=None,
             )
 
         asyncio.run(run_test())

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -958,6 +958,7 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
             self.assertFalse(result)
             self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_not_called()
+            self.plugin.send_matrix_reaction.assert_not_called()
 
         asyncio.run(run_test())
 
@@ -971,11 +972,29 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
             result = await self.plugin.handle_room_message(room, event, "bot: !ping")
             self.assertTrue(result)
             self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_message.assert_called_once_with(
+                "!test:matrix.org", PING_RESPONSE
+            )
             self.plugin.send_matrix_reaction.assert_called_once_with(
                 "!test:matrix.org", event.event_id, "✅"
             )
-            self.plugin.send_matrix_message.assert_called_once_with(
-                "!test:matrix.org", PING_RESPONSE
+
+        asyncio.run(run_test())
+
+    def test_handle_room_message_ping_failure(self):
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.send_matrix_message = AsyncMock(
+            side_effect=Exception("send failed")
+        )
+        room = MagicMock()
+        room.room_id = "!test:matrix.org"
+        event = MagicMock()
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_room_message(room, event, "bot: !ping")
+            self.assertTrue(result)
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "❌"
             )
 
         asyncio.run(run_test())

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -137,6 +137,7 @@ class TestPingPlugin(unittest.TestCase):
             "channel": 0,
             "fromId": "!12345678",
             "to": BROADCAST_NUM,
+            "id": 123,
         }
 
         async def run_test() -> None:
@@ -149,7 +150,7 @@ class TestPingPlugin(unittest.TestCase):
             )
             mock_sleep.assert_called_once_with(1.0)
             self.plugin.send_message.assert_called_once_with(
-                text=PING_RESPONSE, channel=0, reply_id=None
+                text=PING_RESPONSE, channel=0, reply_id=123
             )
             self.plugin.logger.info.assert_called_once()
 
@@ -167,6 +168,7 @@ class TestPingPlugin(unittest.TestCase):
             "channel": 1,
             "fromId": "!12345678",
             "to": 123456789,
+            "id": 123,
         }
 
         async def run_test() -> None:
@@ -179,7 +181,10 @@ class TestPingPlugin(unittest.TestCase):
             )
             mock_sleep.assert_called_once_with(1.0)
             self.plugin.send_message.assert_called_once_with(
-                text=PING_RESPONSE, destination_id="!12345678", reply_id=None
+                text=PING_RESPONSE,
+                channel=1,
+                destination_id="!12345678",
+                reply_id=123,
             )
 
         asyncio.run(run_test())
@@ -930,7 +935,7 @@ class TestPingPluginMimicMode(unittest.TestCase):
             )
             mock_sleep.assert_called_once_with(1.0)
             self.plugin.send_message.assert_called_once_with(
-                text="pong", destination_id="!12345678", reply_id=None
+                text="pong", channel=1, destination_id="!12345678", reply_id=None
             )
 
         asyncio.run(run_test())

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -941,6 +941,7 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
         self.plugin = Plugin()
         self.plugin.logger = MagicMock()
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
 
     def test_handle_room_message_no_match(self):
         self.plugin.matches = MagicMock(return_value=False)
@@ -965,8 +966,11 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
             result = await self.plugin.handle_room_message(room, event, "bot: !ping")
             self.assertTrue(result)
             self.plugin.matches.assert_called_once_with(event)
+            self.plugin.send_matrix_reaction.assert_called_once_with(
+                "!test:matrix.org", event.event_id, "✅"
+            )
             self.plugin.send_matrix_message.assert_called_once_with(
-                "!test:matrix.org", PING_RESPONSE, reply_to_event_id=event.event_id
+                "!test:matrix.org", PING_RESPONSE
             )
 
         asyncio.run(run_test())

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -685,10 +685,8 @@ class TestTelemetryPlugin(unittest.TestCase):
                 result = await self.plugin.handle_room_message(
                     room, event, "!batteryLevel"
                 )
-                self.assertFalse(result)
-                self.plugin.send_matrix_reaction.assert_called_once_with(
-                    "!r", event.event_id, "❌"
-                )
+                self.assertTrue(result)
+                self.plugin.send_matrix_reaction.assert_not_called()
 
             asyncio.run(run_test())
 
@@ -724,7 +722,7 @@ class TestTelemetryPlugin(unittest.TestCase):
                     self.plugin.send_matrix_message.call_args.args[1],
                 )
                 self.plugin.send_matrix_reaction.assert_called_once_with(
-                    "!r", event.event_id, "✅"
+                    "!r", event.event_id, "❌"
                 )
 
             asyncio.run(run_test())

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -14,7 +14,7 @@ import asyncio
 import os
 import sys
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Add src to path for imports
@@ -160,7 +160,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that a valid telemetry message is processed and stored correctly by the plugin.
 
@@ -210,7 +210,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests handling of a Meshtastic telemetry message with partial device metrics, verifying that missing metrics are stored as None to preserve data integrity.
             """
@@ -242,7 +242,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             "decoded": {"portnum": TEXT_MESSAGE_APP, "text": "Hello world"},
         }
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Verify the plugin ignores a non-telemetry Meshtastic packet.
 
@@ -277,7 +277,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Verify that a telemetry packet missing deviceMetrics is ignored by the plugin.
 
@@ -309,7 +309,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             }
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 packet, "formatted_message", "longname", "meshnet_name"
             )
@@ -325,7 +325,7 @@ class TestTelemetryPlugin(unittest.TestCase):
     def test_handle_meshtastic_message_non_dict_decoded(self):
         """Non-dict decoded should return False immediately."""
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(
                 {"decoded": "not_a_dict"}, "f", "l", "m"
             )
@@ -336,7 +336,7 @@ class TestTelemetryPlugin(unittest.TestCase):
     def test_handle_meshtastic_message_no_decoded(self):
         """Packet with no decoded key should return False."""
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message({}, "f", "l", "m")
             self.assertFalse(result)
 
@@ -356,7 +356,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
             self.assertFalse(result)
             stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
@@ -378,7 +378,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
             self.assertFalse(result)
             stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
@@ -401,7 +401,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
             self.assertFalse(result)
             stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
@@ -424,7 +424,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             },
         }
 
-        async def run_test():
+        async def run_test() -> None:
             result = await self.plugin.handle_meshtastic_message(packet, "f", "l", "m")
             self.assertFalse(result)
             stored = self.plugin.set_node_data.call_args.kwargs["node_data"]
@@ -475,7 +475,7 @@ class TestTelemetryPlugin(unittest.TestCase):
         room = MagicMock()
         event = MagicMock()
 
-        async def run_test():
+        async def run_test() -> None:
             """
             Asynchronously tests that handling a room message returns False and verifies that the matches method is called once with the event.
             """
@@ -504,7 +504,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
         ):
 
-            async def run_test():
+            async def run_test() -> None:
                 """
                 Runs the test for handling a Matrix room message and asserts that the result is False.
                 """
@@ -521,7 +521,7 @@ class TestTelemetryPlugin(unittest.TestCase):
     @patch("mmrelay.plugins.telemetry_plugin.plt.xticks")
     @patch("mmrelay.plugins.telemetry_plugin.plt.subplots")
     def test_handle_room_message_valid_command_no_node(
-        self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect
+        self, mock_subplots, _mock_xticks, mock_send_image, mock_upload, mock_connect
     ):
         """
         Test that handle_room_message processes a valid command without a specified node, generates a plot, uploads the image, and sends it to the Matrix room.
@@ -559,7 +559,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             event.body = full_message
             event.source = {"content": {"formatted_body": ""}}
 
-            async def run_test():
+            async def run_test() -> None:
                 """
                 Run the async test that verifies handle_room_message processes a room message to produce and send a plot image.
 
@@ -597,7 +597,7 @@ class TestTelemetryPlugin(unittest.TestCase):
     @patch("mmrelay.plugins.telemetry_plugin.plt.xticks")
     @patch("mmrelay.plugins.telemetry_plugin.plt.subplots")
     def test_handle_room_message_with_specific_node(
-        self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect
+        self, mock_subplots, _mock_xticks, _mock_send_image, _mock_upload, _mock_connect
     ):
         """
         Test that handle_room_message processes a valid command with a specific node parameter, generates a voltage graph for the node, uploads the image, and sends it to the Matrix room.
@@ -640,7 +640,7 @@ class TestTelemetryPlugin(unittest.TestCase):
                 patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
             ):
 
-                async def run_test():
+                async def run_test() -> None:
                     """
                     Verify that handling a room message for a specific node requests that node's data and includes the node and metric in the plot title.
 
@@ -676,7 +676,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             patch("mmrelay.matrix_utils.connect_matrix", return_value=None),
         ):
 
-            async def run_test():
+            async def run_test() -> None:
                 room = MagicMock()
                 room.room_id = "!r"
                 event = MagicMock()
@@ -692,7 +692,7 @@ class TestTelemetryPlugin(unittest.TestCase):
 
     @patch("mmrelay.matrix_utils.connect_matrix")
     @patch("mmrelay.matrix_utils.send_image")
-    def test_handle_room_message_node_no_data(self, mock_send, mock_connect):
+    def test_handle_room_message_node_no_data(self, _mock_send, mock_connect):
         self.plugin.matches = MagicMock(return_value=True)
         self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
         self.plugin.get_node_data.return_value = None
@@ -706,7 +706,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
         ):
 
-            async def run_test():
+            async def run_test() -> None:
                 room = MagicMock()
                 room.room_id = "!r"
                 event = MagicMock()
@@ -729,12 +729,12 @@ class TestTelemetryPlugin(unittest.TestCase):
 
     @patch("mmrelay.matrix_utils.connect_matrix")
     @patch("mmrelay.matrix_utils.send_image")
-    def test_handle_room_message_all_nodes_data(self, mock_send, mock_connect):
+    def test_handle_room_message_all_nodes_data(self, _mock_send, mock_connect):
         import json
 
         self.plugin.matches = MagicMock(return_value=True)
         self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
-        now_ts = datetime.now().timestamp()
+        now_ts = datetime.now(timezone.utc).timestamp()
         self.plugin.get_data.return_value = [
             (json.dumps([{"time": now_ts, "batteryLevel": 80}]),)
         ]
@@ -759,7 +759,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             )
             mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
 
-            async def run_test():
+            async def run_test() -> None:
                 room = MagicMock()
                 room.room_id = "!r"
                 event = MagicMock()
@@ -806,7 +806,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             )
             mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
 
-            async def run_test():
+            async def run_test() -> None:
                 room = MagicMock()
                 room.room_id = "!r"
                 event = MagicMock()
@@ -829,14 +829,14 @@ class TestTelemetryPlugin(unittest.TestCase):
     @patch("mmrelay.plugins.telemetry_plugin.plt.xticks")
     @patch("mmrelay.plugins.telemetry_plugin.plt.subplots")
     def test_handle_room_message_calculate_averages_non_dict_record(
-        self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect
+        self, mock_subplots, _mock_xticks, _mock_send_image, _mock_upload, mock_connect
     ):
         import json
 
         self.plugin.matches = MagicMock(return_value=True)
         self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
 
-        now_ts = datetime.now().timestamp()
+        now_ts = datetime.now(timezone.utc).timestamp()
         self.plugin.get_data.return_value = [
             (json.dumps(["not_a_dict", {"time": now_ts, "batteryLevel": 80}]),)
         ]
@@ -861,7 +861,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             )
             mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
 
-            async def run_test():
+            async def run_test() -> None:
                 room = MagicMock()
                 room.room_id = "!r"
                 event = MagicMock()
@@ -881,7 +881,7 @@ class TestTelemetryPlugin(unittest.TestCase):
     @patch("mmrelay.plugins.telemetry_plugin.plt.xticks")
     @patch("mmrelay.plugins.telemetry_plugin.plt.subplots")
     def test_handle_room_message_calculate_averages_none_timestamp_and_value(
-        self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect
+        self, mock_subplots, _mock_xticks, _mock_send_image, _mock_upload, mock_connect
     ):
         import json
 
@@ -920,7 +920,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             )
             mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
 
-            async def run_test():
+            async def run_test() -> None:
                 room = MagicMock()
                 room.room_id = "!r"
                 event = MagicMock()
@@ -936,7 +936,7 @@ class TestTelemetryPlugin(unittest.TestCase):
 
     @patch("mmrelay.matrix_utils.connect_matrix")
     @patch("mmrelay.matrix_utils.send_image")
-    def test_handle_room_message_generic_exception(self, mock_send, mock_connect):
+    def test_handle_room_message_generic_exception(self, _mock_send, mock_connect):
         self.plugin.matches = MagicMock(return_value=True)
         self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
         self.plugin.get_data.side_effect = RuntimeError("unexpected error")
@@ -949,7 +949,7 @@ class TestTelemetryPlugin(unittest.TestCase):
             patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
         ):
 
-            async def run_test():
+            async def run_test() -> None:
                 room = MagicMock()
                 room.room_id = "!r"
                 event = MagicMock()

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -41,6 +41,7 @@ class TestTelemetryPlugin(unittest.TestCase):
 
         # Mock Matrix client methods
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
         self.plugin.send_room_image = AsyncMock()
         self.plugin.upload_image = AsyncMock()
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
@@ -577,6 +578,11 @@ class TestTelemetryPlugin(unittest.TestCase):
                 mock_ax.set_xlabel.assert_called_once_with("Hour")
                 mock_ax.set_ylabel.assert_called_once_with("batteryLevel")
 
+                # Should send success reaction
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!test:matrix.org", event.event_id, "✅"
+                )
+
                 # Should upload and send image
                 mock_upload.assert_called_once()
                 mock_send_image.assert_called_once()
@@ -654,6 +660,10 @@ class TestTelemetryPlugin(unittest.TestCase):
                     self.assertIn("NodeABC", title_call)
                     self.assertIn("voltage", title_call)
 
+                    self.plugin.send_matrix_reaction.assert_called_once_with(
+                        "!test:matrix.org", event.event_id, "✅"
+                    )
+
                 asyncio.run(run_test())
 
     def test_handle_room_message_matrix_unavailable(self):
@@ -676,6 +686,9 @@ class TestTelemetryPlugin(unittest.TestCase):
                     room, event, "!batteryLevel"
                 )
                 self.assertFalse(result)
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!r", event.event_id, "❌"
+                )
 
             asyncio.run(run_test())
 
@@ -709,6 +722,9 @@ class TestTelemetryPlugin(unittest.TestCase):
                 self.assertIn(
                     "No telemetry data",
                     self.plugin.send_matrix_message.call_args.args[1],
+                )
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!r", event.event_id, "✅"
                 )
 
             asyncio.run(run_test())
@@ -755,6 +771,9 @@ class TestTelemetryPlugin(unittest.TestCase):
                     room, event, "!batteryLevel"
                 )
                 self.assertTrue(result)
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!r", event.event_id, "✅"
+                )
 
             asyncio.run(run_test())
 
@@ -800,6 +819,9 @@ class TestTelemetryPlugin(unittest.TestCase):
                 )
                 self.assertTrue(result)
                 self.assertGreaterEqual(mock_matrix_client.room_send.await_count, 1)
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!r", event.event_id, "❌"
+                )
 
             asyncio.run(run_test())
 

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -799,7 +799,7 @@ class TestTelemetryPlugin(unittest.TestCase):
                     room, event, "!batteryLevel"
                 )
                 self.assertTrue(result)
-                mock_matrix_client.room_send.assert_awaited_once()
+                self.assertGreaterEqual(mock_matrix_client.room_send.await_count, 1)
 
             asyncio.run(run_test())
 

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -823,6 +823,151 @@ class TestTelemetryPlugin(unittest.TestCase):
 
             asyncio.run(run_test())
 
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    @patch("mmrelay.matrix_utils.upload_image")
+    @patch("mmrelay.matrix_utils.send_room_image")
+    @patch("mmrelay.plugins.telemetry_plugin.plt.xticks")
+    @patch("mmrelay.plugins.telemetry_plugin.plt.subplots")
+    def test_handle_room_message_calculate_averages_non_dict_record(
+        self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect
+    ):
+        import json
+
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+
+        now_ts = datetime.now().timestamp()
+        self.plugin.get_data.return_value = [
+            (json.dumps(["not_a_dict", {"time": now_ts, "batteryLevel": 80}]),)
+        ]
+
+        mock_matrix_client = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_subplots.return_value = (mock_fig, mock_ax)
+        mock_canvas = MagicMock()
+        mock_fig.canvas = mock_canvas
+
+        with (
+            patch("mmrelay.plugins.telemetry_plugin.Image") as mock_image_class,
+            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+        ):
+            mock_img = MagicMock()
+            mock_img.mode = "RGBA"
+            mock_image_class.open.return_value.__enter__ = MagicMock(
+                return_value=mock_img
+            )
+            mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
+
+            async def run_test():
+                room = MagicMock()
+                room.room_id = "!r"
+                event = MagicMock()
+                event.body = "!batteryLevel"
+                event.source = {"content": {"formatted_body": ""}}
+                result = await self.plugin.handle_room_message(
+                    room, event, "!batteryLevel"
+                )
+                self.assertTrue(result)
+                mock_ax.plot.assert_called_once()
+
+            asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    @patch("mmrelay.matrix_utils.upload_image")
+    @patch("mmrelay.matrix_utils.send_room_image")
+    @patch("mmrelay.plugins.telemetry_plugin.plt.xticks")
+    @patch("mmrelay.plugins.telemetry_plugin.plt.subplots")
+    def test_handle_room_message_calculate_averages_none_timestamp_and_value(
+        self, mock_subplots, mock_xticks, mock_send_image, mock_upload, mock_connect
+    ):
+        import json
+
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+
+        self.plugin.get_data.return_value = [
+            (
+                json.dumps(
+                    [
+                        {"time": None, "batteryLevel": 80},
+                        {"time": 12345, "batteryLevel": None},
+                        {"time": None, "batteryLevel": None},
+                        {"time": "not_a_number", "batteryLevel": 80},
+                        {"time": float("inf"), "batteryLevel": 50},
+                    ]
+                ),
+            )
+        ]
+
+        mock_matrix_client = AsyncMock()
+        mock_connect.return_value = mock_matrix_client
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_subplots.return_value = (mock_fig, mock_ax)
+
+        with (
+            patch("mmrelay.plugins.telemetry_plugin.Image") as mock_image_class,
+            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+        ):
+            mock_img = MagicMock()
+            mock_img.mode = "RGBA"
+            mock_image_class.open.return_value.__enter__ = MagicMock(
+                return_value=mock_img
+            )
+            mock_image_class.open.return_value.__exit__ = MagicMock(return_value=False)
+
+            async def run_test():
+                room = MagicMock()
+                room.room_id = "!r"
+                event = MagicMock()
+                event.body = "!batteryLevel"
+                event.source = {"content": {"formatted_body": ""}}
+                result = await self.plugin.handle_room_message(
+                    room, event, "!batteryLevel"
+                )
+                self.assertTrue(result)
+                mock_ax.plot.assert_called_once()
+
+            asyncio.run(run_test())
+
+    @patch("mmrelay.matrix_utils.connect_matrix")
+    @patch("mmrelay.matrix_utils.send_image")
+    def test_handle_room_message_generic_exception(self, mock_send, mock_connect):
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_data.side_effect = RuntimeError("unexpected error")
+
+        mock_matrix_client = MagicMock()
+        mock_connect.return_value = mock_matrix_client
+
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+        ):
+
+            async def run_test():
+                room = MagicMock()
+                room.room_id = "!r"
+                event = MagicMock()
+                event.body = "!batteryLevel"
+                event.source = {"content": {"formatted_body": ""}}
+                result = await self.plugin.handle_room_message(
+                    room, event, "!batteryLevel"
+                )
+                self.assertTrue(result)
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!r", event.event_id, "❌"
+                )
+                self.plugin.logger.exception.assert_called_once_with(
+                    "Error handling telemetry command"
+                )
+
+            asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -98,6 +98,8 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         # Default: marine returns no data (land coordinates)
         self.plugin.generate_marine_forecast = MagicMock(return_value=None)
 
+        self.plugin.send_matrix_reaction = AsyncMock()
+
         # Sample weather API response for 2 days (48 hours)
         # Current time is set to 10:00
         self.sample_weather_data = {
@@ -1529,6 +1531,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
 
         mock_event = MagicMock()
         mock_event.body = "!weather"
@@ -1635,7 +1638,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
             )
 
         self.plugin.send_matrix_reaction.assert_called_once_with(
-            "!r", "$no_loc_event", "✅"
+            "!r", "$no_loc_event", "❌"
         )
         call_kwargs = self.plugin.send_matrix_message.call_args.kwargs
         self.assertIsNone(call_kwargs.get("reply_to_event_id"))

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1620,6 +1620,77 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         call_kwargs = self.plugin.send_matrix_message.call_args.kwargs
         self.assertIsNone(call_kwargs.get("reply_to_event_id"))
 
+    async def test_handle_room_message_no_parsed_command_returns_false(self):
+        """Should return False when get_matching_matrix_command returns None (line 914)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value=None)
+
+        mock_event = MagicMock()
+        mock_event.body = "!weather"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        result = await self.plugin.handle_room_message(
+            MagicMock(room_id="!r"), mock_event, "!weather"
+        )
+        self.assertFalse(result)
+
+    async def test_handle_room_message_invalid_units_fallback_to_metric(self):
+        """Invalid units in config should fall back to metric (lines 953-954)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_require_bot_mention = MagicMock(return_value=False)
+        self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
+        self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
+        self.plugin.generate_marine_forecast = MagicMock(return_value=None)
+        self.plugin.config = {"units": "bogus"}
+
+        mock_client = MagicMock()
+        mock_client.nodes = {
+            "n1": {"position": {"latitude": 10.0, "longitude": 20.0}},
+        }
+
+        mock_event = MagicMock()
+        mock_event.body = "!weather"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        with patch(
+            "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+        ):
+            result = await self.plugin.handle_room_message(
+                MagicMock(room_id="!r"), mock_event, "!weather"
+            )
+
+        self.assertTrue(result)
+        marine_call = self.plugin.generate_marine_forecast.call_args
+        self.assertEqual(marine_call.args[3], "metric")
+
+    async def test_handle_room_message_exception_handler(self):
+        """Exception in handle_room_message should log and send reaction (lines 973-975)."""
+        self.plugin.matches = MagicMock(return_value=True)
+        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
+        self.plugin._resolve_location_from_args = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+
+        mock_event = MagicMock()
+        mock_event.event_id = "$err_event"
+        mock_event.body = "!weather"
+        mock_event.source = {"content": {"formatted_body": ""}}
+
+        result = await self.plugin.handle_room_message(
+            MagicMock(room_id="!r"), mock_event, "!weather"
+        )
+        self.assertTrue(result)
+        self.plugin.logger.exception.assert_called_once_with(
+            "Error handling weather command"
+        )
+        self.plugin.send_matrix_reaction.assert_called_once_with(
+            "!r", "$err_event", "❌"
+        )
+
     async def test_handle_room_message_no_location_sends_reaction(self):
         """'Cannot determine location' should still send a reaction."""
         self.plugin.matches = MagicMock(return_value=True)
@@ -1907,6 +1978,22 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         data = {"hourly": {"time": [], "wave_height": []}}
         result = self.plugin._format_hourly_marine(
             data, base_index=0, offsets=[3, 6, 12]
+        )
+        self.assertIsNone(result)
+
+    def test_format_hourly_marine_returns_none_when_all_slots_none(self):
+        """_format_hourly_marine returns None when every slot resolves to None (line 306-307)."""
+        times = [f"2023-08-20T{h:02d}:00" for h in range(24)]
+        data = {
+            "hourly": {
+                "time": times,
+                "wave_height": [None] * 24,
+                "wave_direction": [None] * 24,
+                "wave_period": [None] * 24,
+            }
+        }
+        result = self.plugin._format_hourly_marine(
+            data, base_index=10, offsets=[3, 6, 12]
         )
         self.assertIsNone(result)
 

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1585,10 +1585,11 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     # ------------------------------------------------------------------
 
     async def test_handle_room_message_replies_to_event(self):
-        """handle_room_message should pass event.event_id as reply_to_event_id."""
+        """handle_room_message should send a reaction and not use reply_to_event_id."""
         self.plugin.matches = MagicMock(return_value=True)
         self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
         self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
 
         mock_client = MagicMock()
@@ -1609,14 +1610,18 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertTrue(result)
+        self.plugin.send_matrix_reaction.assert_called_once_with(
+            "!r", "$test_event_123", "✅"
+        )
         call_kwargs = self.plugin.send_matrix_message.call_args.kwargs
-        self.assertEqual(call_kwargs.get("reply_to_event_id"), "$test_event_123")
+        self.assertIsNone(call_kwargs.get("reply_to_event_id"))
 
-    async def test_handle_room_message_no_location_replies_to_event(self):
-        """'Cannot determine location' should also be sent as a reply."""
+    async def test_handle_room_message_no_location_sends_reaction(self):
+        """'Cannot determine location' should still send a reaction."""
         self.plugin.matches = MagicMock(return_value=True)
         self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
         self.plugin.send_matrix_message = AsyncMock()
+        self.plugin.send_matrix_reaction = AsyncMock()
 
         mock_event = MagicMock()
         mock_event.event_id = "$no_loc_event"
@@ -1628,8 +1633,11 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
                 MagicMock(room_id="!r"), mock_event, "!weather"
             )
 
+        self.plugin.send_matrix_reaction.assert_called_once_with(
+            "!r", "$no_loc_event", "✅"
+        )
         call_kwargs = self.plugin.send_matrix_message.call_args.kwargs
-        self.assertEqual(call_kwargs.get("reply_to_event_id"), "$no_loc_event")
+        self.assertIsNone(call_kwargs.get("reply_to_event_id"))
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("mmrelay.plugins.weather_plugin.requests.get")

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1941,7 +1941,8 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.plugin.send_message = MagicMock()
         # Marine string long enough to push combined over 200 bytes
         self.plugin.generate_marine_forecast = MagicMock(
-            return_value="🌊 " + "W" * 200  # 205 bytes alone, guaranteed to exceed limit combined
+            return_value="🌊 "
+            + "W" * 200  # 205 bytes alone, guaranteed to exceed limit combined
         )
 
         packet = {

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -904,6 +904,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.plugin.send_message.assert_called_once()
         call_args = self.plugin.send_message.call_args
         self.assertEqual(call_args.kwargs["destination_id"], TEST_MESHTASTIC_ID)
+        self.assertEqual(call_args.kwargs["channel"], 0)
         self.assertIn(
             _normalize_emoji("Now: 🌤️ Mainly clear"),
             _normalize_emoji(call_args.kwargs["text"]),
@@ -1673,6 +1674,51 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
         call_kwargs = self.plugin.send_message.call_args.kwargs
         self.assertEqual(call_kwargs.get("reply_id"), 42)
+        self.assertEqual(call_kwargs.get("channel"), 0)
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("mmrelay.plugins.weather_plugin.requests.get")
+    async def test_handle_meshtastic_dm_reply_id_and_channel(
+        self, mock_get, mock_connect
+    ):
+        """DM weather responses should propagate reply_id, channel, and destination_id."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.sample_weather_data
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = TEST_NODE_NUM
+        mock_client.nodes = {
+            TEST_MESHTASTIC_ID: {
+                "position": {"latitude": TEST_LAT_NYC, "longitude": TEST_LON_NYC}
+            }
+        }
+        mock_connect.return_value = mock_client
+
+        self.plugin.send_message = MagicMock()
+
+        packet = {
+            "decoded": {"portnum": PORTNUM_TEXT_MESSAGE_APP, "text": "!weather"},
+            "channel": 2,
+            "fromId": TEST_MESHTASTIC_ID,
+            "to": TEST_NODE_NUM,
+            "id": 99,
+        }
+
+        result = await self.plugin.handle_meshtastic_message(
+            packet, "formatted_message", "longname", "meshnet_name"
+        )
+
+        self.assertTrue(result)
+        self.plugin.send_message.assert_called_once()
+        call_kwargs = self.plugin.send_message.call_args.kwargs
+        self.assertEqual(call_kwargs["reply_id"], 99)
+        self.assertEqual(call_kwargs["channel"], 2)
+        self.assertEqual(call_kwargs["destination_id"], TEST_MESHTASTIC_ID)
+        self.plugin.is_channel_enabled.assert_called_once_with(
+            2, is_direct_message=True
+        )
 
     # ------------------------------------------------------------------
     # Marine forecast tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR changes plugin acknowledgements to Matrix reactions and standardizes Meshtastic reply routing and Meshtastic/Matrix connection error handling. Plugins now signal success/failure with reactions (✅/❌), Meshtastic sends go through a plugin-level helper to preserve channel/destination/reply_id, media helpers support replying to Matrix events, and many plugins gained guarded error handling. Tests were expanded to cover these behaviors and several edge cases.

## Key changes

Features
- Add BasePlugin.send_matrix_reaction(room_id, event_id, emoji) and use reactions for simple command acknowledgements (✅ success, ❌ failure).
- Route Meshtastic outgoing messages through plugin.send_message(...) so destination_id, channel, and reply_id propagate consistently (replaces direct meshtastic_client.sendText calls).
- Add optional reply_to_event_id to matrix media helpers (send_room_image, send_image) to include m.relates_to / m.in_reply_to for image replies.
- Ping plugin now extracts incoming Meshtastic packet id and passes it as reply_id when replying.

Fixes & robustness
- Introduce ConnectionCompletedWithoutClientError and explicit checks to avoid continuing when a Meshtastic client is not produced; replace fragile assertions with explicit errors/logging.
- Guard logout_matrix_bot against AsyncClient being None to avoid instantiation attempts; log and return early.
- Wrap many plugin handlers (health, help, map, nodes, ping, telemetry, weather, drop) in try/except to prevent crashes and to emit ❌ reactions on exceptions or known failure paths.
- Silence redundant Matrix errors when Matrix client is unavailable during plugin execution.

Refactors & small behavior changes
- Standardize argument names and shapes: destinationId → destination_id, channelIndex → channel; relax destination_id typing to accept str|int|None.
- Replace inline meshtastic_client.sendText usages with internal send_message helper across plugins, preserving channel and reply propagation.
- Minor API/docstring/formatting clarifications (e.g., describe reply semantics as “a reply” and unify content building).

Testing
- Expanded tests to assert send_matrix_reaction on success/failure paths, plugin exception handling, telemetry edge cases, weather fallback and parsing failures, channel/ reply_id propagation, media reply payloads, Meshtastic connection TCP/no-client paths, and logout AsyncClient None behavior.
- Many plugin tests switched from mocking meshtastic_client.sendText to mocking plugin.send_message and send_matrix_reaction.

CI / tooling
- Update pinned tool versions in .trunk/trunk.yaml (renovate, pyright, prettier, ruff).
- Update GitHub Action pin in .github/workflows/package-windows.yml.

## Breaking changes / migration notes
- Code that previously called meshtastic_client.sendText should be migrated to plugin.send_message(...) and use destination_id, channel, and reply_id parameters as appropriate.
- Simple command acknowledgements are now Matrix reactions rather than quick reply-to messages; tests or integrations that relied on those reply messages should be updated to expect reactions.
- Tests should mock plugin.send_message and plugin.send_matrix_reaction where they previously mocked low-level meshtastic client calls or room_send payloads.
- When sending images as replies, provide reply_to_event_id to send_room_image/send_image to include m.in_reply_to in the Matrix payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->