### PR TITLE
ci: expand python version matrix to include 3.13 & 3.14

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -16,7 +16,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.python-version == '3.14' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -16,9 +16,11 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.python-version == '3.14' }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -46,13 +48,8 @@ jobs:
           # Run full suite (including performance tests) now that they are fast and deterministic
           python -m pytest tests/ -v --cov --cov-report=xml --cov-report=html --junitxml=junit.xml
 
-      - name: Debug Python version for codecov
-        run: |
-          echo "Current Python version: ${{ matrix.python-version }}"
-          echo "Will upload coverage: ${{ matrix.python-version == '3.11' }}"
-
       - name: Upload coverage reports to Codecov
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ MagicMock/
 /k8s/
 
 # Git worktrees
-.worktrees/
+/.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ MagicMock/
 
 # Generated Kubernetes manifests (user-specific, not to be committed)
 /k8s/
+
+# Git worktrees
+.worktrees/

--- a/docs/dev/TESTING_GUIDE.md
+++ b/docs/dev/TESTING_GUIDE.md
@@ -72,6 +72,63 @@ def test_handle_auth_logout_keyboard_interrupt(self, mock_print, mock_logout):
 | Direct async function testing                 | `AsyncMock`    | `mock_func = AsyncMock(return_value=result)` |
 | Exception in async context                    | Regular `Mock` | `mock_func.side_effect = Exception()`        |
 
+### Coroutine Leak Prevention Patterns
+
+Some failures only show up on certain Python versions (commonly 3.10/3.11/3.13+) as:
+
+```text
+PytestUnraisableExceptionWarning: coroutine ... was never awaited
+```
+
+Use these patterns to avoid creating throwaway coroutines in tests:
+
+1. **Match the production call shape exactly**
+   - If production does `fn(...)` (sync call): use `Mock`/sync `def`, not `AsyncMock`/`async def`.
+   - If production does `await fn(...)`: use `AsyncMock` or an async stub.
+
+2. **When mocking scheduler/submission helpers, close passed coroutines**
+   - Applies to fakes for `_submit_coro`, `run_coroutine_threadsafe`, etc.
+   - Example:
+
+```python
+from concurrent.futures import Future
+import asyncio
+
+def _submit_done(coro, loop=None):
+    if asyncio.iscoroutine(coro):
+        coro.close()
+    fut = Future()
+    fut.set_result(None)
+    return fut
+```
+
+3. **When mocking `asyncio.wait_for` to raise timeout, close awaitables first**
+   - Prevents leaked coroutine objects from timeout branches.
+
+```python
+def _timeout_wait_for(awaitable, timeout=None):
+    if asyncio.iscoroutine(awaitable):
+        awaitable.close()
+    raise asyncio.TimeoutError()
+```
+
+4. **Avoid async `_noop` helpers for sync-only paths**
+   - For sync cleanup hooks (for example mocked `disconnect()` in sync branches), use:
+   - `def _noop(*a, **k): return None`
+
+5. **If you need an awaitable return without AsyncMock bookkeeping, use a lightweight awaitable**
+   - Useful for methods like `close()` where you only need awaitability and not `assert_awaited_*`.
+
+```python
+class _ImmediateAwaitable:
+    def __init__(self, value=None):
+        self._value = value
+    def __await__(self):
+        if False:
+            yield
+        return self._value
+```
+
 ## Standardized Async Patterns
 
 Use standardized async testing patterns and avoid test-environment detection branches (for example, `MMRELAY_TESTING`).

--- a/docs/dev/TESTING_GUIDE.md
+++ b/docs/dev/TESTING_GUIDE.md
@@ -129,6 +129,11 @@ class _ImmediateAwaitable:
         return self._value
 ```
 
+6. **Be explicit when patching async functions**
+   - `patch("module.async_fn")` defaults to `AsyncMock`, which creates coroutine objects when called.
+   - If code under test only passes that coroutine to a mocked scheduler/submission helper, and the helper raises early, the coroutine can leak.
+   - Use an explicit sync `Mock(...)` when no await is needed, or make the scheduler fake close the passed coroutine before raising.
+
 ## Standardized Async Patterns
 
 Use standardized async testing patterns and avoid test-environment detection branches (for example, `MMRELAY_TESTING`).

--- a/docs/dev/TESTING_GUIDE.md
+++ b/docs/dev/TESTING_GUIDE.md
@@ -86,7 +86,7 @@ Use these patterns to avoid creating throwaway coroutines in tests:
    - If production does `fn(...)` (sync call): use `Mock`/sync `def`, not `AsyncMock`/`async def`.
    - If production does `await fn(...)`: use `AsyncMock` or an async stub.
 
-2. **When mocking scheduler/submission helpers, close passed coroutines**
+1. **When mocking scheduler/submission helpers, close passed coroutines**
    - Applies to fakes for `_submit_coro`, `run_coroutine_threadsafe`, etc.
    - Example:
 
@@ -102,7 +102,7 @@ def _submit_done(coro, loop=None):
     return fut
 ```
 
-3. **When mocking `asyncio.wait_for` to raise timeout, close awaitables first**
+1. **When mocking `asyncio.wait_for` to raise timeout, close awaitables first**
    - Prevents leaked coroutine objects from timeout branches.
 
 ```python
@@ -112,11 +112,11 @@ def _timeout_wait_for(awaitable, timeout=None):
     raise asyncio.TimeoutError()
 ```
 
-4. **Avoid async `_noop` helpers for sync-only paths**
+1. **Avoid async `_noop` helpers for sync-only paths**
    - For sync cleanup hooks (for example mocked `disconnect()` in sync branches), use:
    - `def _noop(*a, **k): return None`
 
-5. **If you need an awaitable return without AsyncMock bookkeeping, use a lightweight awaitable**
+1. **If you need an awaitable return without AsyncMock bookkeeping, use a lightweight awaitable**
    - Useful for methods like `close()` where you only need awaitability and not `assert_awaited_*`.
 
 ```python
@@ -129,7 +129,7 @@ class _ImmediateAwaitable:
         return self._value
 ```
 
-6. **Be explicit when patching async functions**
+1. **Be explicit when patching async functions**
    - `patch("module.async_fn")` defaults to `AsyncMock`, which creates coroutine objects when called.
    - If code under test only passes that coroutine to a mocked scheduler/submission helper, and the helper raises early, the coroutine can leak.
    - Use an explicit sync `Mock(...)` when no await is needed, or make the scheduler fake close the passed coroutine before raising.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
   "Development Status :: 4 - Beta",
   "Topic :: Communications",

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -3,6 +3,7 @@ Command-line interface handling for Meshtastic Matrix Relay.
 """
 
 import argparse
+import contextlib
 import importlib
 import importlib.resources
 import ipaddress
@@ -2143,8 +2144,9 @@ def _print_system_health(paths_info: dict[str, Any]) -> None:
 
             # Check WAL mode if possible
             try:
-                with sqlite3.connect(str(db_path)) as conn:
-                    cursor = conn.execute("PRAGMA journal_mode;")
+                with contextlib.closing(sqlite3.connect(str(db_path))) as conn:
+                    with conn as managed_conn:
+                        cursor = managed_conn.execute("PRAGMA journal_mode;")
                     mode = cursor.fetchone()[0]
                     if mode.lower() == "wal":
                         print("      Journal: WAL mode ✅")

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -2147,7 +2147,7 @@ def _print_system_health(paths_info: dict[str, Any]) -> None:
                 with contextlib.closing(sqlite3.connect(str(db_path))) as conn:
                     with conn as managed_conn:
                         cursor = managed_conn.execute("PRAGMA journal_mode;")
-                    mode = cursor.fetchone()[0]
+                        mode = cursor.fetchone()[0]
                     if mode.lower() == "wal":
                         print("      Journal: WAL mode ✅")
                     else:

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -553,8 +553,7 @@ class DatabaseManager:
         """
         try:
             self.close()
-        except Exception:
-            # Avoid surfacing destructor-time errors during interpreter shutdown.
+        except Exception:  # nosec B110
             pass
 
 

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -535,11 +535,24 @@ class DatabaseManager:
                         "Error closing connection during shutdown", exc_info=True
                     )
 
-        if hasattr(self._thread_local, "connection"):
+        old_thread_local = self._thread_local
+        self._thread_local = threading.local()
+
+        if hasattr(old_thread_local, "connection"):
             try:
-                del self._thread_local.connection
+                del old_thread_local.connection
             except AttributeError:
                 pass
+
+    def __del__(self) -> None:
+        """
+        Best-effort fallback to avoid leaving connections open if close() is skipped.
+        """
+        try:
+            self.close()
+        except Exception:
+            # Avoid surfacing destructor-time errors during interpreter shutdown.
+            pass
 
 
 # Convenience alias for type hints

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -14,7 +14,7 @@ import threading
 from collections.abc import Callable
 from concurrent.futures import CancelledError as ConcurrentCancelledError
 from concurrent.futures import Future, ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from functools import lru_cache
 from typing import Any, Generator, Optional
 

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -255,6 +255,15 @@ class DatabaseManager:
 
         with self._connections_lock:
             self._connections.add(conn)
+        logger.debug(
+            "DB conn created: id=%d path=%s manager=%d thread=%s(%d) pool_size=%d",
+            id(conn),
+            self._path,
+            id(self),
+            threading.current_thread().name,
+            threading.current_thread().ident,
+            len(self._connections),
+        )
         return conn
 
     def _get_connection(self) -> sqlite3.Connection:

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -255,6 +255,7 @@ class DatabaseManager:
 
         with self._connections_lock:
             self._connections.add(conn)
+            pool_size = len(self._connections)
         logger.debug(
             "DB conn created: id=%d path=%s manager=%d thread=%s(%d) pool_size=%d",
             id(conn),
@@ -262,7 +263,7 @@ class DatabaseManager:
             id(self),
             threading.current_thread().name,
             threading.current_thread().ident,
-            len(self._connections),
+            pool_size,
         )
         return conn
 

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -196,13 +196,15 @@ class DatabaseManager:
 
     def _create_connection(self) -> sqlite3.Connection:
         """
-        Create and configure a new sqlite3.Connection for this manager, apply configured PRAGMA directives, and register the connection for later cleanup.
-
+        Create and configure a new sqlite3.Connection for the manager and register it for later cleanup.
+        
+        Configures busy timeout, journal mode (WAL), foreign keys, and any validated extra PRAGMA directives. If configuration fails, the partially configured connection is closed before the error is propagated.
+        
         Returns:
-            sqlite3.Connection: A connection configured with the manager's pragmas and tracked by the manager.
-
+            sqlite3.Connection: A configured and tracked SQLite connection.
+        
         Raises:
-            sqlite3.Error: If an SQLite error occurs during connection creation or PRAGMA setup (the partially configured connection is closed before the error is propagated).
+            sqlite3.Error: If an SQLite error occurs during connection creation or PRAGMA setup.
             ValueError: If an extra PRAGMA name or string value fails validation.
             TypeError: If an extra PRAGMA value has an unsupported type.
         """
@@ -547,7 +549,7 @@ class DatabaseManager:
 
     def __del__(self) -> None:
         """
-        Best-effort fallback to avoid leaving connections open if close() is skipped.
+        Attempt to close managed database connections and other resources, suppressing all exceptions to avoid errors during interpreter shutdown.
         """
         try:
             self.close()

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -197,12 +197,12 @@ class DatabaseManager:
     def _create_connection(self) -> sqlite3.Connection:
         """
         Create and configure a new sqlite3.Connection for the manager and register it for later cleanup.
-        
+
         Configures busy timeout, journal mode (WAL), foreign keys, and any validated extra PRAGMA directives. If configuration fails, the partially configured connection is closed before the error is propagated.
-        
+
         Returns:
             sqlite3.Connection: A configured and tracked SQLite connection.
-        
+
         Raises:
             sqlite3.Error: If an SQLite error occurs during connection creation or PRAGMA setup.
             ValueError: If an extra PRAGMA name or string value fails validation.

--- a/src/mmrelay/db_runtime.py
+++ b/src/mmrelay/db_runtime.py
@@ -542,19 +542,15 @@ class DatabaseManager:
         self._thread_local = threading.local()
 
         if hasattr(old_thread_local, "connection"):
-            try:
+            with suppress(AttributeError):
                 del old_thread_local.connection
-            except AttributeError:
-                pass
 
     def __del__(self) -> None:
         """
         Attempt to close managed database connections and other resources, suppressing all exceptions to avoid errors during interpreter shutdown.
         """
-        try:
+        with suppress(Exception):
             self.close()
-        except Exception:  # nosec B110
-            pass
 
 
 # Convenience alias for type hints

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import json
 import logging
 import os
@@ -585,13 +584,20 @@ def get_db_path() -> str:
 
 def _close_manager_safely(manager: DatabaseManager | None) -> None:
     """
-    Close the given DatabaseManager if provided, suppressing any exceptions raised during close.
+    Close the given DatabaseManager if provided, logging non-fatal close failures.
 
-    Closes the manager when non-None; any exception raised by the manager's close() is ignored.
+    Closes the manager when non-None; non-fatal close() exceptions are logged and suppressed.
     """
     if manager:
-        with contextlib.suppress(Exception):
+        try:
             manager.close()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            logger.warning(
+                "Failed to close DatabaseManager cleanly; resources may be released by GC",
+                exc_info=True,
+            )
 
 
 def _reset_db_manager() -> None:
@@ -729,7 +735,8 @@ def _get_db_manager() -> DatabaseManager:
         tuple(sorted(extra_pragmas.items())),
     )
 
-    manager_to_close = None
+    manager_to_close: DatabaseManager | None = None
+    manager_to_return: DatabaseManager | None = None
     with _db_manager_lock:
         if _db_manager is None or _db_manager_signature != signature:
             try:
@@ -743,7 +750,6 @@ def _get_db_manager() -> DatabaseManager:
                 manager_to_close = _db_manager
                 _db_manager = new_manager
                 _db_manager_signature = signature
-                _close_manager_safely(manager_to_close)
             except (KeyboardInterrupt, SystemExit):
                 raise
             except Exception:
@@ -764,7 +770,14 @@ def _get_db_manager() -> DatabaseManager:
         # the lock but before we return, causing an unexpected RuntimeError.
         if _db_manager is None:
             raise RuntimeError("Database manager initialization failed")
-        return _db_manager
+        manager_to_return = _db_manager
+
+    if manager_to_close is not None:
+        _close_manager_safely(manager_to_close)
+
+    if manager_to_return is None:
+        raise RuntimeError("Database manager initialization failed")
+    return manager_to_return
 
 
 # Initialize SQLite database

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -585,7 +585,7 @@ def get_db_path() -> str:
 def _close_manager_safely(manager: DatabaseManager | None) -> None:
     """
     Close the given DatabaseManager if provided.
-    
+
     If a manager is supplied, calls its close() method; re-raises KeyboardInterrupt and SystemExit, and logs then suppresses any other exceptions.
     """
     if manager:

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -586,16 +586,21 @@ def _close_manager_safely(manager: DatabaseManager | None) -> None:
     """
     Close the given DatabaseManager if provided.
 
-    If a manager is supplied, calls its close() method; re-raises KeyboardInterrupt and SystemExit, and logs then suppresses any other exceptions.
+    If a manager is supplied, calls its close() method; re-raises KeyboardInterrupt, SystemExit, and RuntimeError, and logs then suppresses any other exceptions.
     """
     if manager:
         try:
             manager.close()
-        except (KeyboardInterrupt, SystemExit):
+        except (KeyboardInterrupt, SystemExit, RuntimeError):
             raise
-        except Exception:
+        except (sqlite3.Error, OSError):
             logger.warning(
                 "Failed to close DatabaseManager cleanly; resources may be released by GC",
+                exc_info=True,
+            )
+        except Exception:
+            logger.warning(
+                "Unexpected error closing DatabaseManager; resources may be released by GC",
                 exc_info=True,
             )
 

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -584,9 +584,9 @@ def get_db_path() -> str:
 
 def _close_manager_safely(manager: DatabaseManager | None) -> None:
     """
-    Close the given DatabaseManager if provided, logging non-fatal close failures.
-
-    Closes the manager when non-None; non-fatal close() exceptions are logged and suppressed.
+    Close the given DatabaseManager if provided.
+    
+    If a manager is supplied, calls its close() method; re-raises KeyboardInterrupt and SystemExit, and logs then suppresses any other exceptions.
     """
     if manager:
         try:

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -775,8 +775,6 @@ def _get_db_manager() -> DatabaseManager:
     if manager_to_close is not None:
         _close_manager_safely(manager_to_close)
 
-    if manager_to_return is None:
-        raise RuntimeError("Database manager initialization failed")
     return manager_to_return
 
 

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -598,11 +598,6 @@ def _close_manager_safely(manager: DatabaseManager | None) -> None:
                 "Failed to close DatabaseManager cleanly; resources may be released by GC",
                 exc_info=True,
             )
-        except Exception:
-            logger.warning(
-                "Unexpected error closing DatabaseManager; resources may be released by GC",
-                exc_info=True,
-            )
 
 
 def _reset_db_manager() -> None:

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -586,7 +586,7 @@ def _close_manager_safely(manager: DatabaseManager | None) -> None:
     """
     Close the given DatabaseManager if provided.
 
-    If a manager is supplied, calls its close() method; re-raises KeyboardInterrupt, SystemExit, and RuntimeError, and logs then suppresses any other exceptions.
+    If a manager is supplied, calls its close() method; re-raises KeyboardInterrupt, SystemExit, and RuntimeError, and logs then suppresses sqlite3.Error and OSError.
     """
     if manager:
         try:

--- a/src/mmrelay/meshtastic/async_utils.py
+++ b/src/mmrelay/meshtastic/async_utils.py
@@ -197,13 +197,13 @@ def _submit_coro(
                 try:
                     facade.asyncio.set_event_loop(new_loop)
                     result = new_loop.run_until_complete(coro)
+                finally:
                     with contextlib.suppress(Exception):
                         new_loop.run_until_complete(new_loop.shutdown_asyncgens())
                     with contextlib.suppress(Exception):
                         new_loop.run_until_complete(
                             new_loop.shutdown_default_executor()
                         )
-                finally:
                     new_loop.close()
                     with contextlib.suppress(Exception):
                         facade.asyncio.set_event_loop(None)

--- a/src/mmrelay/meshtastic/async_utils.py
+++ b/src/mmrelay/meshtastic/async_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import inspect
 import logging
 import math
@@ -184,22 +185,32 @@ def _submit_coro(
     except RuntimeError:
         # No running loop: check if we can safely create a new loop
         try:
-            # Try to get the current event loop policy and create a new loop
-            # This is safer than asyncio.run() which can cause deadlocks
-            policy = facade.asyncio.get_event_loop_policy()
             facade.logger.debug(
                 "No running event loop detected; creating a temporary loop to execute coroutine"
             )
-            new_loop = policy.new_event_loop()
-            facade.asyncio.set_event_loop(new_loop)
-            try:
-                result = new_loop.run_until_complete(coro)
-                result_future: Future[Any] = Future()
-                result_future.set_result(result)
-                return result_future
-            finally:
-                new_loop.close()
-                facade.asyncio.set_event_loop(None)
+            runner_cls = getattr(facade.asyncio, "Runner", None)
+            if runner_cls is not None:
+                with runner_cls() as runner:
+                    result = runner.run(coro)
+            else:
+                new_loop = facade.asyncio.new_event_loop()
+                try:
+                    facade.asyncio.set_event_loop(new_loop)
+                    result = new_loop.run_until_complete(coro)
+                    with contextlib.suppress(Exception):
+                        new_loop.run_until_complete(new_loop.shutdown_asyncgens())
+                    with contextlib.suppress(Exception):
+                        new_loop.run_until_complete(
+                            new_loop.shutdown_default_executor()
+                        )
+                finally:
+                    new_loop.close()
+                    with contextlib.suppress(Exception):
+                        facade.asyncio.set_event_loop(None)
+
+            result_future: Future[Any] = Future()
+            result_future.set_result(result)
+            return result_future
         except Exception as e:
             # Final fallback: always return a Future so _fire_and_forget can log
             # exceptions instead of crashing a background thread when no loop is

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -3,7 +3,7 @@ import functools
 import inspect
 import math
 from concurrent.futures import Future
-from typing import Any
+from typing import Any, NoReturn
 
 import mmrelay.meshtastic_utils as facade
 from mmrelay.constants.config import (
@@ -53,7 +53,7 @@ class ConnectionCompletedWithoutClientError(ConnectionError):
     """Connection path returned without producing a usable client."""
 
 
-def _raise_no_client(connection_type: str) -> None:
+def _raise_no_client(connection_type: str) -> NoReturn:
     """Raise ConnectionCompletedWithoutClientError for the given connection type."""
     raise ConnectionCompletedWithoutClientError(
         f"Meshtastic {connection_type} connection completed without a client."

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1126,6 +1126,8 @@ def _connect_meshtastic_impl(
                 )
                 _raise_no_client(connection_type)
 
+            if client is None:
+                raise RuntimeError("Unreachable: client validated above")
             successful = True
 
             # Acquire lock only for the final setup and subscription

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1126,8 +1126,6 @@ def _connect_meshtastic_impl(
                 )
                 _raise_no_client(connection_type)
 
-            if client is None:
-                raise RuntimeError("Unreachable: client validated above")
             successful = True
 
             # Acquire lock only for the final setup and subscription

--- a/src/mmrelay/migrate.py
+++ b/src/mmrelay/migrate.py
@@ -1582,11 +1582,11 @@ def migrate_database(
         ):
             try:
                 db_uri = f"{main_db_staged.resolve().as_uri()}?mode=ro"
-                with contextlib.closing(sqlite3.connect(db_uri, uri=True)) as conn:
-                    with conn as managed_conn:
-                        result = managed_conn.execute(
-                            "PRAGMA integrity_check"
-                        ).fetchone()
+                with (
+                    contextlib.closing(sqlite3.connect(db_uri, uri=True)) as conn,
+                    conn as managed_conn,
+                ):
+                    result = managed_conn.execute("PRAGMA integrity_check").fetchone()
                 if result and result[0] != "ok":
                     raise MigrationError.integrity_check_failed(result[0])
                 logger.info("Database integrity check passed in staging")

--- a/src/mmrelay/migrate.py
+++ b/src/mmrelay/migrate.py
@@ -45,6 +45,7 @@ Plugin Data Migration (Three-Tier System):
 """
 
 import atexit
+import contextlib
 import errno
 import json
 import os
@@ -1581,8 +1582,11 @@ def migrate_database(
         ):
             try:
                 db_uri = f"{main_db_staged.resolve().as_uri()}?mode=ro"
-                with sqlite3.connect(db_uri, uri=True) as conn:
-                    result = conn.execute("PRAGMA integrity_check").fetchone()
+                with contextlib.closing(sqlite3.connect(db_uri, uri=True)) as conn:
+                    with conn as managed_conn:
+                        result = managed_conn.execute(
+                            "PRAGMA integrity_check"
+                        ).fetchone()
                 if result and result[0] != "ok":
                     raise MigrationError.integrity_check_failed(result[0])
                 logger.info("Database integrity check passed in staging")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,14 @@ sys.modules["schedule"] = MagicMock()
 sys.modules["platformdirs"] = MagicMock()
 sys.modules["py_staticmaps"] = MagicMock()
 
+# AsyncMock cleanup tuning:
+# Full generation-2 gc.collect() is relatively expensive on newer CPython runtimes
+# and can dominate teardown time when run after every qualifying test. We still do
+# cheap generation-0 collection every time, and periodically run a full collection
+# to reclaim cyclic coroutine objects before they leak into unrelated tests.
+_ASYNCMOCK_FULL_GC_INTERVAL = 25
+_asyncmock_cleanup_invocations = 0
+
 
 class _ConnectionProvenance:
     """Track every sqlite3.connect() call with creation metadata."""
@@ -857,15 +865,18 @@ def cleanup_asyncmock_objects(request):
     ]
 
     if any(pattern in test_file for pattern in asyncmock_patterns):
-        import gc
+        global _asyncmock_cleanup_invocations
         import warnings
 
+        _asyncmock_cleanup_invocations += 1
         # Suppress RuntimeWarning about unawaited coroutines during cleanup
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", category=RuntimeWarning, message=".*never awaited.*"
             )
-            gc.collect()
+            gc.collect(0)
+            if _asyncmock_cleanup_invocations % _ASYNCMOCK_FULL_GC_INTERVAL == 0:
+                gc.collect()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,6 +167,13 @@ class _ConnectionProvenance:
     def clear(self) -> None:
         self._registry.clear()
 
+    def uninstall(self) -> None:
+        if not self._patched:
+            return
+        sqlite3.connect = self._real_connect
+        self._patched = False
+        self._registry.clear()
+
 
 _conn_provenance = _ConnectionProvenance()
 
@@ -1500,16 +1507,17 @@ def clean_migration_home(
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _install_sqlite_provenance():
+def _install_sqlite_provenance() -> Generator[None, None, None]:
     _conn_provenance.install()
     yield
+    _conn_provenance.uninstall()
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
+    _conn_provenance._current_nodeid = item.nodeid
     outcome = yield
     report = outcome.get_result()
-    _conn_provenance._current_nodeid = item.nodeid
     if report.when == "call" and report.failed:
         open_conns = _conn_provenance.report_open()
         if open_conns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,12 +130,26 @@ class _ConnectionProvenance:
     """Track every sqlite3.connect() call with creation metadata."""
 
     def __init__(self) -> None:
+        """
+        Initialize the connection provenance tracker state.
+        
+        Sets up internal registry and bookkeeping used to record metadata for sqlite3 connections:
+        - _registry: mapping from connection id to metadata dict (db path, creation stack, thread info, etc.).
+        - _current_nodeid: test node identifier used when reporting leaked connections.
+        - _real_connect: reference to the original sqlite3.connect function before patching.
+        - _patched: boolean flag indicating whether sqlite3.connect has been replaced.
+        """
         self._registry: dict[int, dict[str, Any]] = {}
         self._current_nodeid: str = ""
         self._real_connect = sqlite3.connect
         self._patched: bool = False
 
     def install(self) -> None:
+        """
+        Install a connection tracker that intercepts sqlite3.connect and records provenance for each new connection.
+        
+        Replaces the module-level sqlite3.connect with a tracked wrapper (no-op if already installed). Each call to the tracked connect stores a metadata dictionary in self._registry keyed by id(connection) containing: "conn_id", "db_path", "test_nodeid", "thread_name", "thread_id", and "creation_stack".
+        """
         if self._patched:
             return
         real_connect = self._real_connect
@@ -143,6 +157,18 @@ class _ConnectionProvenance:
         tracker = self
 
         def _tracked_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+            """
+            Proxy for sqlite3.connect that records provenance metadata for each created connection.
+            
+            Records metadata (connection id, database path, current test nodeid, thread name/id, and creation stack) in the tracker registry keyed by the connection object's id.
+            
+            Parameters:
+                *args: Positional arguments forwarded to sqlite3.connect (first positional arg is the database path).
+                **kwargs: Keyword arguments forwarded to sqlite3.connect (may include "database").
+            
+            Returns:
+                sqlite3.Connection: The connection object returned by the underlying sqlite3.connect call.
+            """
             conn = real_connect(*args, **kwargs)
             db_path = args[0] if args else kwargs.get("database", "?")
             registry[id(conn)] = {
@@ -159,15 +185,38 @@ class _ConnectionProvenance:
         self._patched = True
 
     def remove(self, conn: sqlite3.Connection) -> None:
+        """
+        Stop tracking the given SQLite connection by removing its provenance entry from the internal registry.
+        
+        Parameters:
+            conn (sqlite3.Connection): The connection object to remove from tracking.
+        """
         self._registry.pop(id(conn), None)
 
     def report_open(self) -> list[dict[str, Any]]:
+        """
+        Retrieve metadata for all currently tracked SQLite connections.
+        
+        Returns:
+            list[dict[str, Any]]: A list of metadata dictionaries for each connection currently recorded in the provenance registry. Each dictionary contains the provenance information captured when the connection was created.
+        """
         return list(self._registry.values())
 
     def clear(self) -> None:
+        """
+        Remove all recorded sqlite3 connection provenance entries.
+        
+        This clears the internal registry of tracked connection metadata so subsequent
+        calls will behave as if no connections have been recorded.
+        """
         self._registry.clear()
 
     def uninstall(self) -> None:
+        """
+        Restore the original sqlite3.connect function and clear the registry of tracked connections.
+        
+        If the provenance patch is not currently installed, this is a no-op. After calling this, the object is marked as unpatched and any stored connection metadata is removed.
+        """
         if not self._patched:
             return
         sqlite3.connect = self._real_connect
@@ -180,7 +229,13 @@ _conn_provenance = _ConnectionProvenance()
 
 def _safe_is_done(future: Any) -> bool:
     """
-    Check future/task completion state while suppressing known state errors.
+    Determine whether a future-like object reports it is completed.
+    
+    Parameters:
+        future (Any): Object expected to provide a callable `done()` method.
+    
+    Returns:
+        bool: `True` if `future.done()` exists and returns a truthy value; `False` otherwise (including when `done()` is absent or raises known invalid-state errors).
     """
     done_fn = getattr(future, "done", None)
     if not callable(done_fn):
@@ -1479,12 +1534,13 @@ def clean_migration_home(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> Generator[Path, None, None]:
     """
-    Create and yield a clean temporary home directory for migration tests.
-
-    Creates tmp_path / "clean_migration_home", sets MMRELAY_HOME to it,
-    removes migration_completed.flag if present so tests start without prior migration state,
-    and yields the directory path.
-
+    Provide a temporary clean MMRELAY_HOME directory for migration tests.
+    
+    Creates a directory at tmp_path / "clean_migration_home", sets the `MMRELAY_HOME`
+    environment variable to that path, forces mmrelay.paths to re-resolve the home
+    location, and removes any existing `migration_completed.flag` so tests run with
+    no prior migration state.
+    
     Yields:
         Path: Path to the created clean home directory.
     """
@@ -1508,6 +1564,11 @@ def clean_migration_home(
 
 @pytest.fixture(scope="session", autouse=True)
 def _install_sqlite_provenance() -> Generator[None, None, None]:
+    """
+    Install sqlite3 connection provenance tracking for the test session.
+    
+    Patches `sqlite3.connect` to record metadata for each created connection so leaked connections can be reported during test failures, and restores the original `sqlite3.connect` on teardown.
+    """
     _conn_provenance.install()
     yield
     _conn_provenance.uninstall()
@@ -1515,6 +1576,20 @@ def _install_sqlite_provenance() -> Generator[None, None, None]:
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
+    """
+    Pytest hook wrapper that records the current test nodeid for sqlite connection provenance, appends a report section listing any tracked open sqlite connections when a test fails, and clears the provenance registry at teardown.
+    
+    Parameters:
+        item: pytest.Item
+            The test item being executed; used to set the current nodeid for provenance tracking.
+        call: pytest.CallInfo
+            The call phase information passed by pytest; this function yields to allow the default report generation to proceed.
+    
+    Notes:
+        - This is a pytest hook wrapper (generator-style) and yields once to obtain the test report.
+        - When the report indicates a failure in the "call" phase, any open sqlite connections tracked by the global provenance recorder are added to the report as a section named "sqlite-connection-provenance".
+        - On the "teardown" phase, the provenance registry is cleared to reset state between tests.
+    """
     _conn_provenance._current_nodeid = item.nodeid
     outcome = yield
     report = outcome.get_result()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,11 @@ import contextlib
 import gc
 import inspect
 import logging
-
-# Preserve references to built-in modules that should NOT be mocked
 import queue
+import sqlite3
 import threading
 import time
+import traceback
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, Generator
@@ -116,6 +116,51 @@ sys.modules["haversine"] = MagicMock()
 sys.modules["schedule"] = MagicMock()
 sys.modules["platformdirs"] = MagicMock()
 sys.modules["py_staticmaps"] = MagicMock()
+
+
+class _ConnectionProvenance:
+    """Track every sqlite3.connect() call with creation metadata."""
+
+    def __init__(self) -> None:
+        self._registry: dict[int, dict[str, Any]] = {}
+        self._current_nodeid: str = ""
+        self._real_connect = sqlite3.connect
+        self._patched: bool = False
+
+    def install(self) -> None:
+        if self._patched:
+            return
+        real_connect = self._real_connect
+        registry = self._registry
+        tracker = self
+
+        def _tracked_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+            conn = real_connect(*args, **kwargs)
+            db_path = args[0] if args else kwargs.get("database", "?")
+            registry[id(conn)] = {
+                "conn_id": id(conn),
+                "db_path": str(db_path),
+                "test_nodeid": tracker._current_nodeid,
+                "thread_name": threading.current_thread().name,
+                "thread_id": threading.current_thread().ident,
+                "creation_stack": "".join(traceback.format_stack()),
+            }
+            return conn
+
+        sqlite3.connect = _tracked_connect
+        self._patched = True
+
+    def remove(self, conn: sqlite3.Connection) -> None:
+        self._registry.pop(id(conn), None)
+
+    def report_open(self) -> list[dict[str, Any]]:
+        return list(self._registry.values())
+
+    def clear(self) -> None:
+        self._registry.clear()
+
+
+_conn_provenance = _ConnectionProvenance()
 
 
 def _safe_is_done(future: Any) -> bool:
@@ -1441,3 +1486,35 @@ def clean_migration_home(
     state_file.unlink(missing_ok=True)
 
     yield home
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _install_sqlite_provenance():
+    _conn_provenance.install()
+    yield
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    _conn_provenance._current_nodeid = item.nodeid
+    if report.when == "call" and report.failed:
+        open_conns = _conn_provenance.report_open()
+        if open_conns:
+            stacks = []
+            for entry in open_conns:
+                stacks.append(
+                    f"  LEAKED conn={entry['conn_id']} db={entry['db_path']} "
+                    f"created_in={entry['test_nodeid']} thread={entry['thread_name']}\n"
+                    f"{entry['creation_stack']}"
+                )
+            report.sections.append(
+                (
+                    "sqlite-connection-provenance",
+                    f"\n{len(open_conns)} OPEN sqlite connections at failure:\n"
+                    + "\n---\n".join(stacks),
+                )
+            )
+    if report.when == "teardown":
+        _conn_provenance.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,6 @@ import sqlite3
 import threading
 import time
 import traceback
-import weakref
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, Generator
@@ -157,6 +156,22 @@ class _ConnectionProvenance:
         registry = self._registry
         tracker = self
 
+        def _make_tracked_class(
+            base: type[sqlite3.Connection],
+        ) -> type[sqlite3.Connection]:
+            """
+            Create a tracked connection subclass that deregisters from the provenance registry on close.
+            """
+
+            class _TrackedConnection(base):
+                def close(self) -> None:
+                    try:
+                        super().close()
+                    finally:
+                        registry.pop(id(self), None)
+
+            return _TrackedConnection
+
         def _tracked_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
             """
             Proxy for sqlite3.connect that records provenance metadata for each created connection.
@@ -170,6 +185,16 @@ class _ConnectionProvenance:
             Returns:
                 sqlite3.Connection: The connection object returned by the underlying sqlite3.connect call.
             """
+            caller_factory = kwargs.get("factory", None)
+            if caller_factory is not None and (
+                isinstance(caller_factory, type)
+                and issubclass(caller_factory, sqlite3.Connection)
+            ):
+                tracked_cls = _make_tracked_class(caller_factory)
+            else:
+                tracked_cls = _make_tracked_class(sqlite3.Connection)
+            kwargs["factory"] = tracked_cls
+
             conn = real_connect(*args, **kwargs)
             db_path = args[0] if args else kwargs.get("database", "?")
             conn_id = id(conn)
@@ -181,21 +206,6 @@ class _ConnectionProvenance:
                 "thread_id": threading.current_thread().ident,
                 "creation_stack": "".join(traceback.format_stack()),
             }
-            original_close = conn.close
-
-            def _tracked_close(*c_args: Any, **c_kwargs: Any) -> Any:
-                try:
-                    return original_close(*c_args, **c_kwargs)
-                finally:
-                    registry.pop(conn_id, None)
-
-            try:
-                conn.close = _tracked_close  # type: ignore[method-assign]
-            except (AttributeError, TypeError):
-                try:
-                    weakref.finalize(conn, registry.pop, conn_id, None)
-                except TypeError:
-                    pass
             return conn
 
         sqlite3.connect = _tracked_connect
@@ -1591,14 +1601,25 @@ def _install_sqlite_provenance() -> Generator[None, None, None]:
     _conn_provenance.uninstall()
 
 
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    """
+    Set the current test nodeid for sqlite connection provenance tracking before any test phase runs.
+
+    This ensures connections created during setup/fixtures are attributed to the correct test,
+    rather than inheriting a stale nodeid from a previous test.
+    """
+    _conn_provenance._current_nodeid = item.nodeid
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """
-    Pytest hook wrapper that records the current test nodeid for sqlite connection provenance, appends a report section listing any tracked open sqlite connections when a test fails, and clears the provenance registry at teardown.
+    Pytest hook wrapper that appends a report section listing any tracked open sqlite connections when a test fails, and clears the provenance registry at teardown.
 
     Parameters:
         item: pytest.Item
-            The test item being executed; used to set the current nodeid for provenance tracking.
+            The test item being executed.
         call: pytest.CallInfo
             The call phase information passed by pytest; this function yields to allow the default report generation to proceed.
 
@@ -1607,7 +1628,6 @@ def pytest_runtest_makereport(item, call):
         - When the report indicates a failure in the "call" phase, any open sqlite connections tracked by the global provenance recorder are added to the report as a section named "sqlite-connection-provenance".
         - On the "teardown" phase, the provenance registry is cleared to reset state between tests.
     """
-    _conn_provenance._current_nodeid = item.nodeid
     outcome = yield
     report = outcome.get_result()
     if report.when == "call" and report.failed:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ class _ConnectionProvenance:
     def __init__(self) -> None:
         """
         Initialize the connection provenance tracker state.
-        
+
         Sets up internal registry and bookkeeping used to record metadata for sqlite3 connections:
         - _registry: mapping from connection id to metadata dict (db path, creation stack, thread info, etc.).
         - _current_nodeid: test node identifier used when reporting leaked connections.
@@ -147,7 +147,7 @@ class _ConnectionProvenance:
     def install(self) -> None:
         """
         Install a connection tracker that intercepts sqlite3.connect and records provenance for each new connection.
-        
+
         Replaces the module-level sqlite3.connect with a tracked wrapper (no-op if already installed). Each call to the tracked connect stores a metadata dictionary in self._registry keyed by id(connection) containing: "conn_id", "db_path", "test_nodeid", "thread_name", "thread_id", and "creation_stack".
         """
         if self._patched:
@@ -159,13 +159,13 @@ class _ConnectionProvenance:
         def _tracked_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
             """
             Proxy for sqlite3.connect that records provenance metadata for each created connection.
-            
+
             Records metadata (connection id, database path, current test nodeid, thread name/id, and creation stack) in the tracker registry keyed by the connection object's id.
-            
+
             Parameters:
                 *args: Positional arguments forwarded to sqlite3.connect (first positional arg is the database path).
                 **kwargs: Keyword arguments forwarded to sqlite3.connect (may include "database").
-            
+
             Returns:
                 sqlite3.Connection: The connection object returned by the underlying sqlite3.connect call.
             """
@@ -187,7 +187,7 @@ class _ConnectionProvenance:
     def remove(self, conn: sqlite3.Connection) -> None:
         """
         Stop tracking the given SQLite connection by removing its provenance entry from the internal registry.
-        
+
         Parameters:
             conn (sqlite3.Connection): The connection object to remove from tracking.
         """
@@ -196,7 +196,7 @@ class _ConnectionProvenance:
     def report_open(self) -> list[dict[str, Any]]:
         """
         Retrieve metadata for all currently tracked SQLite connections.
-        
+
         Returns:
             list[dict[str, Any]]: A list of metadata dictionaries for each connection currently recorded in the provenance registry. Each dictionary contains the provenance information captured when the connection was created.
         """
@@ -205,7 +205,7 @@ class _ConnectionProvenance:
     def clear(self) -> None:
         """
         Remove all recorded sqlite3 connection provenance entries.
-        
+
         This clears the internal registry of tracked connection metadata so subsequent
         calls will behave as if no connections have been recorded.
         """
@@ -214,7 +214,7 @@ class _ConnectionProvenance:
     def uninstall(self) -> None:
         """
         Restore the original sqlite3.connect function and clear the registry of tracked connections.
-        
+
         If the provenance patch is not currently installed, this is a no-op. After calling this, the object is marked as unpatched and any stored connection metadata is removed.
         """
         if not self._patched:
@@ -230,10 +230,10 @@ _conn_provenance = _ConnectionProvenance()
 def _safe_is_done(future: Any) -> bool:
     """
     Determine whether a future-like object reports it is completed.
-    
+
     Parameters:
         future (Any): Object expected to provide a callable `done()` method.
-    
+
     Returns:
         bool: `True` if `future.done()` exists and returns a truthy value; `False` otherwise (including when `done()` is absent or raises known invalid-state errors).
     """
@@ -1535,12 +1535,12 @@ def clean_migration_home(
 ) -> Generator[Path, None, None]:
     """
     Provide a temporary clean MMRELAY_HOME directory for migration tests.
-    
+
     Creates a directory at tmp_path / "clean_migration_home", sets the `MMRELAY_HOME`
     environment variable to that path, forces mmrelay.paths to re-resolve the home
     location, and removes any existing `migration_completed.flag` so tests run with
     no prior migration state.
-    
+
     Yields:
         Path: Path to the created clean home directory.
     """
@@ -1566,7 +1566,7 @@ def clean_migration_home(
 def _install_sqlite_provenance() -> Generator[None, None, None]:
     """
     Install sqlite3 connection provenance tracking for the test session.
-    
+
     Patches `sqlite3.connect` to record metadata for each created connection so leaked connections can be reported during test failures, and restores the original `sqlite3.connect` on teardown.
     """
     _conn_provenance.install()
@@ -1578,13 +1578,13 @@ def _install_sqlite_provenance() -> Generator[None, None, None]:
 def pytest_runtest_makereport(item, call):
     """
     Pytest hook wrapper that records the current test nodeid for sqlite connection provenance, appends a report section listing any tracked open sqlite connections when a test fails, and clears the provenance registry at teardown.
-    
+
     Parameters:
         item: pytest.Item
             The test item being executed; used to set the current nodeid for provenance tracking.
         call: pytest.CallInfo
             The call phase information passed by pytest; this function yields to allow the default report generation to proceed.
-    
+
     Notes:
         - This is a pytest hook wrapper (generator-style) and yields once to obtain the test report.
         - When the report indicates a failure in the "call" phase, any open sqlite connections tracked by the global provenance recorder are added to the report as a section named "sqlite-connection-provenance".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ import sqlite3
 import threading
 import time
 import traceback
+import weakref
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, Generator
@@ -171,14 +172,30 @@ class _ConnectionProvenance:
             """
             conn = real_connect(*args, **kwargs)
             db_path = args[0] if args else kwargs.get("database", "?")
-            registry[id(conn)] = {
-                "conn_id": id(conn),
+            conn_id = id(conn)
+            registry[conn_id] = {
+                "conn_id": conn_id,
                 "db_path": str(db_path),
                 "test_nodeid": tracker._current_nodeid,
                 "thread_name": threading.current_thread().name,
                 "thread_id": threading.current_thread().ident,
                 "creation_stack": "".join(traceback.format_stack()),
             }
+            original_close = conn.close
+
+            def _tracked_close(*c_args: Any, **c_kwargs: Any) -> Any:
+                try:
+                    return original_close(*c_args, **c_kwargs)
+                finally:
+                    registry.pop(conn_id, None)
+
+            try:
+                conn.close = _tracked_close  # type: ignore[method-assign]
+            except (AttributeError, TypeError):
+                try:
+                    weakref.finalize(conn, registry.pop, conn_id, None)
+                except TypeError:
+                    pass
             return conn
 
         sqlite3.connect = _tracked_connect

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1628,4 +1628,9 @@ def pytest_runtest_makereport(item, call):
                 )
             )
     if report.when == "teardown":
-        _conn_provenance.clear()
+        nodeid = item.nodeid
+        _conn_provenance._registry = {
+            cid: meta
+            for cid, meta in _conn_provenance._registry.items()
+            if meta.get("test_nodeid") != nodeid
+        }

--- a/tests/test_cli_system_health_coverage.py
+++ b/tests/test_cli_system_health_coverage.py
@@ -21,7 +21,7 @@ from mmrelay.cli import _print_system_health
 class TestPrintSystemHealthDatabase(unittest.TestCase):
     """Tests for _print_system_health database journal mode check."""
 
-    def _make_paths_info(self, db_path):
+    def _make_paths_info(self, db_path: Path) -> dict[str, str]:
         return {
             "home": tempfile.gettempdir(),
             "database_dir": str(db_path.parent),

--- a/tests/test_cli_system_health_coverage.py
+++ b/tests/test_cli_system_health_coverage.py
@@ -22,12 +22,26 @@ class TestPrintSystemHealthDatabase(unittest.TestCase):
     """Tests for _print_system_health database journal mode check."""
 
     def _make_paths_info(self, db_path: Path) -> dict[str, str]:
+        """
+        Create a paths_info dictionary containing the system temporary directory as "home" and the parent directory of the given database path as "database_dir".
+        
+        Parameters:
+            db_path (Path): Path to the database file; its parent directory is used for "database_dir".
+        
+        Returns:
+            dict[str, str]: A mapping with keys "home" (system temporary directory) and "database_dir" (string path of db_path's parent).
+        """
         return {
             "home": tempfile.gettempdir(),
             "database_dir": str(db_path.parent),
         }
 
     def test_wal_mode_prints_wal_emoji(self):
+        """
+        Verify that system health output reports WAL journal mode.
+        
+        Creates a temporary SQLite database configured with `PRAGMA journal_mode=wal`, patches the database path and E2EE dependency check, captures printed output from _print_system_health, and asserts that at least one printed message contains the substring "WAL mode".
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "test.db"
             conn = sqlite3.connect(str(db_path))

--- a/tests/test_cli_system_health_coverage.py
+++ b/tests/test_cli_system_health_coverage.py
@@ -92,9 +92,10 @@ class TestPrintSystemHealthDatabase(unittest.TestCase):
             with (
                 patch("mmrelay.paths.get_database_path", return_value=db_path),
                 patch("mmrelay.cli._e2ee_dependencies_available", return_value=True),
-                patch("builtins.print"),
+                patch("builtins.print") as mock_print,
             ):
                 _print_system_health(paths_info)
+                assert mock_print.called
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_system_health_coverage.py
+++ b/tests/test_cli_system_health_coverage.py
@@ -1,0 +1,87 @@
+"""
+Tests for _print_system_health WAL mode check in cli.py (lines 2146-2152).
+
+Covers the database journal mode check that reads PRAGMA journal_mode
+and prints whether WAL mode is active.
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mmrelay.cli import _print_system_health
+
+
+class TestPrintSystemHealthDatabase(unittest.TestCase):
+    """Tests for _print_system_health database journal mode check."""
+
+    def _make_paths_info(self, db_path):
+        return {
+            "home": tempfile.gettempdir(),
+            "database_dir": str(db_path.parent),
+        }
+
+    def test_wal_mode_prints_wal_emoji(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = sqlite3.connect(str(db_path))
+            conn.execute("PRAGMA journal_mode=wal;")
+            conn.execute("CREATE TABLE t(x)")
+            conn.commit()
+            conn.close()
+
+            paths_info = self._make_paths_info(db_path)
+
+            with (
+                patch("mmrelay.paths.get_database_path", return_value=db_path),
+                patch("mmrelay.cli._e2ee_dependencies_available", return_value=True),
+                patch("builtins.print") as mock_print,
+            ):
+                _print_system_health(paths_info)
+
+            printed = [str(c) for c in mock_print.call_args_list]
+            self.assertTrue(any("WAL mode" in p for p in printed))
+
+    def test_non_wal_mode_prints_mode_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            conn = sqlite3.connect(str(db_path))
+            conn.execute("PRAGMA journal_mode=delete;")
+            conn.execute("CREATE TABLE t(x)")
+            conn.commit()
+            conn.close()
+
+            paths_info = self._make_paths_info(db_path)
+
+            with (
+                patch("mmrelay.paths.get_database_path", return_value=db_path),
+                patch("mmrelay.cli._e2ee_dependencies_available", return_value=True),
+                patch("builtins.print") as mock_print,
+            ):
+                _print_system_health(paths_info)
+
+            printed = [str(c) for c in mock_print.call_args_list]
+            self.assertTrue(any("delete" in p.lower() for p in printed))
+
+    def test_sqlite_error_does_not_crash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db_path.write_text("not a sqlite db")
+            paths_info = self._make_paths_info(db_path)
+
+            with (
+                patch("mmrelay.paths.get_database_path", return_value=db_path),
+                patch("mmrelay.cli._e2ee_dependencies_available", return_value=True),
+                patch("builtins.print"),
+            ):
+                _print_system_health(paths_info)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_system_health_coverage.py
+++ b/tests/test_cli_system_health_coverage.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -24,10 +24,10 @@ class TestPrintSystemHealthDatabase(unittest.TestCase):
     def _make_paths_info(self, db_path: Path) -> dict[str, str]:
         """
         Create a paths_info dictionary containing the system temporary directory as "home" and the parent directory of the given database path as "database_dir".
-        
+
         Parameters:
             db_path (Path): Path to the database file; its parent directory is used for "database_dir".
-        
+
         Returns:
             dict[str, str]: A mapping with keys "home" (system temporary directory) and "database_dir" (string path of db_path's parent).
         """
@@ -39,7 +39,7 @@ class TestPrintSystemHealthDatabase(unittest.TestCase):
     def test_wal_mode_prints_wal_emoji(self):
         """
         Verify that system health output reports WAL journal mode.
-        
+
         Creates a temporary SQLite database configured with `PRAGMA journal_mode=wal`, patches the database path and E2EE dependency check, captures printed output from _print_system_health, and asserts that at least one printed message contains the substring "WAL mode".
         """
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -38,7 +38,7 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
 
         # Mock the stdout capture
         with patch("sys.stdout", new_callable=lambda: Mock()):
-            with patch("io.StringIO") as mock_stringio:
+            with patch("mmrelay.meshtastic.metadata.io.StringIO") as mock_stringio:
                 mock_output = Mock()
                 mock_output.getvalue.return_value = long_output
                 mock_stringio.return_value = mock_output
@@ -69,7 +69,7 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
         for output, expected in test_cases:
             with self.subTest(output=output):
                 # Mock the stdout capture
-                with patch("io.StringIO") as mock_stringio:
+                with patch("mmrelay.meshtastic.metadata.io.StringIO") as mock_stringio:
                     mock_output = Mock()
                     mock_output.getvalue.return_value = output
                     mock_stringio.return_value = mock_output
@@ -84,7 +84,7 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
         mock_interface.localNode = Mock()
 
         # Mock the stdout capture with output that has no firmware version
-        with patch("io.StringIO") as mock_stringio:
+        with patch("mmrelay.meshtastic.metadata.io.StringIO") as mock_stringio:
             mock_output = Mock()
             mock_output.getvalue.return_value = "some other output"
             mock_stringio.return_value = mock_output

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -34,7 +34,16 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
     @staticmethod
     def _immediate_metadata_submit(callback: Callable[[], Any]) -> Future[None]:
         """
-        Execute metadata probe callback synchronously and return a completed Future.
+        Run a metadata probe callback immediately and return a completed Future.
+        
+        Parameters:
+            callback (Callable[[], Any]): Function to execute synchronously; its return value is ignored.
+        
+        Returns:
+            Future[None]: A Future already completed with result `None` after `callback` returns.
+        
+        Raises:
+            Exception: Any exception raised by `callback` is propagated to the caller.
         """
         future: Future[None] = Future()
         callback()

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -6,7 +6,9 @@ Focuses on specific functions and edge cases that are currently missing test cov
 import os
 import sys
 import unittest
+from collections.abc import Callable
 from concurrent.futures import Future
+from typing import Any
 from unittest.mock import Mock, patch
 
 # Add src to path for imports
@@ -30,16 +32,13 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
         }
 
     @staticmethod
-    def _immediate_metadata_submit(callback):
+    def _immediate_metadata_submit(callback: Callable[[], Any]) -> Future[None]:
         """
         Execute metadata probe callback synchronously and return a completed Future.
         """
-        future = Future()
-        try:
-            callback()
-            future.set_result(None)
-        except Exception as exc:  # pragma: no cover - defensive for parity with runtime
-            future.set_exception(exc)
+        future: Future[None] = Future()
+        callback()
+        future.set_result(None)
         return future
 
     def test_get_device_metadata_console_output_truncation(self):

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -35,13 +35,13 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
     def _immediate_metadata_submit(callback: Callable[[], Any]) -> Future[None]:
         """
         Run a metadata probe callback immediately and return a completed Future.
-        
+
         Parameters:
             callback (Callable[[], Any]): Function to execute synchronously; its return value is ignored.
-        
+
         Returns:
             Future[None]: A Future already completed with result `None` after `callback` returns.
-        
+
         Raises:
             Exception: Any exception raised by `callback` is propagated to the caller.
         """

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -61,6 +61,11 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
         mock_interface.localNode.getMetadata.side_effect = lambda: print(
             long_output, end=""
         )
+        # Patching at the _submit_metadata_probe boundary rather than the
+        # underlying ThreadPoolExecutor because the helper encapsulates
+        # lock management, stale-future detection, degraded-state checks,
+        # done-callback wiring, and cleanup scheduling — all of which would
+        # need to be replicated if we patched the executor directly.
         with patch(
             "mmrelay.meshtastic_utils._submit_metadata_probe",
             side_effect=self._immediate_metadata_submit,
@@ -93,6 +98,11 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
                 mock_interface.localNode.getMetadata.side_effect = (
                     lambda out=output: print(out, end="")
                 )
+                # Patching at the _submit_metadata_probe boundary rather than the
+                # underlying ThreadPoolExecutor because the helper encapsulates
+                # lock management, stale-future detection, degraded-state checks,
+                # done-callback wiring, and cleanup scheduling — all of which would
+                # need to be replicated if we patched the executor directly.
                 with patch(
                     "mmrelay.meshtastic_utils._submit_metadata_probe",
                     side_effect=self._immediate_metadata_submit,
@@ -109,6 +119,11 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
             "some other output", end=""
         )
 
+        # Patching at the _submit_metadata_probe boundary rather than the
+        # underlying ThreadPoolExecutor because the helper encapsulates
+        # lock management, stale-future detection, degraded-state checks,
+        # done-callback wiring, and cleanup scheduling — all of which would
+        # need to be replicated if we patched the executor directly.
         with patch(
             "mmrelay.meshtastic_utils._submit_metadata_probe",
             side_effect=self._immediate_metadata_submit,

--- a/tests/test_core_utils_coverage.py
+++ b/tests/test_core_utils_coverage.py
@@ -6,6 +6,7 @@ Focuses on specific functions and edge cases that are currently missing test cov
 import os
 import sys
 import unittest
+from concurrent.futures import Future
 from unittest.mock import Mock, patch
 
 # Add src to path for imports
@@ -28,6 +29,19 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
             "matrix_rooms": [{"id": "!room1:example.com", "meshtastic_channel": 0}],
         }
 
+    @staticmethod
+    def _immediate_metadata_submit(callback):
+        """
+        Execute metadata probe callback synchronously and return a completed Future.
+        """
+        future = Future()
+        try:
+            callback()
+            future.set_result(None)
+        except Exception as exc:  # pragma: no cover - defensive for parity with runtime
+            future.set_exception(exc)
+        return future
+
     def test_get_device_metadata_console_output_truncation(self):
         """Test that console output is truncated when too long"""
         mock_interface = Mock()
@@ -36,14 +50,14 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
         # Create a very long output string (> 4096 chars)
         long_output = "firmware_version: 1.2.3\n" + "x" * 5000
 
-        # Mock the stdout capture
-        with patch("sys.stdout", new_callable=lambda: Mock()):
-            with patch("mmrelay.meshtastic.metadata.io.StringIO") as mock_stringio:
-                mock_output = Mock()
-                mock_output.getvalue.return_value = long_output
-                mock_stringio.return_value = mock_output
-
-                result = meshtastic_utils._get_device_metadata(mock_interface)
+        mock_interface.localNode.getMetadata.side_effect = lambda: print(
+            long_output, end=""
+        )
+        with patch(
+            "mmrelay.meshtastic_utils._submit_metadata_probe",
+            side_effect=self._immediate_metadata_submit,
+        ):
+            result = meshtastic_utils._get_device_metadata(mock_interface)
 
         # Should truncate and add ellipsis
         self.assertIn("raw_output", result)
@@ -68,27 +82,29 @@ class TestMeshtasticUtilsCoverage(unittest.TestCase):
 
         for output, expected in test_cases:
             with self.subTest(output=output):
-                # Mock the stdout capture
-                with patch("mmrelay.meshtastic.metadata.io.StringIO") as mock_stringio:
-                    mock_output = Mock()
-                    mock_output.getvalue.return_value = output
-                    mock_stringio.return_value = mock_output
-
+                mock_interface.localNode.getMetadata.side_effect = (
+                    lambda out=output: print(out, end="")
+                )
+                with patch(
+                    "mmrelay.meshtastic_utils._submit_metadata_probe",
+                    side_effect=self._immediate_metadata_submit,
+                ):
                     result = meshtastic_utils._get_device_metadata(mock_interface)
-                    self.assertEqual(result["firmware_version"], expected)
-                    self.assertTrue(result["success"])
+                self.assertEqual(result["firmware_version"], expected)
+                self.assertTrue(result["success"])
 
     def test_get_device_metadata_no_firmware_version_found(self):
         """Test when no firmware version is found in output"""
         mock_interface = Mock()
         mock_interface.localNode = Mock()
+        mock_interface.localNode.getMetadata.side_effect = lambda: print(
+            "some other output", end=""
+        )
 
-        # Mock the stdout capture with output that has no firmware version
-        with patch("mmrelay.meshtastic.metadata.io.StringIO") as mock_stringio:
-            mock_output = Mock()
-            mock_output.getvalue.return_value = "some other output"
-            mock_stringio.return_value = mock_output
-
+        with patch(
+            "mmrelay.meshtastic_utils._submit_metadata_probe",
+            side_effect=self._immediate_metadata_submit,
+        ):
             result = meshtastic_utils._get_device_metadata(mock_interface)
 
         self.assertEqual(result["firmware_version"], "unknown")

--- a/tests/test_db_runtime_del_coverage.py
+++ b/tests/test_db_runtime_del_coverage.py
@@ -1,0 +1,42 @@
+"""
+Tests for DatabaseManager.__del__ in db_runtime.py (lines 553-555).
+
+Covers the best-effort fallback destructor that catches exceptions
+to avoid surfacing errors during interpreter shutdown.
+"""
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mmrelay.db_runtime import DatabaseManager
+
+
+class TestDatabaseManagerDel:
+    """Tests for DatabaseManager.__del__ fallback."""
+
+    def test_del_calls_close(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        mgr = DatabaseManager(db_path)
+        with patch.object(mgr, "close") as mock_close:
+            mgr.__del__()
+            mock_close.assert_called_once()
+
+    def test_del_suppresses_close_exception(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        mgr = DatabaseManager(db_path)
+        with patch.object(mgr, "close", side_effect=RuntimeError("boom")):
+            mgr.__del__()
+
+    def test_del_suppresses_sqlite_error(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        mgr = DatabaseManager(db_path)
+        with patch.object(mgr, "close", side_effect=sqlite3.Error("shutdown error")):
+            mgr.__del__()
+
+    def test_del_suppresses_generic_exception(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        mgr = DatabaseManager(db_path)
+        with patch.object(mgr, "close", side_effect=Exception("any error")):
+            mgr.__del__()

--- a/tests/test_db_runtime_del_coverage.py
+++ b/tests/test_db_runtime_del_coverage.py
@@ -5,6 +5,7 @@ Covers the best-effort fallback destructor that catches exceptions
 to avoid surfacing errors during interpreter shutdown.
 """
 
+import contextlib
 import sqlite3
 from unittest.mock import patch
 
@@ -31,10 +32,8 @@ class TestDatabaseManagerDel:
             with patch.object(mgr, "close", side_effect=RuntimeError("boom")):
                 mgr.__del__()
         finally:
-            try:
+            with contextlib.suppress(Exception):
                 mgr.close()
-            except Exception:
-                pass
 
     def test_del_suppresses_sqlite_error(self, tmp_path):
         db_path = str(tmp_path / "test.db")
@@ -45,10 +44,8 @@ class TestDatabaseManagerDel:
             ):
                 mgr.__del__()
         finally:
-            try:
+            with contextlib.suppress(Exception):
                 mgr.close()
-            except Exception:
-                pass
 
     def test_del_suppresses_generic_exception(self, tmp_path):
         """
@@ -65,7 +62,5 @@ class TestDatabaseManagerDel:
             with patch.object(mgr, "close", side_effect=Exception("any error")):
                 mgr.__del__()
         finally:
-            try:
+            with contextlib.suppress(Exception):
                 mgr.close()
-            except Exception:
-                pass

--- a/tests/test_db_runtime_del_coverage.py
+++ b/tests/test_db_runtime_del_coverage.py
@@ -36,6 +36,14 @@ class TestDatabaseManagerDel:
             mgr.__del__()
 
     def test_del_suppresses_generic_exception(self, tmp_path):
+        """
+        Verifies that DatabaseManager.__del__ swallows any generic Exception raised by its close() method.
+        
+        Patches the instance's close method to raise Exception("any error") and invokes __del__; the test succeeds if no exception is propagated.
+        
+        Parameters:
+            tmp_path (pathlib.Path): pytest-provided temporary directory for creating a test database file.
+        """
         db_path = str(tmp_path / "test.db")
         mgr = DatabaseManager(db_path)
         with patch.object(mgr, "close", side_effect=Exception("any error")):

--- a/tests/test_db_runtime_del_coverage.py
+++ b/tests/test_db_runtime_del_coverage.py
@@ -17,21 +17,38 @@ class TestDatabaseManagerDel:
     def test_del_calls_close(self, tmp_path):
         db_path = str(tmp_path / "test.db")
         mgr = DatabaseManager(db_path)
-        with patch.object(mgr, "close") as mock_close:
-            mgr.__del__()
-            mock_close.assert_called_once()
+        try:
+            with patch.object(mgr, "close") as mock_close:
+                mgr.__del__()
+                mock_close.assert_called_once()
+        finally:
+            mgr.close()
 
     def test_del_suppresses_close_exception(self, tmp_path):
         db_path = str(tmp_path / "test.db")
         mgr = DatabaseManager(db_path)
-        with patch.object(mgr, "close", side_effect=RuntimeError("boom")):
-            mgr.__del__()
+        try:
+            with patch.object(mgr, "close", side_effect=RuntimeError("boom")):
+                mgr.__del__()
+        finally:
+            try:
+                mgr.close()
+            except Exception:
+                pass
 
     def test_del_suppresses_sqlite_error(self, tmp_path):
         db_path = str(tmp_path / "test.db")
         mgr = DatabaseManager(db_path)
-        with patch.object(mgr, "close", side_effect=sqlite3.Error("shutdown error")):
-            mgr.__del__()
+        try:
+            with patch.object(
+                mgr, "close", side_effect=sqlite3.Error("shutdown error")
+            ):
+                mgr.__del__()
+        finally:
+            try:
+                mgr.close()
+            except Exception:
+                pass
 
     def test_del_suppresses_generic_exception(self, tmp_path):
         """
@@ -44,5 +61,11 @@ class TestDatabaseManagerDel:
         """
         db_path = str(tmp_path / "test.db")
         mgr = DatabaseManager(db_path)
-        with patch.object(mgr, "close", side_effect=Exception("any error")):
-            mgr.__del__()
+        try:
+            with patch.object(mgr, "close", side_effect=Exception("any error")):
+                mgr.__del__()
+        finally:
+            try:
+                mgr.close()
+            except Exception:
+                pass

--- a/tests/test_db_runtime_del_coverage.py
+++ b/tests/test_db_runtime_del_coverage.py
@@ -6,9 +6,7 @@ to avoid surfacing errors during interpreter shutdown.
 """
 
 import sqlite3
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from mmrelay.db_runtime import DatabaseManager
 
@@ -38,9 +36,9 @@ class TestDatabaseManagerDel:
     def test_del_suppresses_generic_exception(self, tmp_path):
         """
         Verifies that DatabaseManager.__del__ swallows any generic Exception raised by its close() method.
-        
+
         Patches the instance's close method to raise Exception("any error") and invokes __del__; the test succeeds if no exception is propagated.
-        
+
         Parameters:
             tmp_path (pathlib.Path): pytest-provided temporary directory for creating a test database file.
         """

--- a/tests/test_db_runtime_security.py
+++ b/tests/test_db_runtime_security.py
@@ -684,11 +684,13 @@ class TestDatabaseManager(unittest.TestCase):
         result1, result2 = asyncio.run(run_test())
         self.assertEqual((result1, result2), ("first", "second"))
 
-        with contextlib.closing(sqlite3.connect(self.db_path)) as conn:
-            with conn as managed_conn:
-                count = managed_conn.execute(
-                    "SELECT COUNT(*) FROM test_async_close"
-                ).fetchone()[0]
+        with (
+            contextlib.closing(sqlite3.connect(self.db_path)) as conn,
+            conn as managed_conn,
+        ):
+            count = managed_conn.execute(
+                "SELECT COUNT(*) FROM test_async_close"
+            ).fetchone()[0]
         self.assertEqual(count, 2)
 
     def test_thread_local_connections(self):

--- a/tests/test_db_runtime_security.py
+++ b/tests/test_db_runtime_security.py
@@ -11,6 +11,7 @@ This test module covers:
 """
 
 import asyncio
+import contextlib
 import os
 import sqlite3
 import tempfile
@@ -683,8 +684,11 @@ class TestDatabaseManager(unittest.TestCase):
         result1, result2 = asyncio.run(run_test())
         self.assertEqual((result1, result2), ("first", "second"))
 
-        with sqlite3.connect(self.db_path) as conn:
-            count = conn.execute("SELECT COUNT(*) FROM test_async_close").fetchone()[0]
+        with contextlib.closing(sqlite3.connect(self.db_path)) as conn:
+            with conn as managed_conn:
+                count = managed_conn.execute(
+                    "SELECT COUNT(*) FROM test_async_close"
+                ).fetchone()[0]
         self.assertEqual(count, 2)
 
     def test_thread_local_connections(self):

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -68,12 +68,12 @@ from mmrelay.db_utils import (
 def _make_failing_cursor_proxy_side_effect(write_failed_flag: list[bool]):
     """
     Create a DatabaseManager.run_sync side effect that injects a single sqlite3.Error on the first write.
-    
+
     When the returned side effect is used, the first cursor.execute() invoked during a call with write=True will raise sqlite3.Error("forced longname write failure") exactly once. The function returns a tuple (side_effect_function, original_run_sync) suitable for use with patch.object to replace DatabaseManager.run_sync and later restore it.
-    
+
     Parameters:
         write_failed_flag (list[bool]): A single-element mutable list used to record whether the forced failure has already occurred; the function sets write_failed_flag[0] to True when the failure is triggered.
-    
+
     Returns:
         tuple: (side_effect_function, original_run_sync) where side_effect_function has the signature (self, func, *, write=False) and original_run_sync is the original DatabaseManager.run_sync method.
     """
@@ -111,10 +111,10 @@ def _make_failing_cursor_proxy_side_effect(write_failed_flag: list[bool]):
 def _managed_sqlite_connection(path: str) -> Generator[sqlite3.Connection, None, None]:
     """
     Yield a SQLite connection wrapped in a transactional context and always close it on exit.
-    
+
     Parameters:
         path (str): Filesystem path to the SQLite database file.
-    
+
     Yields:
         sqlite3.Connection: An open connection where the transaction is managed by the context; the connection is closed when the context exits.
     """
@@ -1772,7 +1772,7 @@ class TestDbUtils(unittest.TestCase):
     def test_get_db_path_legacy_database_root_level(self):
         """
         Verify get_db_path() returns a legacy database file when a database exists at the root of a legacy directory and the deprecation window is active.
-        
+
         Creates a legacy database file at legacy_dir/<DATABASE_FILENAME>, clears cached config to force default-path resolution, patches path-resolution helpers to make the legacy directory discoverable, activates the deprecation window, and asserts get_db_path() returns the legacy database path.
         """
         # Clear cache and config to test default behavior with legacy database

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -20,8 +20,9 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 # Add src to path for imports

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -20,7 +20,8 @@ import sqlite3
 import sys
 import tempfile
 import unittest
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Generator
 from unittest.mock import MagicMock, patch
 
 # Add src to path for imports
@@ -98,6 +99,22 @@ def _make_failing_cursor_proxy_side_effect(write_failed_flag: list[bool]):
         return original_run_sync(self, func, write=write)
 
     return fail_on_first_write, original_run_sync
+
+
+@contextmanager
+def _managed_sqlite_connection(path: str) -> Generator[sqlite3.Connection, None, None]:
+    """
+    Yield a SQLite connection with transaction semantics and guaranteed closure.
+
+    The built-in sqlite3 connection context manager commits/rolls back but does not
+    close the connection. Wrapping it ensures tests do not leak file handles.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
 
 
 class TestDbUtils(unittest.TestCase):
@@ -269,7 +286,7 @@ class TestDbUtils(unittest.TestCase):
         self.assertTrue(os.path.exists(self.test_db_path))
 
         # Verify tables were created
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
 
             # Check longnames table
@@ -303,7 +320,7 @@ class TestDbUtils(unittest.TestCase):
 
     def test_initialize_database_migrates_legacy_message_map_with_mesh_column(self):
         """Legacy table with meshnet should be merged then dropped."""
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "CREATE TABLE message_map (meshtastic_id TEXT, matrix_event_id TEXT PRIMARY KEY, matrix_room_id TEXT, meshtastic_text TEXT, meshtastic_meshnet TEXT)"
@@ -319,7 +336,7 @@ class TestDbUtils(unittest.TestCase):
 
         initialize_database()
 
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT meshtastic_id, matrix_event_id, meshtastic_meshnet FROM message_map"
@@ -334,7 +351,7 @@ class TestDbUtils(unittest.TestCase):
 
     def test_initialize_database_rebuilds_non_text_message_map_schema(self):
         """INTEGER meshtastic_id schema should be rebuilt to TEXT with meshnet column."""
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "CREATE TABLE message_map (meshtastic_id INTEGER, matrix_event_id TEXT PRIMARY KEY, matrix_room_id TEXT, meshtastic_text TEXT)"
@@ -351,7 +368,7 @@ class TestDbUtils(unittest.TestCase):
 
         initialize_database()
 
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute("PRAGMA table_info(message_map)")
             table_info = {row[1]: row[2].upper() for row in cursor.fetchall()}
@@ -366,7 +383,7 @@ class TestDbUtils(unittest.TestCase):
 
     def test_initialize_database_merges_stale_temp_before_non_text_rebuild(self):
         """A stale message_map_old_temp is merged into rebuilt message_map."""
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "CREATE TABLE message_map (meshtastic_id INTEGER, matrix_event_id TEXT PRIMARY KEY, matrix_room_id TEXT, meshtastic_text TEXT)"
@@ -386,7 +403,7 @@ class TestDbUtils(unittest.TestCase):
 
         initialize_database()
 
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute("PRAGMA table_info(message_map)")
             table_info = {row[1]: row[2].upper() for row in cursor.fetchall()}
@@ -407,7 +424,7 @@ class TestDbUtils(unittest.TestCase):
 
     def test_initialize_database_merges_preexisting_stale_temp_into_temp(self):
         """Pre-existing message_map_stale_temp rows are merged before rebuild."""
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "CREATE TABLE message_map (meshtastic_id INTEGER, matrix_event_id TEXT PRIMARY KEY, matrix_room_id TEXT, meshtastic_text TEXT)"
@@ -434,7 +451,7 @@ class TestDbUtils(unittest.TestCase):
 
         initialize_database()
 
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT meshtastic_id, matrix_event_id, meshtastic_meshnet FROM message_map ORDER BY matrix_event_id"
@@ -460,7 +477,7 @@ class TestDbUtils(unittest.TestCase):
         self,
     ):
         """Stale-temp meshnet values should not be dropped when temp schema is older."""
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "CREATE TABLE message_map (meshtastic_id TEXT, matrix_event_id TEXT PRIMARY KEY, matrix_room_id TEXT, meshtastic_text TEXT)"
@@ -489,7 +506,7 @@ class TestDbUtils(unittest.TestCase):
 
         initialize_database()
 
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT meshtastic_id, matrix_event_id, meshtastic_meshnet FROM message_map ORDER BY matrix_event_id"
@@ -513,7 +530,7 @@ class TestDbUtils(unittest.TestCase):
 
     def test_initialize_database_keeps_stale_temp_when_merge_fails(self):
         """Failed stale-temp merge should keep preserved rows for future recovery."""
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "CREATE TABLE message_map (meshtastic_id INTEGER, matrix_event_id TEXT PRIMARY KEY, matrix_room_id TEXT, meshtastic_text TEXT)"
@@ -532,7 +549,7 @@ class TestDbUtils(unittest.TestCase):
 
         initialize_database()
 
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='message_map_stale_temp'"
@@ -877,7 +894,7 @@ class TestDbUtils(unittest.TestCase):
         }
         first_state = sync_name_tables_if_changed(nodes, previous_state=None)
 
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             conn.execute("DELETE FROM longnames WHERE meshtastic_id = ?", ("!1",))
 
         self.assertIsNone(get_longname("!1"))
@@ -984,7 +1001,7 @@ class TestDbUtils(unittest.TestCase):
         state = sync_name_tables_if_changed(None, previous_state=None)
 
         self.assertIsNone(state)
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             longname_rows = conn.execute("SELECT COUNT(*) FROM longnames").fetchone()
             shortname_rows = conn.execute("SELECT COUNT(*) FROM shortnames").fetchone()
         self.assertIsNotNone(longname_rows)
@@ -1000,7 +1017,7 @@ class TestDbUtils(unittest.TestCase):
         state = sync_name_tables_if_changed(bad_nodes, previous_state=None)
 
         self.assertIsNone(state)
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             longname_rows = conn.execute("SELECT COUNT(*) FROM longnames").fetchone()
             shortname_rows = conn.execute("SELECT COUNT(*) FROM shortnames").fetchone()
         self.assertIsNotNone(longname_rows)
@@ -1378,7 +1395,7 @@ class TestDbUtils(unittest.TestCase):
         prune_message_map(5)
 
         # Verify only recent entries remain
-        with sqlite3.connect(self.test_db_path) as conn:
+        with _managed_sqlite_connection(self.test_db_path) as conn:
             cursor = conn.cursor()
             cursor.execute("SELECT COUNT(*) FROM message_map")
             count = cursor.fetchone()[0]
@@ -1764,7 +1781,7 @@ class TestDbUtils(unittest.TestCase):
             # Create legacy database at root level
             os.makedirs(legacy_dir, exist_ok=True)
             legacy_db_path = os.path.join(legacy_dir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Mock paths and deprecation window
@@ -1801,7 +1818,7 @@ class TestDbUtils(unittest.TestCase):
             data_subdir = os.path.join(legacy_dir, "data")
             os.makedirs(data_subdir, exist_ok=True)
             legacy_db_path = os.path.join(data_subdir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Mock paths and deprecation window
@@ -1838,7 +1855,7 @@ class TestDbUtils(unittest.TestCase):
             database_subdir = os.path.join(legacy_dir, "database")
             os.makedirs(database_subdir, exist_ok=True)
             legacy_db_path = os.path.join(database_subdir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Mock paths and deprecation window
@@ -1908,13 +1925,13 @@ class TestDbUtils(unittest.TestCase):
             # Create default database
             os.makedirs(database_dir, exist_ok=True)
             default_db_path = os.path.join(database_dir, DATABASE_FILENAME)
-            with sqlite3.connect(default_db_path) as conn:
+            with _managed_sqlite_connection(default_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Create legacy database (should NOT be returned)
             os.makedirs(legacy_dir, exist_ok=True)
             legacy_db_path = os.path.join(legacy_dir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Mock paths and deprecation window
@@ -1951,7 +1968,7 @@ class TestDbUtils(unittest.TestCase):
             # Create legacy database (should NOT be returned when deprecation inactive)
             os.makedirs(legacy_dir, exist_ok=True)
             legacy_db_path = os.path.join(legacy_dir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Mock paths and deprecation window (inactive)
@@ -1989,7 +2006,7 @@ class TestDbUtils(unittest.TestCase):
             # Create legacy database
             os.makedirs(legacy_dir, exist_ok=True)
             legacy_db_path = os.path.join(legacy_dir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Mock paths and deprecation window
@@ -2034,12 +2051,12 @@ class TestDbUtils(unittest.TestCase):
             # Create databases in both legacy directories
             os.makedirs(legacy_dir1, exist_ok=True)
             legacy_db_path1 = os.path.join(legacy_dir1, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path1) as conn:
+            with _managed_sqlite_connection(legacy_db_path1) as conn:
                 conn.execute("CREATE TABLE test_table1 (id INTEGER)")
 
             os.makedirs(legacy_dir2, exist_ok=True)
             legacy_db_path2 = os.path.join(legacy_dir2, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path2) as conn:
+            with _managed_sqlite_connection(legacy_db_path2) as conn:
                 conn.execute("CREATE TABLE test_table2 (id INTEGER)")
 
             # Mock paths and deprecation window
@@ -2077,7 +2094,7 @@ class TestDbUtils(unittest.TestCase):
             # Create legacy database
             os.makedirs(legacy_dir, exist_ok=True)
             legacy_db_path = os.path.join(legacy_dir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             # Mock paths and deprecation window
@@ -2121,7 +2138,7 @@ class TestDbUtils(unittest.TestCase):
             # Create legacy database
             os.makedirs(legacy_dir, exist_ok=True)
             legacy_db_path = os.path.join(legacy_dir, DATABASE_FILENAME)
-            with sqlite3.connect(legacy_db_path) as conn:
+            with _managed_sqlite_connection(legacy_db_path) as conn:
                 conn.execute("CREATE TABLE test_table (id INTEGER)")
 
             with patch(

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -67,10 +67,15 @@ from mmrelay.db_utils import (
 
 def _make_failing_cursor_proxy_side_effect(write_failed_flag: list[bool]):
     """
-    Create a side effect for DatabaseManager.run_sync that fails once on first write.
-
-    Returns a tuple of (side_effect_function, original_run_sync) for use with patch.object.
-    The write_failed_flag is a mutable list containing a single bool to track failure state.
+    Create a DatabaseManager.run_sync side effect that injects a single sqlite3.Error on the first write.
+    
+    When the returned side effect is used, the first cursor.execute() invoked during a call with write=True will raise sqlite3.Error("forced longname write failure") exactly once. The function returns a tuple (side_effect_function, original_run_sync) suitable for use with patch.object to replace DatabaseManager.run_sync and later restore it.
+    
+    Parameters:
+        write_failed_flag (list[bool]): A single-element mutable list used to record whether the forced failure has already occurred; the function sets write_failed_flag[0] to True when the failure is triggered.
+    
+    Returns:
+        tuple: (side_effect_function, original_run_sync) where side_effect_function has the signature (self, func, *, write=False) and original_run_sync is the original DatabaseManager.run_sync method.
     """
     original_run_sync = DatabaseManager.run_sync
 
@@ -105,10 +110,13 @@ def _make_failing_cursor_proxy_side_effect(write_failed_flag: list[bool]):
 @contextmanager
 def _managed_sqlite_connection(path: str) -> Generator[sqlite3.Connection, None, None]:
     """
-    Yield a SQLite connection with transaction semantics and guaranteed closure.
-
-    The built-in sqlite3 connection context manager commits/rolls back but does not
-    close the connection. Wrapping it ensures tests do not leak file handles.
+    Yield a SQLite connection wrapped in a transactional context and always close it on exit.
+    
+    Parameters:
+        path (str): Filesystem path to the SQLite database file.
+    
+    Yields:
+        sqlite3.Connection: An open connection where the transaction is managed by the context; the connection is closed when the context exits.
     """
     conn = sqlite3.connect(path)
     try:
@@ -1763,10 +1771,9 @@ class TestDbUtils(unittest.TestCase):
 
     def test_get_db_path_legacy_database_root_level(self):
         """
-        Test that get_db_path() returns legacy database path when database exists at root level of legacy directory.
-
-        This test verifies lines 144-164: when default path doesn't exist and deprecation window is active,
-        legacy directories are searched for existing databases.
+        Verify get_db_path() returns a legacy database file when a database exists at the root of a legacy directory and the deprecation window is active.
+        
+        Creates a legacy database file at legacy_dir/<DATABASE_FILENAME>, clears cached config to force default-path resolution, patches path-resolution helpers to make the legacy directory discoverable, activates the deprecation window, and asserts get_db_path() returns the legacy database path.
         """
         # Clear cache and config to test default behavior with legacy database
         clear_db_path_cache()

--- a/tests/test_db_utils_async.py
+++ b/tests/test_db_utils_async.py
@@ -668,9 +668,9 @@ class TestDatabaseManagerReset(unittest.TestCase):
             # Create manager
             manager = _get_db_manager()
 
-            # Mock close to raise an exception
-            with patch.object(manager, "close", side_effect=Exception("Close error")):
-                # Should not raise exception
+            with patch.object(
+                manager, "close", side_effect=sqlite3.Error("Close error")
+            ):
                 _reset_db_manager()
 
             # Verify manager was still reset

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -60,6 +60,7 @@ class TestCloseManagerSafelyKeyboardInterrupt:
         mock_mgr = MagicMock()
         mock_mgr.close.side_effect = sqlite3.Error("close failed")
         with caplog.at_level(logging.WARNING, logger=mmrelay.db_utils.logger.name):
+            mmrelay.db_utils.logger.addHandler(caplog.handler)
             _close_manager_safely(mock_mgr)
         mock_mgr.close.assert_called_once()
         assert any(

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -6,6 +6,8 @@ Covers:
 - _get_db_manager lines 778-779: RuntimeError when manager_to_return is None
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from mmrelay.db_utils import (
@@ -37,25 +39,20 @@ class TestCloseManagerSafelyKeyboardInterrupt:
     """Tests for _close_manager_safely re-raising KeyboardInterrupt."""
 
     def test_keyboard_interrupt_is_reraised(self):
-        mock_mgr = type(
-            "FakeMgr",
-            (),
-            {"close": lambda self: (_ for _ in ()).throw(KeyboardInterrupt("ctrl-c"))},
-        )()
+        mock_mgr = MagicMock()
+        mock_mgr.close.side_effect = KeyboardInterrupt("ctrl-c")
         with pytest.raises(KeyboardInterrupt):
             _close_manager_safely(mock_mgr)
 
     def test_system_exit_is_reraised(self):
-        mock_mgr = type(
-            "FakeMgr", (), {"close": lambda self: (_ for _ in ()).throw(SystemExit(1))}
-        )()
+        mock_mgr = MagicMock()
+        mock_mgr.close.side_effect = SystemExit(1)
         with pytest.raises(SystemExit):
             _close_manager_safely(mock_mgr)
 
     def test_generic_exception_is_logged(self, caplog):
         import logging
         import sqlite3
-        from unittest.mock import MagicMock
 
         import mmrelay.db_utils
 
@@ -71,8 +68,6 @@ class TestCloseManagerSafelyKeyboardInterrupt:
         )
 
     def test_runtime_error_is_reraised(self):
-        from unittest.mock import MagicMock
-
         mock_mgr = MagicMock()
         mock_mgr.close.side_effect = RuntimeError("close failed")
         with pytest.raises(RuntimeError, match="close failed"):
@@ -91,8 +86,6 @@ class TestGetDbManagerNullReturn:
 
         Patches get_db_path and _resolve_database_options to fixed values and forces DatabaseManager construction to raise RuntimeError; resets the cached manager state and asserts that calling _get_db_manager() raises a RuntimeError with a message matching "init failed" or "initialization failed".
         """
-        from unittest.mock import patch
-
         with (
             patch(
                 "mmrelay.db_utils.get_db_path",
@@ -102,13 +95,11 @@ class TestGetDbManagerNullReturn:
                 "mmrelay.db_utils._resolve_database_options",
                 return_value=(True, 5000, {}),
             ),
-        ):
-            with patch(
+            patch(
                 "mmrelay.db_utils.DatabaseManager",
                 side_effect=RuntimeError("init failed"),
-            ):
-                _reset_db_manager()
-                with pytest.raises(
-                    RuntimeError, match="init failed|initialization failed"
-                ):
-                    _get_db_manager()
+            ),
+        ):
+            _reset_db_manager()
+            with pytest.raises(RuntimeError, match="init failed|initialization failed"):
+                _get_db_manager()

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -18,6 +18,11 @@ from mmrelay.db_utils import (
 
 @pytest.fixture(autouse=True)
 def _reset_state():
+    """
+    Reset shared database-related global state before a test and restore it after the test.
+    
+    Performs setup by clearing the database path cache, resetting the cached DatabaseManager, and setting mmrelay.db_utils.config to None; after the test, clears the cache and resets the manager again to ensure a clean state for subsequent tests.
+    """
     clear_db_path_cache()
     _reset_db_manager()
     import mmrelay.db_utils
@@ -76,6 +81,11 @@ class TestGetDbManagerNullReturn:
     """Tests for _get_db_manager RuntimeError on null manager_to_return."""
 
     def test_raises_runtime_error_when_manager_cannot_be_created(self):
+        """
+        Verifies that _get_db_manager raises a RuntimeError when DatabaseManager initialization fails.
+        
+        Patches get_db_path and _resolve_database_options to fixed values and forces DatabaseManager construction to raise RuntimeError; resets the cached manager state and asserts that calling _get_db_manager() raises a RuntimeError with a message matching "init failed" or "initialization failed".
+        """
         from unittest.mock import patch
 
         with (

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -47,13 +47,26 @@ class TestCloseManagerSafelyKeyboardInterrupt:
         with pytest.raises(SystemExit):
             _close_manager_safely(mock_mgr)
 
-    def test_generic_exception_is_logged(self):
+    def test_generic_exception_is_logged(self, caplog):
+        import logging
         from unittest.mock import MagicMock
+
+        import mmrelay.db_utils
 
         mock_mgr = MagicMock()
         mock_mgr.close.side_effect = RuntimeError("close failed")
-        _close_manager_safely(mock_mgr)
+        original_propagate = mmrelay.db_utils.logger.propagate
+        mmrelay.db_utils.logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger="db_utils"):
+                _close_manager_safely(mock_mgr)
+        finally:
+            mmrelay.db_utils.logger.propagate = original_propagate
         mock_mgr.close.assert_called_once()
+        assert any(
+            "Failed to close DatabaseManager" in rec.getMessage()
+            for rec in caplog.records
+        )
 
     def test_none_manager_is_noop(self):
         _close_manager_safely(None)

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -61,13 +61,9 @@ class TestCloseManagerSafelyKeyboardInterrupt:
 
         mock_mgr = MagicMock()
         mock_mgr.close.side_effect = sqlite3.Error("close failed")
-        original_propagate = mmrelay.db_utils.logger.propagate
-        mmrelay.db_utils.logger.propagate = True
-        try:
-            with caplog.at_level(logging.WARNING, logger=mmrelay.db_utils.logger.name):
-                _close_manager_safely(mock_mgr)
-        finally:
-            mmrelay.db_utils.logger.propagate = original_propagate
+        with caplog.at_level(logging.WARNING, logger=mmrelay.db_utils.logger.name):
+            mmrelay.db_utils.logger.addHandler(caplog.handler)
+            _close_manager_safely(mock_mgr)
         mock_mgr.close.assert_called_once()
         assert any(
             "Failed to close DatabaseManager" in rec.getMessage()

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -54,16 +54,17 @@ class TestCloseManagerSafelyKeyboardInterrupt:
 
     def test_generic_exception_is_logged(self, caplog):
         import logging
+        import sqlite3
         from unittest.mock import MagicMock
 
         import mmrelay.db_utils
 
         mock_mgr = MagicMock()
-        mock_mgr.close.side_effect = RuntimeError("close failed")
+        mock_mgr.close.side_effect = sqlite3.Error("close failed")
         original_propagate = mmrelay.db_utils.logger.propagate
         mmrelay.db_utils.logger.propagate = True
         try:
-            with caplog.at_level(logging.WARNING, logger="db_utils"):
+            with caplog.at_level(logging.WARNING, logger=mmrelay.db_utils.logger.name):
                 _close_manager_safely(mock_mgr)
         finally:
             mmrelay.db_utils.logger.propagate = original_propagate
@@ -72,6 +73,14 @@ class TestCloseManagerSafelyKeyboardInterrupt:
             "Failed to close DatabaseManager" in rec.getMessage()
             for rec in caplog.records
         )
+
+    def test_runtime_error_is_reraised(self):
+        from unittest.mock import MagicMock
+
+        mock_mgr = MagicMock()
+        mock_mgr.close.side_effect = RuntimeError("close failed")
+        with pytest.raises(RuntimeError, match="close failed"):
+            _close_manager_safely(mock_mgr)
 
     def test_none_manager_is_noop(self):
         _close_manager_safely(None)

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -20,7 +20,7 @@ from mmrelay.db_utils import (
 def _reset_state():
     """
     Reset shared database-related global state before a test and restore it after the test.
-    
+
     Performs setup by clearing the database path cache, resetting the cached DatabaseManager, and setting mmrelay.db_utils.config to None; after the test, clears the cache and resets the manager again to ensure a clean state for subsequent tests.
     """
     clear_db_path_cache()
@@ -83,7 +83,7 @@ class TestGetDbManagerNullReturn:
     def test_raises_runtime_error_when_manager_cannot_be_created(self):
         """
         Verifies that _get_db_manager raises a RuntimeError when DatabaseManager initialization fails.
-        
+
         Patches get_db_path and _resolve_database_options to fixed values and forces DatabaseManager construction to raise RuntimeError; resets the cached manager state and asserts that calling _get_db_manager() raises a RuntimeError with a message matching "init failed" or "initialization failed".
         """
         from unittest.mock import patch

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -6,6 +6,7 @@ Covers:
 - _get_db_manager lines 778-779: RuntimeError when manager_to_return is None
 """
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,7 +20,7 @@ from mmrelay.db_utils import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_state():
+def _reset_state() -> Generator[None, None, None]:
     """
     Reset shared database-related global state before a test and restore it after the test.
 
@@ -59,7 +60,6 @@ class TestCloseManagerSafelyKeyboardInterrupt:
         mock_mgr = MagicMock()
         mock_mgr.close.side_effect = sqlite3.Error("close failed")
         with caplog.at_level(logging.WARNING, logger=mmrelay.db_utils.logger.name):
-            mmrelay.db_utils.logger.addHandler(caplog.handler)
             _close_manager_safely(mock_mgr)
         mock_mgr.close.assert_called_once()
         assert any(
@@ -101,5 +101,7 @@ class TestGetDbManagerNullReturn:
             ),
         ):
             _reset_db_manager()
-            with pytest.raises(RuntimeError, match="init failed|initialization failed"):
+            with pytest.raises(
+                RuntimeError, match=r"init failed|initialization failed"
+            ):
                 _get_db_manager()

--- a/tests/test_db_utils_close_manager_coverage.py
+++ b/tests/test_db_utils_close_manager_coverage.py
@@ -1,0 +1,86 @@
+"""
+Tests for _close_manager_safely and _get_db_manager edge cases in db_utils.py.
+
+Covers:
+- _close_manager_safely lines 594-595: KeyboardInterrupt/SystemExit re-raise
+- _get_db_manager lines 778-779: RuntimeError when manager_to_return is None
+"""
+
+import pytest
+
+from mmrelay.db_utils import (
+    _close_manager_safely,
+    _get_db_manager,
+    _reset_db_manager,
+    clear_db_path_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    clear_db_path_cache()
+    _reset_db_manager()
+    import mmrelay.db_utils
+
+    mmrelay.db_utils.config = None
+    yield
+    clear_db_path_cache()
+    _reset_db_manager()
+
+
+class TestCloseManagerSafelyKeyboardInterrupt:
+    """Tests for _close_manager_safely re-raising KeyboardInterrupt."""
+
+    def test_keyboard_interrupt_is_reraised(self):
+        mock_mgr = type(
+            "FakeMgr",
+            (),
+            {"close": lambda self: (_ for _ in ()).throw(KeyboardInterrupt("ctrl-c"))},
+        )()
+        with pytest.raises(KeyboardInterrupt):
+            _close_manager_safely(mock_mgr)
+
+    def test_system_exit_is_reraised(self):
+        mock_mgr = type(
+            "FakeMgr", (), {"close": lambda self: (_ for _ in ()).throw(SystemExit(1))}
+        )()
+        with pytest.raises(SystemExit):
+            _close_manager_safely(mock_mgr)
+
+    def test_generic_exception_is_logged(self):
+        from unittest.mock import MagicMock
+
+        mock_mgr = MagicMock()
+        mock_mgr.close.side_effect = RuntimeError("close failed")
+        _close_manager_safely(mock_mgr)
+        mock_mgr.close.assert_called_once()
+
+    def test_none_manager_is_noop(self):
+        _close_manager_safely(None)
+
+
+class TestGetDbManagerNullReturn:
+    """Tests for _get_db_manager RuntimeError on null manager_to_return."""
+
+    def test_raises_runtime_error_when_manager_cannot_be_created(self):
+        from unittest.mock import patch
+
+        with (
+            patch(
+                "mmrelay.db_utils.get_db_path",
+                return_value="/nonexistent/path/db.sqlite",
+            ),
+            patch(
+                "mmrelay.db_utils._resolve_database_options",
+                return_value=(True, 5000, {}),
+            ),
+        ):
+            with patch(
+                "mmrelay.db_utils.DatabaseManager",
+                side_effect=RuntimeError("init failed"),
+            ):
+                _reset_db_manager()
+                with pytest.raises(
+                    RuntimeError, match="init failed|initialization failed"
+                ):
+                    _get_db_manager()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3148,9 +3148,28 @@ class TestStartupRollback(unittest.TestCase):
 
         def mock_check_conn() -> object:
             # Return a non-coroutine sentinel; create_task is patched below.
+            """
+            Provide the sentinel value representing a mocked connection check.
+            
+            Returns:
+                object: The sentinel `check_conn_sentinel` used by the patched `asyncio.create_task` to identify the mocked check-connection invocation.
+            """
             return check_conn_sentinel
 
         def mock_create_task(coro: Any, *_args: Any, **_kwargs: Any) -> Any:
+            """
+            Provide a test stub for asyncio.create_task that returns prebuilt mock tasks for recognized inputs and fails for anything unexpected.
+            
+            Parameters:
+                coro: Either the special sentinel `check_conn_sentinel`, a coroutine object whose code name may match `_node_name_refresh_supervisor`, or another value passed where an asyncio task would normally be scheduled. Recognized inputs return corresponding mock task objects; coroutine objects that are not recognized are closed before failing.
+                *_args, **_kwargs: Ignored.
+            
+            Returns:
+                The corresponding mock task object for the recognized sentinel or coroutine.
+            
+            Raises:
+                AssertionError: If a coroutine is scheduled but its name is not expected, or if a non-coroutine, non-sentinel value is scheduled.
+            """
             if coro is check_conn_sentinel:
                 return mock_check_task
             if inspect.iscoroutine(coro):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3144,15 +3144,17 @@ class TestStartupRollback(unittest.TestCase):
 
         config = {"matrix_rooms": [{"id": "!room:matrix.org"}]}
 
-        async def mock_check_conn():
-            return None
+        check_conn_sentinel = object()
+
+        def mock_check_conn():
+            # Return a non-coroutine sentinel; create_task is patched below.
+            return check_conn_sentinel
 
         def mock_create_task(coro, *args, **kwargs):
+            if coro is check_conn_sentinel:
+                return mock_check_task
             if inspect.iscoroutine(coro):
                 coro_name = getattr(getattr(coro, "cr_code", None), "co_name", "")
-                if coro_name == "mock_check_conn":
-                    coro.close()
-                    return mock_check_task
                 if coro_name == "_node_name_refresh_supervisor":
                     coro.close()
                     return mock_supervisor_task

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3150,7 +3150,7 @@ class TestStartupRollback(unittest.TestCase):
             # Return a non-coroutine sentinel; create_task is patched below.
             """
             Provide the sentinel value representing a mocked connection check.
-            
+
             Returns:
                 object: The sentinel `check_conn_sentinel` used by the patched `asyncio.create_task` to identify the mocked check-connection invocation.
             """
@@ -3159,14 +3159,14 @@ class TestStartupRollback(unittest.TestCase):
         def mock_create_task(coro: Any, *_args: Any, **_kwargs: Any) -> Any:
             """
             Provide a test stub for asyncio.create_task that returns prebuilt mock tasks for recognized inputs and fails for anything unexpected.
-            
+
             Parameters:
                 coro: Either the special sentinel `check_conn_sentinel`, a coroutine object whose code name may match `_node_name_refresh_supervisor`, or another value passed where an asyncio task would normally be scheduled. Recognized inputs return corresponding mock task objects; coroutine objects that are not recognized are closed before failing.
                 *_args, **_kwargs: Ignored.
-            
+
             Returns:
                 The corresponding mock task object for the recognized sentinel or coroutine.
-            
+
             Raises:
                 AssertionError: If a coroutine is scheduled but its name is not expected, or if a non-coroutine, non-sentinel value is scheduled.
             """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3156,7 +3156,7 @@ class TestStartupRollback(unittest.TestCase):
             """
             return check_conn_sentinel
 
-        def mock_create_task(coro: Any, *_args: Any, **_kwargs: Any) -> Any:
+        def mock_create_task(coro: object, *_args: object, **_kwargs: object) -> object:
             """
             Provide a test stub for asyncio.create_task that returns prebuilt mock tasks for recognized inputs and fails for anything unexpected.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3146,11 +3146,11 @@ class TestStartupRollback(unittest.TestCase):
 
         check_conn_sentinel = object()
 
-        def mock_check_conn():
+        def mock_check_conn() -> object:
             # Return a non-coroutine sentinel; create_task is patched below.
             return check_conn_sentinel
 
-        def mock_create_task(coro, *args, **kwargs):
+        def mock_create_task(coro: Any, *_args: Any, **_kwargs: Any) -> Any:
             if coro is check_conn_sentinel:
                 return mock_check_task
             if inspect.iscoroutine(coro):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3151,8 +3151,10 @@ class TestStartupRollback(unittest.TestCase):
             if inspect.iscoroutine(coro):
                 coro_name = getattr(getattr(coro, "cr_code", None), "co_name", "")
                 if coro_name == "mock_check_conn":
+                    coro.close()
                     return mock_check_task
                 if coro_name == "_node_name_refresh_supervisor":
+                    coro.close()
                     return mock_supervisor_task
                 coro.close()
                 raise AssertionError(f"Unexpected task scheduled: {coro_name}")

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -33,13 +33,14 @@ _make_patched_get_running_loop = make_patched_get_running_loop
 def _make_async_return(value):
     """
     Create an async function that ignores its arguments and always returns the given value.
-    
+
     Parameters:
         value: The value the created async function will return when awaited.
-    
+
     Returns:
         async_callable (callable): An async function that accepts any arguments and returns `value` when awaited.
     """
+
     async def _async_return(*_args, **_kwargs):
         return value
 
@@ -52,7 +53,7 @@ class _ImmediateAwaitable:
     def __init__(self, value: Any = None) -> None:
         """
         Initialize the awaitable that immediately returns a stored value when awaited.
-        
+
         Parameters:
             value (Any): The value to be returned by awaiting this object. Defaults to None.
         """
@@ -61,10 +62,10 @@ class _ImmediateAwaitable:
     def __await__(self) -> Generator[None, None, Any]:
         """
         Provide the generator required by the await protocol and immediately yield the wrapped value.
-        
+
         This implements the generator-based __await__ protocol so that awaiting the object
         returns the stored value without any suspension.
-        
+
         Returns:
             The wrapped value stored in the instance.
         """
@@ -76,7 +77,7 @@ class _ImmediateAwaitable:
 def _make_matrix_client_with_awaitable_close() -> MagicMock:
     """
     Create a MagicMock matrix client whose close() returns an awaitable that completes immediately to avoid coroutine warnings.
-    
+
     Returns:
         MagicMock: A mocked matrix client with `close()` returning an awaitable that yields `None`.
     """
@@ -88,7 +89,7 @@ def _make_matrix_client_with_awaitable_close() -> MagicMock:
 async def _async_noop(*_args, **_kwargs) -> None:
     """
     Immediately completes without performing any action.
-    
+
     Returns:
         None: Always returns None.
     """
@@ -174,7 +175,7 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
     def test_await_background_task_shutdown_logs_error_on_runtime_error(self):
         """
         Verifies that mmrelay.main logs an error when a background connection-health task raises a RuntimeError during shutdown waiting.
-        
+
         Patches runtime dependencies to run main() with a meshtastic connection-health coroutine that raises a RuntimeError after a short delay, runs the shutdown sequence, and asserts that the main logger received an error containing "Error while waiting for" and "connection health task". Restores modified mmrelay.meshtastic_utils module-level globals after the test.
         """
         import mmrelay.meshtastic_utils as mu
@@ -245,12 +246,12 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
     def test_await_background_task_shutdown_timeout_on_cancel_gather(self):
         """
         Verify that main's shutdown logs a timeout warning when cancelling background tasks fails to complete.
-        
+
         Patches the runtime to:
         - make the meshtastic connection health coroutine ignore cancellation,
         - cause `asyncio.wait_for` to raise `asyncio.TimeoutError` on the second invocation,
         - and provide an awaitable matrix client close.
-        
+
         Asserts that a warning containing "Timed out cancelling" is emitted during shutdown.
         """
         import mmrelay.meshtastic_utils as mu
@@ -359,7 +360,7 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
     def test_shutdown_cancels_and_awaits_reconnect_task_future(self):
         """
         Verifies that shutdown cancels and awaits any active meshtastic reconnect task future.
-        
+
         Sets up a long-running reconnect task future, runs the main shutdown sequence, and asserts that the reconnect future was either cancelled or observed cancellation, is completed, and that the global `reconnect_task_future` has been cleared.
         """
         import mmrelay.meshtastic_utils as mu
@@ -379,7 +380,7 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
             def _capture_reconnect_future(*_args, **_kwargs):
                 """
                 Create and store a long-running reconnect task and record it in module state.
-                
+
                 Starts an asyncio Task that sleeps for an extended period; if the task is cancelled,
                 the outer-scope flag `cancel_observed` is set to True. The created Task is stored
                 in the outer-scope `captured_future` and assigned to `mu.reconnect_task_future` and
@@ -406,7 +407,7 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
             ) -> None:
                 """
                 Trigger creation and capture of the reconnect task/future during tests.
-                
+
                 Acting as an async shim, this function invokes the test helper that creates a long-running reconnect task and stores its Task/future for later inspection and shutdown verification. Intended for use as an async replacement for the connection-health callback in tests.
                 """
                 _capture_reconnect_future(*_args, **_kwargs)

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -10,7 +10,6 @@ Covers:
 import asyncio
 import unittest
 from collections.abc import Generator
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 from mmrelay.constants.network import CONNECTION_TYPE_SERIAL
@@ -30,7 +29,7 @@ from tests.helpers import (
 _make_patched_get_running_loop = make_patched_get_running_loop
 
 
-def _make_async_return(value):
+def _make_async_return(value: object) -> MagicMock:
     """
     Create an async function that ignores its arguments and always returns the given value.
 
@@ -41,7 +40,7 @@ def _make_async_return(value):
         async_callable (callable): An async function that accepts any arguments and returns `value` when awaited.
     """
 
-    async def _async_return(*_args, **_kwargs):
+    async def _async_return(*_args: object, **_kwargs: object) -> object:
         return value
 
     return _async_return
@@ -50,7 +49,7 @@ def _make_async_return(value):
 class _ImmediateAwaitable:
     """Lightweight awaitable that resolves immediately without creating coroutines."""
 
-    def __init__(self, value: Any = None) -> None:
+    def __init__(self, value: object = None) -> None:
         """
         Initialize the awaitable that immediately returns a stored value when awaited.
 
@@ -59,7 +58,7 @@ class _ImmediateAwaitable:
         """
         self._value = value
 
-    def __await__(self) -> Generator[None, None, Any]:
+    def __await__(self) -> Generator[None, None, object]:
         """
         Provide the generator required by the await protocol and immediately yield the wrapped value.
 
@@ -86,7 +85,7 @@ def _make_matrix_client_with_awaitable_close() -> MagicMock:
     return client
 
 
-async def _async_noop(*_args, **_kwargs) -> None:
+async def _async_noop(*_args: object, **_kwargs: object) -> None:
     """
     Immediately completes without performing any action.
 
@@ -192,7 +191,9 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
 
             runtime_error = RuntimeError("background task exploded")
 
-            async def _check_connection_that_raises_after_delay(*_args, **_kwargs):
+            async def _check_connection_that_raises_after_delay(
+                *_args: object, **_kwargs: object
+            ) -> None:
                 await asyncio.sleep(0.5)
                 raise runtime_error
 
@@ -269,14 +270,18 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
             original_wait_for = asyncio.wait_for
             wait_for_call_count = 0
 
-            async def _wait_for_that_times_out_on_gather(coro, timeout):
+            async def _wait_for_that_times_out_on_gather(
+                coro: object, timeout: object = None
+            ) -> None:
                 nonlocal wait_for_call_count
                 wait_for_call_count += 1
                 if wait_for_call_count >= 2:
                     raise asyncio.TimeoutError()
                 return await original_wait_for(coro, timeout)
 
-            async def _check_connection_that_ignores_cancel(*_args, **_kwargs):
+            async def _check_connection_that_ignores_cancel(
+                *_args: object, **_kwargs: object
+            ) -> None:
                 try:
                     while True:
                         await asyncio.sleep(10)
@@ -377,7 +382,9 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
             captured_future = None
             cancel_observed = False
 
-            def _capture_reconnect_future(*_args, **_kwargs):
+            def _capture_reconnect_future(
+                *_args: object, **_kwargs: object
+            ) -> MagicMock:
                 """
                 Create and store a long-running reconnect task and record it in module state.
 
@@ -389,7 +396,7 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
                 nonlocal captured_future
                 nonlocal cancel_observed
 
-                async def _fake_reconnect():
+                async def _fake_reconnect() -> None:
                     nonlocal cancel_observed
                     try:
                         await asyncio.sleep(300)
@@ -403,7 +410,7 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
                 return None
 
             async def _capture_reconnect_future_async(
-                *_args: Any, **_kwargs: Any
+                *_args: object, **_kwargs: object
             ) -> None:
                 """
                 Trigger creation and capture of the reconnect task/future during tests.

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -9,7 +9,7 @@ Covers:
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from mmrelay.constants.network import CONNECTION_TYPE_SERIAL
 from mmrelay.main import main
@@ -33,6 +33,25 @@ def _make_async_return(value):
         return value
 
     return _async_return
+
+
+class _ImmediateAwaitable:
+    """Lightweight awaitable that resolves immediately without creating coroutines."""
+
+    def __init__(self, value=None):
+        self._value = value
+
+    def __await__(self):
+        if False:  # pragma: no cover
+            yield
+        return self._value
+
+
+def _make_matrix_client_with_awaitable_close():
+    """Build a matrix client mock whose close() is awaitable and warning-safe."""
+    client = MagicMock()
+    client.close = MagicMock(return_value=_ImmediateAwaitable(None))
+    return client
 
 
 async def _async_noop(*_args, **_kwargs) -> None:
@@ -141,7 +160,9 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
                 patch("mmrelay.main.connect_meshtastic", return_value=MagicMock()),
                 patch(
                     "mmrelay.main.connect_matrix",
-                    side_effect=_make_async_return(MagicMock(close=AsyncMock())),
+                    side_effect=_make_async_return(
+                        _make_matrix_client_with_awaitable_close()
+                    ),
                 ),
                 patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
                 patch("mmrelay.main.shutdown_plugins"),
@@ -216,7 +237,9 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
                 patch("mmrelay.main.connect_meshtastic", return_value=MagicMock()),
                 patch(
                     "mmrelay.main.connect_matrix",
-                    side_effect=_make_async_return(MagicMock(close=AsyncMock())),
+                    side_effect=_make_async_return(
+                        _make_matrix_client_with_awaitable_close()
+                    ),
                 ),
                 patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
                 patch("mmrelay.main.shutdown_plugins"),
@@ -324,7 +347,9 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
                 patch("mmrelay.main.connect_meshtastic", return_value=MagicMock()),
                 patch(
                     "mmrelay.main.connect_matrix",
-                    side_effect=_make_async_return(MagicMock(close=AsyncMock())),
+                    side_effect=_make_async_return(
+                        _make_matrix_client_with_awaitable_close()
+                    ),
                 ),
                 patch("mmrelay.main.join_matrix_room", side_effect=_async_noop),
                 patch("mmrelay.main.shutdown_plugins"),

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -9,6 +9,8 @@ Covers:
 
 import asyncio
 import unittest
+from collections.abc import Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from mmrelay.constants.network import CONNECTION_TYPE_SERIAL
@@ -38,16 +40,16 @@ def _make_async_return(value):
 class _ImmediateAwaitable:
     """Lightweight awaitable that resolves immediately without creating coroutines."""
 
-    def __init__(self, value=None):
+    def __init__(self, value: Any = None) -> None:
         self._value = value
 
-    def __await__(self):
+    def __await__(self) -> Generator[None, None, Any]:
         if False:  # pragma: no cover
             yield
         return self._value
 
 
-def _make_matrix_client_with_awaitable_close():
+def _make_matrix_client_with_awaitable_close() -> MagicMock:
     """Build a matrix client mock whose close() is awaitable and warning-safe."""
     client = MagicMock()
     client.close = MagicMock(return_value=_ImmediateAwaitable(None))
@@ -336,9 +338,10 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
                 mu.reconnect_task = captured_future
                 return None
 
-            async def _capture_reconnect_future_async(*_args, **_kwargs):
+            async def _capture_reconnect_future_async(
+                *_args: Any, **_kwargs: Any
+            ) -> None:
                 _capture_reconnect_future(*_args, **_kwargs)
-                return None
 
             with (
                 patch("mmrelay.main.initialize_database"),

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -31,6 +31,15 @@ _make_patched_get_running_loop = make_patched_get_running_loop
 
 
 def _make_async_return(value):
+    """
+    Create an async function that ignores its arguments and always returns the given value.
+    
+    Parameters:
+        value: The value the created async function will return when awaited.
+    
+    Returns:
+        async_callable (callable): An async function that accepts any arguments and returns `value` when awaited.
+    """
     async def _async_return(*_args, **_kwargs):
         return value
 
@@ -41,22 +50,48 @@ class _ImmediateAwaitable:
     """Lightweight awaitable that resolves immediately without creating coroutines."""
 
     def __init__(self, value: Any = None) -> None:
+        """
+        Initialize the awaitable that immediately returns a stored value when awaited.
+        
+        Parameters:
+            value (Any): The value to be returned by awaiting this object. Defaults to None.
+        """
         self._value = value
 
     def __await__(self) -> Generator[None, None, Any]:
+        """
+        Provide the generator required by the await protocol and immediately yield the wrapped value.
+        
+        This implements the generator-based __await__ protocol so that awaiting the object
+        returns the stored value without any suspension.
+        
+        Returns:
+            The wrapped value stored in the instance.
+        """
         if False:  # pragma: no cover
             yield
         return self._value
 
 
 def _make_matrix_client_with_awaitable_close() -> MagicMock:
-    """Build a matrix client mock whose close() is awaitable and warning-safe."""
+    """
+    Create a MagicMock matrix client whose close() returns an awaitable that completes immediately to avoid coroutine warnings.
+    
+    Returns:
+        MagicMock: A mocked matrix client with `close()` returning an awaitable that yields `None`.
+    """
     client = MagicMock()
     client.close = MagicMock(return_value=_ImmediateAwaitable(None))
     return client
 
 
 async def _async_noop(*_args, **_kwargs) -> None:
+    """
+    Immediately completes without performing any action.
+    
+    Returns:
+        None: Always returns None.
+    """
     return None
 
 
@@ -137,6 +172,11 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
         _reset_all_mmrelay_globals()
 
     def test_await_background_task_shutdown_logs_error_on_runtime_error(self):
+        """
+        Verifies that mmrelay.main logs an error when a background connection-health task raises a RuntimeError during shutdown waiting.
+        
+        Patches runtime dependencies to run main() with a meshtastic connection-health coroutine that raises a RuntimeError after a short delay, runs the shutdown sequence, and asserts that the main logger received an error containing "Error while waiting for" and "connection health task". Restores modified mmrelay.meshtastic_utils module-level globals after the test.
+        """
         import mmrelay.meshtastic_utils as mu
 
         original_client = mu.meshtastic_client
@@ -203,6 +243,16 @@ class TestAwaitBackgroundTaskShutdownErrorPaths(unittest.TestCase):
             mu.reconnect_task_future = original_reconnect_task_future
 
     def test_await_background_task_shutdown_timeout_on_cancel_gather(self):
+        """
+        Verify that main's shutdown logs a timeout warning when cancelling background tasks fails to complete.
+        
+        Patches the runtime to:
+        - make the meshtastic connection health coroutine ignore cancellation,
+        - cause `asyncio.wait_for` to raise `asyncio.TimeoutError` on the second invocation,
+        - and provide an awaitable matrix client close.
+        
+        Asserts that a warning containing "Timed out cancelling" is emitted during shutdown.
+        """
         import mmrelay.meshtastic_utils as mu
 
         original_client = mu.meshtastic_client
@@ -307,6 +357,11 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
         _reset_all_mmrelay_globals()
 
     def test_shutdown_cancels_and_awaits_reconnect_task_future(self):
+        """
+        Verifies that shutdown cancels and awaits any active meshtastic reconnect task future.
+        
+        Sets up a long-running reconnect task future, runs the main shutdown sequence, and asserts that the reconnect future was either cancelled or observed cancellation, is completed, and that the global `reconnect_task_future` has been cleared.
+        """
         import mmrelay.meshtastic_utils as mu
 
         original_client = mu.meshtastic_client
@@ -322,6 +377,14 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
             cancel_observed = False
 
             def _capture_reconnect_future(*_args, **_kwargs):
+                """
+                Create and store a long-running reconnect task and record it in module state.
+                
+                Starts an asyncio Task that sleeps for an extended period; if the task is cancelled,
+                the outer-scope flag `cancel_observed` is set to True. The created Task is stored
+                in the outer-scope `captured_future` and assigned to `mu.reconnect_task_future` and
+                `mu.reconnect_task` for later inspection and shutdown handling.
+                """
                 nonlocal captured_future
                 nonlocal cancel_observed
 
@@ -341,6 +404,11 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
             async def _capture_reconnect_future_async(
                 *_args: Any, **_kwargs: Any
             ) -> None:
+                """
+                Trigger creation and capture of the reconnect task/future during tests.
+                
+                Acting as an async shim, this function invokes the test helper that creates a long-running reconnect task and stores its Task/future for later inspection and shutdown verification. Intended for use as an async replacement for the connection-health callback in tests.
+                """
                 _capture_reconnect_future(*_args, **_kwargs)
 
             with (

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -9,7 +9,7 @@ Covers:
 
 import asyncio
 import unittest
-from collections.abc import Generator
+from collections.abc import Awaitable, Callable, Generator
 from unittest.mock import MagicMock, patch
 
 from mmrelay.constants.network import CONNECTION_TYPE_SERIAL
@@ -29,7 +29,7 @@ from tests.helpers import (
 _make_patched_get_running_loop = make_patched_get_running_loop
 
 
-def _make_async_return(value: object) -> MagicMock:
+def _make_async_return(value: object) -> Callable[..., Awaitable[object]]:
     """
     Create an async function that ignores its arguments and always returns the given value.
 
@@ -37,7 +37,7 @@ def _make_async_return(value: object) -> MagicMock:
         value: The value the created async function will return when awaited.
 
     Returns:
-        async_callable (callable): An async function that accepts any arguments and returns `value` when awaited.
+        Callable[..., Awaitable[object]]: An async function that accepts any arguments and returns `value` when awaited.
     """
 
     async def _async_return(*_args: object, **_kwargs: object) -> object:
@@ -382,9 +382,7 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
             captured_future = None
             cancel_observed = False
 
-            def _capture_reconnect_future(
-                *_args: object, **_kwargs: object
-            ) -> MagicMock:
+            def _capture_reconnect_future(*_args: object, **_kwargs: object) -> None:
                 """
                 Create and store a long-running reconnect task and record it in module state.
 

--- a/tests/test_main_shutdown_coverage.py
+++ b/tests/test_main_shutdown_coverage.py
@@ -313,6 +313,10 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
                 mu.reconnect_task = captured_future
                 return None
 
+            async def _capture_reconnect_future_async(*_args, **_kwargs):
+                _capture_reconnect_future(*_args, **_kwargs)
+                return None
+
             with (
                 patch("mmrelay.main.initialize_database"),
                 patch("mmrelay.main.load_plugins"),
@@ -334,7 +338,7 @@ class TestShutdownWithReconnectTaskFuture(unittest.TestCase):
                 patch("mmrelay.main.asyncio.to_thread", side_effect=inline_to_thread),
                 patch(
                     "mmrelay.main.meshtastic_utils.check_connection",
-                    side_effect=_capture_reconnect_future,
+                    new=_capture_reconnect_future_async,
                 ),
                 patch("mmrelay.main.logger"),
                 patch("mmrelay.main.meshtastic_logger"),

--- a/tests/test_matrix_utils_auth_logout.py
+++ b/tests/test_matrix_utils_auth_logout.py
@@ -234,6 +234,16 @@ async def test_logout_matrix_bot_timeout():
         mock_async_client.return_value = mock_temp_client
 
         def _timeout_wait_for(awaitable, timeout=None, **kwargs):
+            """
+            Simulate an asyncio.wait_for timeout by closing a coroutine awaitable (if provided) and raising asyncio.TimeoutError.
+            
+            Parameters:
+                awaitable: The awaitable or coroutine that would have been awaited; if it is a coroutine it will be closed.
+                timeout: Ignored. Present to match the wait_for signature.
+            
+            Raises:
+                asyncio.TimeoutError: Always raised to simulate a timeout.
+            """
             if asyncio.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()

--- a/tests/test_matrix_utils_auth_logout.py
+++ b/tests/test_matrix_utils_auth_logout.py
@@ -232,7 +232,13 @@ async def test_logout_matrix_bot_timeout():
         mock_temp_client = AsyncMock()
         mock_temp_client.close = AsyncMock()
         mock_async_client.return_value = mock_temp_client
-        mock_wait_for.side_effect = asyncio.TimeoutError()
+
+        def _timeout_wait_for(awaitable, timeout=None, **kwargs):
+            if asyncio.iscoroutine(awaitable):
+                awaitable.close()
+            raise asyncio.TimeoutError()
+
+        mock_wait_for.side_effect = _timeout_wait_for
 
         result = await logout_matrix_bot(password="test_password")
 

--- a/tests/test_matrix_utils_auth_logout.py
+++ b/tests/test_matrix_utils_auth_logout.py
@@ -1,6 +1,7 @@
 """Tests for Matrix logout functionality."""
 
 import asyncio
+from typing import NoReturn
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -233,17 +234,22 @@ async def test_logout_matrix_bot_timeout():
         mock_temp_client.close = AsyncMock()
         mock_async_client.return_value = mock_temp_client
 
-        def _timeout_wait_for(awaitable, timeout=None, **kwargs):
+        def _timeout_wait_for(
+            awaitable: object,
+            timeout: float | None = None,
+            **kwargs: object,
+        ) -> NoReturn:
             """
-            Simulate an asyncio.wait_for timeout by closing a coroutine awaitable (if provided) and raising asyncio.TimeoutError.
+            Simulate asyncio.wait_for timeout by closing a coroutine awaitable.
 
             Parameters:
-                awaitable: The awaitable or coroutine that would have been awaited; if it is a coroutine it will be closed.
+                awaitable: Coroutine to close; if it is a coroutine, will be closed.
                 timeout: Ignored. Present to match the wait_for signature.
 
             Raises:
                 asyncio.TimeoutError: Always raised to simulate a timeout.
             """
+            del timeout, kwargs
             if asyncio.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()

--- a/tests/test_matrix_utils_auth_logout.py
+++ b/tests/test_matrix_utils_auth_logout.py
@@ -236,11 +236,11 @@ async def test_logout_matrix_bot_timeout():
         def _timeout_wait_for(awaitable, timeout=None, **kwargs):
             """
             Simulate an asyncio.wait_for timeout by closing a coroutine awaitable (if provided) and raising asyncio.TimeoutError.
-            
+
             Parameters:
                 awaitable: The awaitable or coroutine that would have been awaited; if it is a coroutine it will be closed.
                 timeout: Ignored. Present to match the wait_for signature.
-            
+
             Raises:
                 asyncio.TimeoutError: Always raised to simulate a timeout.
             """

--- a/tests/test_matrix_utils_connect.py
+++ b/tests/test_matrix_utils_connect.py
@@ -5,11 +5,23 @@ and legacy config handling during Matrix connection establishment.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from mmrelay.matrix_utils import MissingMatrixRoomsError, connect_matrix
+
+
+class _ImmediateAwaitable:
+    """Awaitable that resolves immediately without creating coroutine objects."""
+
+    def __init__(self, value=None):
+        self._value = value
+
+    def __await__(self):
+        if False:  # pragma: no cover
+            yield
+        return self._value
 
 
 @pytest.mark.asyncio
@@ -71,28 +83,24 @@ async def test_connect_matrix_missing_matrix_rooms_raises():
 
 
 @pytest.mark.asyncio
-@patch("mmrelay.matrix_utils.async_load_credentials", new_callable=AsyncMock)
 @patch("mmrelay.matrix_utils._create_ssl_context")
 @patch("mmrelay.matrix_utils.AsyncClient")
-async def test_connect_matrix_legacy_config(
-    mock_async_client, mock_ssl_context, mock_load_credentials
-):
+async def test_connect_matrix_legacy_config(mock_async_client, mock_ssl_context):
     """Test Matrix connection with legacy config (no E2EE)."""
-    # No credentials.json available
-    mock_load_credentials.return_value = None
-
     # Mock SSL context
     mock_ssl_context.return_value = MagicMock()
 
     # Mock AsyncClient instance
     mock_client_instance = MagicMock()
-    mock_client_instance.sync = AsyncMock()
+    mock_client_instance.sync = Mock(
+        return_value=_ImmediateAwaitable(SimpleNamespace())
+    )
     mock_client_instance.rooms = {}
-    mock_client_instance.whoami = AsyncMock()
-    mock_client_instance.whoami.return_value = MagicMock(device_id="LEGACY_DEVICE")
-    mock_client_instance.get_displayname = AsyncMock()
-    mock_client_instance.get_displayname.return_value = MagicMock(
-        displayname="Test Bot"
+    mock_client_instance.whoami = Mock(
+        return_value=_ImmediateAwaitable(MagicMock(device_id="LEGACY_DEVICE"))
+    )
+    mock_client_instance.get_displayname = Mock(
+        return_value=_ImmediateAwaitable(MagicMock(displayname="Test Bot"))
     )
     mock_async_client.return_value = mock_client_instance
 
@@ -107,7 +115,13 @@ async def test_connect_matrix_legacy_config(
     }
 
     # Mock the global matrix_client to None to ensure fresh creation
-    with patch("mmrelay.matrix_utils.matrix_client", None):
+    with (
+        patch("mmrelay.matrix_utils.matrix_client", None),
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            Mock(return_value=_ImmediateAwaitable(None)),
+        ),
+    ):
         client = await connect_matrix(test_config)
 
         assert client is not None

--- a/tests/test_matrix_utils_connect.py
+++ b/tests/test_matrix_utils_connect.py
@@ -6,27 +6,29 @@ and legacy config handling during Matrix connection establishment.
 
 from collections.abc import Generator
 from types import SimpleNamespace
-from typing import Any
+from typing import Generic, TypeVar
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from mmrelay.matrix_utils import MissingMatrixRoomsError, connect_matrix
 
+_T = TypeVar("_T")
 
-class _ImmediateAwaitable:
+
+class _ImmediateAwaitable(Generic[_T]):
     """Awaitable that resolves immediately without creating coroutine objects."""
 
-    def __init__(self, value: Any = None) -> None:
+    def __init__(self, value: _T) -> None:
         """
-        Initialize the instance with an optional initial value stored in the private `_value` attribute.
+        Initialize the instance with a value stored in the private `_value` attribute.
 
         Parameters:
-            value (Any, optional): Initial value to store on the instance. Defaults to None.
+            value: Initial value to store on the instance.
         """
         self._value = value
 
-    def __await__(self) -> Generator[None, None, Any]:
+    def __await__(self) -> Generator[None, None, _T]:
         """
         Allow the instance to be awaited and immediately yield its preset value.
 

--- a/tests/test_matrix_utils_connect.py
+++ b/tests/test_matrix_utils_connect.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
-from mmrelay.matrix_utils import MatrixAuthInfo, MissingMatrixRoomsError, connect_matrix
+from mmrelay.matrix_utils import MissingMatrixRoomsError, connect_matrix
 
 
 class _ImmediateAwaitable:
@@ -20,7 +20,7 @@ class _ImmediateAwaitable:
     def __init__(self, value: Any = None) -> None:
         """
         Initialize the instance with an optional initial value stored in the private `_value` attribute.
-        
+
         Parameters:
             value (Any, optional): Initial value to store on the instance. Defaults to None.
         """
@@ -29,7 +29,7 @@ class _ImmediateAwaitable:
     def __await__(self) -> Generator[None, None, Any]:
         """
         Allow the instance to be awaited and immediately yield its preset value.
-        
+
         Returns:
             The value stored on the instance that will be produced to the awaiting caller.
         """

--- a/tests/test_matrix_utils_connect.py
+++ b/tests/test_matrix_utils_connect.py
@@ -4,7 +4,9 @@ This module tests general connection setup, config validation,
 and legacy config handling during Matrix connection establishment.
 """
 
+from collections.abc import Generator
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -15,10 +17,10 @@ from mmrelay.matrix_utils import MatrixAuthInfo, MissingMatrixRoomsError, connec
 class _ImmediateAwaitable:
     """Awaitable that resolves immediately without creating coroutine objects."""
 
-    def __init__(self, value=None):
+    def __init__(self, value: Any = None) -> None:
         self._value = value
 
-    def __await__(self):
+    def __await__(self) -> Generator[None, None, Any]:
         if False:  # pragma: no cover
             yield
         return self._value
@@ -117,21 +119,8 @@ async def test_connect_matrix_legacy_config(mock_async_client, mock_ssl_context)
     # Mock the global matrix_client to None to ensure fresh creation
     with (
         patch("mmrelay.matrix_utils.matrix_client", None),
-        patch(
-            "mmrelay.matrix_utils._resolve_and_load_credentials",
-            Mock(
-                return_value=_ImmediateAwaitable(
-                    MatrixAuthInfo(
-                        homeserver="https://matrix.example.org",
-                        access_token="legacy_token",
-                        user_id="@bot:example.org",
-                        device_id=None,
-                        credentials=None,
-                        credentials_path=None,
-                    )
-                )
-            ),
-        ),
+        patch("mmrelay.config.os.path.exists", return_value=False),
+        patch("mmrelay.matrix.credentials.os.path.isfile", return_value=False),
         patch(
             "mmrelay.matrix_utils._resolve_aliases_in_mapping",
             Mock(return_value=_ImmediateAwaitable(None)),

--- a/tests/test_matrix_utils_connect.py
+++ b/tests/test_matrix_utils_connect.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
-from mmrelay.matrix_utils import MissingMatrixRoomsError, connect_matrix
+from mmrelay.matrix_utils import MatrixAuthInfo, MissingMatrixRoomsError, connect_matrix
 
 
 class _ImmediateAwaitable:
@@ -118,8 +118,27 @@ async def test_connect_matrix_legacy_config(mock_async_client, mock_ssl_context)
     with (
         patch("mmrelay.matrix_utils.matrix_client", None),
         patch(
-            "mmrelay.matrix_utils.async_load_credentials",
+            "mmrelay.matrix_utils._resolve_and_load_credentials",
+            Mock(
+                return_value=_ImmediateAwaitable(
+                    MatrixAuthInfo(
+                        homeserver="https://matrix.example.org",
+                        access_token="legacy_token",
+                        user_id="@bot:example.org",
+                        device_id=None,
+                        credentials=None,
+                        credentials_path=None,
+                    )
+                )
+            ),
+        ),
+        patch(
+            "mmrelay.matrix_utils._resolve_aliases_in_mapping",
             Mock(return_value=_ImmediateAwaitable(None)),
+        ),
+        patch(
+            "mmrelay.matrix_utils._display_room_channel_mappings",
+            lambda *_a, **_k: None,
         ),
     ):
         client = await connect_matrix(test_config)

--- a/tests/test_matrix_utils_connect.py
+++ b/tests/test_matrix_utils_connect.py
@@ -18,9 +18,21 @@ class _ImmediateAwaitable:
     """Awaitable that resolves immediately without creating coroutine objects."""
 
     def __init__(self, value: Any = None) -> None:
+        """
+        Initialize the instance with an optional initial value stored in the private `_value` attribute.
+        
+        Parameters:
+            value (Any, optional): Initial value to store on the instance. Defaults to None.
+        """
         self._value = value
 
     def __await__(self) -> Generator[None, None, Any]:
+        """
+        Allow the instance to be awaited and immediately yield its preset value.
+        
+        Returns:
+            The value stored on the instance that will be produced to the awaiting caller.
+        """
         if False:  # pragma: no cover
             yield
         return self._value

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -1,0 +1,118 @@
+"""
+Tests for _submit_coro fallback paths in meshtastic/async_utils.py.
+
+Covers lines 192-209: the no-running-loop fallback that creates a temporary
+event loop (with Runner or manual new_event_loop) to execute a coroutine.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestSubmitCoroNoLoopFallback:
+    """Test _submit_coro when there is no running event loop."""
+
+    def _make_coro(self):
+        async def coro():
+            return 42
+
+        return coro()
+
+    def test_uses_runner_when_available(self):
+        from mmrelay.meshtastic.async_utils import _submit_coro
+
+        mu.event_loop = None
+
+        class FakeRunner:
+            def __init__(self):
+                self._runner = MagicMock()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+            def run(self, coro):
+                asyncio.set_event_loop(asyncio.new_event_loop())
+                try:
+                    return asyncio.get_event_loop().run_until_complete(coro)
+                finally:
+                    asyncio.get_event_loop().close()
+                    asyncio.set_event_loop(None)
+
+        fake_runner_cls = FakeRunner
+
+        mock_asyncio = MagicMock(spec=asyncio)
+        mock_asyncio.Runner = fake_runner_cls
+        mock_asyncio.get_running_loop.side_effect = RuntimeError("no running loop")
+        mock_asyncio.AbstractEventLoop = asyncio.AbstractEventLoop
+
+        coro = self._make_coro()
+        try:
+            with patch.object(mu, "asyncio", mock_asyncio):
+                result = _submit_coro(coro)
+            assert result is not None
+            assert result.result(timeout=2) == 42
+        finally:
+            pass
+
+    def test_fallback_to_new_event_loop_without_runner(self):
+        from mmrelay.meshtastic.async_utils import _submit_coro
+
+        mu.event_loop = None
+
+        real_asyncio = asyncio
+        mock_asyncio = MagicMock(spec=asyncio)
+        mock_asyncio.Runner = None
+        mock_asyncio.get_running_loop.side_effect = RuntimeError("no running loop")
+        mock_asyncio.new_event_loop = real_asyncio.new_event_loop
+        mock_asyncio.set_event_loop = real_asyncio.set_event_loop
+        mock_asyncio.AbstractEventLoop = real_asyncio.AbstractEventLoop
+
+        coro = self._make_coro()
+        try:
+            with patch.object(mu, "asyncio", mock_asyncio):
+                result = _submit_coro(coro)
+            assert result is not None
+            assert result.result(timeout=2) == 42
+        finally:
+            pass
+
+    def test_fallback_sets_event_loop_none_on_cleanup(self):
+        from mmrelay.meshtastic.async_utils import _submit_coro
+
+        mu.event_loop = None
+
+        real_asyncio = asyncio
+        call_log = []
+
+        mock_asyncio = MagicMock(spec=asyncio)
+        mock_asyncio.Runner = None
+        mock_asyncio.get_running_loop.side_effect = RuntimeError("no running loop")
+        mock_asyncio.new_event_loop = real_asyncio.new_event_loop
+        mock_asyncio.AbstractEventLoop = real_asyncio.AbstractEventLoop
+
+        original_set = real_asyncio.set_event_loop
+
+        def tracking_set(loop):
+            call_log.append(("set_event_loop", loop))
+            original_set(loop)
+
+        mock_asyncio.set_event_loop = tracking_set
+
+        coro = self._make_coro()
+        try:
+            with patch.object(mu, "asyncio", mock_asyncio):
+                result = _submit_coro(coro)
+            assert result is not None
+            assert result.result(timeout=2) == 42
+            set_calls = [c for c in call_log if c[0] == "set_event_loop"]
+            assert any(c[1] is None for c in set_calls)
+        finally:
+            pass

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -8,7 +8,7 @@ event loop (with Runner or manual new_event_loop) to execute a coroutine.
 import asyncio
 from collections.abc import Coroutine
 from types import TracebackType
-from typing import Any, Self
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -47,7 +47,7 @@ class TestSubmitCoroNoLoopFallback:
                 """
                 self._runner = MagicMock()
 
-            def __enter__(self) -> Self:
+            def __enter__(self) -> "FakeRunner":
                 """
                 Enter the context manager and provide the context object.
 

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -54,13 +54,10 @@ class TestSubmitCoroNoLoopFallback:
         mock_asyncio.AbstractEventLoop = asyncio.AbstractEventLoop
 
         coro = self._make_coro()
-        try:
-            with patch.object(mu, "asyncio", mock_asyncio):
-                result = _submit_coro(coro)
-            assert result is not None
-            assert result.result(timeout=2) == 42
-        finally:
-            pass
+        with patch.object(mu, "asyncio", mock_asyncio):
+            result = _submit_coro(coro)
+        assert result is not None
+        assert result.result(timeout=2) == 42
 
     def test_fallback_to_new_event_loop_without_runner(self):
         from mmrelay.meshtastic.async_utils import _submit_coro
@@ -76,13 +73,10 @@ class TestSubmitCoroNoLoopFallback:
         mock_asyncio.AbstractEventLoop = real_asyncio.AbstractEventLoop
 
         coro = self._make_coro()
-        try:
-            with patch.object(mu, "asyncio", mock_asyncio):
-                result = _submit_coro(coro)
-            assert result is not None
-            assert result.result(timeout=2) == 42
-        finally:
-            pass
+        with patch.object(mu, "asyncio", mock_asyncio):
+            result = _submit_coro(coro)
+        assert result is not None
+        assert result.result(timeout=2) == 42
 
     def test_fallback_sets_event_loop_none_on_cleanup(self):
         from mmrelay.meshtastic.async_utils import _submit_coro
@@ -107,12 +101,9 @@ class TestSubmitCoroNoLoopFallback:
         mock_asyncio.set_event_loop = tracking_set
 
         coro = self._make_coro()
-        try:
-            with patch.object(mu, "asyncio", mock_asyncio):
-                result = _submit_coro(coro)
-            assert result is not None
-            assert result.result(timeout=2) == 42
-            set_calls = [c for c in call_log if c[0] == "set_event_loop"]
-            assert any(c[1] is None for c in set_calls)
-        finally:
-            pass
+        with patch.object(mu, "asyncio", mock_asyncio):
+            result = _submit_coro(coro)
+        assert result is not None
+        assert result.result(timeout=2) == 42
+        set_calls = [c for c in call_log if c[0] == "set_event_loop"]
+        assert any(c[1] is None for c in set_calls)

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -6,6 +6,9 @@ event loop (with Runner or manual new_event_loop) to execute a coroutine.
 """
 
 import asyncio
+from collections.abc import Coroutine
+from types import TracebackType
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,7 +20,7 @@ import mmrelay.meshtastic_utils as mu
 class TestSubmitCoroNoLoopFallback:
     """Test _submit_coro when there is no running event loop."""
 
-    def _make_coro(self):
+    def _make_coro(self) -> Coroutine[Any, Any, int]:
         """
         Create and return a coroutine that resolves to 42.
 
@@ -25,7 +28,7 @@ class TestSubmitCoroNoLoopFallback:
             coroutine: A coroutine object which returns the integer 42 when awaited.
         """
 
-        async def coro():
+        async def coro() -> int:
             return 42
 
         return coro()
@@ -130,12 +133,12 @@ class TestSubmitCoroNoLoopFallback:
 
         original_set = real_asyncio.set_event_loop
 
-        def tracking_set(loop):
+        def tracking_set(loop: asyncio.AbstractEventLoop | None) -> None:
             """
             Record a call to set_event_loop and forward it to the original setter.
 
             Parameters:
-                loop (asyncio.AbstractEventLoop | None): The event loop being installed, or `None` to clear the current loop.
+                loop: The event loop being installed, or `None` to clear the current loop.
             """
             call_log.append(("set_event_loop", loop))
             original_set(loop)

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -20,10 +20,11 @@ class TestSubmitCoroNoLoopFallback:
     def _make_coro(self):
         """
         Create and return a coroutine that resolves to 42.
-        
+
         Returns:
             coroutine: A coroutine object which returns the integer 42 when awaited.
         """
+
         async def coro():
             return 42
 
@@ -38,7 +39,7 @@ class TestSubmitCoroNoLoopFallback:
             def __init__(self):
                 """
                 Initialize the instance with a MagicMock runner used to emulate asyncio Runner behavior in tests.
-                
+
                 Stores a MagicMock object on self._runner for capturing and asserting runner interactions.
                 """
                 self._runner = MagicMock()
@@ -46,7 +47,7 @@ class TestSubmitCoroNoLoopFallback:
             def __enter__(self):
                 """
                 Enter the context manager and provide the context object.
-                
+
                 Returns:
                     The context manager instance (`self`).
                 """
@@ -55,7 +56,7 @@ class TestSubmitCoroNoLoopFallback:
             def __exit__(self, *args):
                 """
                 Do nothing when exiting the context manager.
-                
+
                 Parameters:
                     *args: Values provided by the context-management protocol (exception type, value, traceback); intentionally ignored.
                 """
@@ -64,13 +65,13 @@ class TestSubmitCoroNoLoopFallback:
             def run(self, coro):
                 """
                 Run the given coroutine in a fresh temporary event loop and return its result.
-                
+
                 Parameters:
                     coro: The coroutine object to execute.
-                
+
                 Returns:
                     The value produced by the coroutine.
-                    
+
                 Description:
                     Creates a new event loop for the duration of the call, runs the coroutine to completion on that loop, closes the loop, and clears the global event loop reference.
                 """
@@ -132,7 +133,7 @@ class TestSubmitCoroNoLoopFallback:
         def tracking_set(loop):
             """
             Record a call to set_event_loop and forward it to the original setter.
-            
+
             Parameters:
                 loop (asyncio.AbstractEventLoop | None): The event loop being installed, or `None` to clear the current loop.
             """

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -8,7 +8,7 @@ event loop (with Runner or manual new_event_loop) to execute a coroutine.
 import asyncio
 from collections.abc import Coroutine
 from types import TracebackType
-from typing import Any
+from typing import Any, Self
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -39,7 +39,7 @@ class TestSubmitCoroNoLoopFallback:
         mu.event_loop = None
 
         class FakeRunner:
-            def __init__(self):
+            def __init__(self) -> None:
                 """
                 Initialize the instance with a MagicMock runner used to emulate asyncio Runner behavior in tests.
 
@@ -47,7 +47,7 @@ class TestSubmitCoroNoLoopFallback:
                 """
                 self._runner = MagicMock()
 
-            def __enter__(self):
+            def __enter__(self) -> Self:
                 """
                 Enter the context manager and provide the context object.
 
@@ -56,16 +56,22 @@ class TestSubmitCoroNoLoopFallback:
                 """
                 return self
 
-            def __exit__(self, *args):
+            def __exit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc_val: BaseException | None,
+                exc_tb: TracebackType | None,
+            ) -> None:
                 """
                 Do nothing when exiting the context manager.
 
                 Parameters:
-                    *args: Values provided by the context-management protocol (exception type, value, traceback); intentionally ignored.
+                    exc_type: Exception type provided by the context-management protocol.
+                    exc_val: Exception value provided by the context-management protocol.
+                    exc_tb: Traceback provided by the context-management protocol.
                 """
-                pass
 
-            def run(self, coro):
+            def run(self, coro: Coroutine[Any, Any, int]) -> int:
                 """
                 Run the given coroutine in a fresh temporary event loop and return its result.
 

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -118,10 +118,13 @@ class TestSubmitCoroNoLoopFallback:
         mock_asyncio.AbstractEventLoop = real_asyncio.AbstractEventLoop
 
         coro = self._make_coro()
-        with patch.object(mu, "asyncio", mock_asyncio):
-            result = _submit_coro(coro)
-        assert result is not None
-        assert result.result(timeout=2) == 42
+        try:
+            with patch.object(mu, "asyncio", mock_asyncio):
+                result = _submit_coro(coro)
+            assert result is not None
+            assert result.result(timeout=2) == 42
+        finally:
+            asyncio.set_event_loop(None)
 
     def test_fallback_sets_event_loop_none_on_cleanup(self):
         from mmrelay.meshtastic.async_utils import _submit_coro

--- a/tests/test_meshtastic_async_utils_submit_coro.py
+++ b/tests/test_meshtastic_async_utils_submit_coro.py
@@ -18,6 +18,12 @@ class TestSubmitCoroNoLoopFallback:
     """Test _submit_coro when there is no running event loop."""
 
     def _make_coro(self):
+        """
+        Create and return a coroutine that resolves to 42.
+        
+        Returns:
+            coroutine: A coroutine object which returns the integer 42 when awaited.
+        """
         async def coro():
             return 42
 
@@ -30,15 +36,44 @@ class TestSubmitCoroNoLoopFallback:
 
         class FakeRunner:
             def __init__(self):
+                """
+                Initialize the instance with a MagicMock runner used to emulate asyncio Runner behavior in tests.
+                
+                Stores a MagicMock object on self._runner for capturing and asserting runner interactions.
+                """
                 self._runner = MagicMock()
 
             def __enter__(self):
+                """
+                Enter the context manager and provide the context object.
+                
+                Returns:
+                    The context manager instance (`self`).
+                """
                 return self
 
             def __exit__(self, *args):
+                """
+                Do nothing when exiting the context manager.
+                
+                Parameters:
+                    *args: Values provided by the context-management protocol (exception type, value, traceback); intentionally ignored.
+                """
                 pass
 
             def run(self, coro):
+                """
+                Run the given coroutine in a fresh temporary event loop and return its result.
+                
+                Parameters:
+                    coro: The coroutine object to execute.
+                
+                Returns:
+                    The value produced by the coroutine.
+                    
+                Description:
+                    Creates a new event loop for the duration of the call, runs the coroutine to completion on that loop, closes the loop, and clears the global event loop reference.
+                """
                 asyncio.set_event_loop(asyncio.new_event_loop())
                 try:
                     return asyncio.get_event_loop().run_until_complete(coro)
@@ -95,6 +130,12 @@ class TestSubmitCoroNoLoopFallback:
         original_set = real_asyncio.set_event_loop
 
         def tracking_set(loop):
+            """
+            Record a call to set_event_loop and forward it to the original setter.
+            
+            Parameters:
+                loop (asyncio.AbstractEventLoop | None): The event loop being installed, or `None` to clear the current loop.
+            """
             call_log.append(("set_event_loop", loop))
             original_set(loop)
 

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -4699,7 +4699,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
             Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
             """
-            pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.side_effect = _noop
@@ -4729,7 +4728,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
             Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
             """
-            pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.side_effect = _noop

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -4638,7 +4638,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         def _noop(*_args: object, **_kwargs: object) -> None:
-            """Synchronous no-op used for sync disconnect mocks."""
+            """
+            Synchronous no-op callable that accepts any positional and keyword arguments and does nothing.
+            
+            Used as a replacement/mock for synchronous disconnect functions in tests; ignores all inputs and returns None.
+            """
 
         mock_client = Mock()
         mock_client.is_connected = True  # bool, not callable
@@ -4663,7 +4667,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         def _noop(*_args: object, **_kwargs: object) -> None:
-            """Synchronous no-op used for sync disconnect mocks."""
+            """
+            Synchronous no-op callable that accepts any positional and keyword arguments and does nothing.
+            
+            Used as a replacement/mock for synchronous disconnect functions in tests; ignores all inputs and returns None.
+            """
 
         mock_client = Mock()
         mock_client.is_connected = False  # bool, not callable
@@ -4686,6 +4694,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         def _noop(*_args: object, **_kwargs: object) -> None:
+            """
+            No-operation callable that accepts and ignores all positional and keyword arguments.
+            
+            Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
+            """
             pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -4711,6 +4724,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         def _noop(*_args: object, **_kwargs: object) -> None:
+            """
+            No-operation callable that accepts and ignores all positional and keyword arguments.
+            
+            Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
+            """
             pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -4743,6 +4761,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         class _ImmediateAwaitable:
             def __await__(self) -> Generator[Any, None, None]:
+                """
+                Expose this object as awaitable by providing its awaiting generator.
+                
+                Returns:
+                    Generator: A generator used by the `await` expression; it yields control to the event loop and produces no value.
+                """
                 if False:  # pragma: no cover
                     yield
 
@@ -4750,6 +4774,15 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mock_sleep.return_value = None
 
         def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
+            """
+            Close the given awaitable if it is a coroutine, then raise an asyncio.TimeoutError.
+            
+            Parameters:
+            	awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
+            
+            Raises:
+            	asyncio.TimeoutError: Always raised by this function.
+            """
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()
@@ -4785,10 +4818,25 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         class _ImmediateAwaitable:
             def __await__(self) -> Generator[Any, None, None]:
+                """
+                Expose this object as awaitable by providing its awaiting generator.
+                
+                Returns:
+                    Generator: A generator used by the `await` expression; it yields control to the event loop and produces no value.
+                """
                 if False:  # pragma: no cover
                     yield
 
         def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
+            """
+            Close the given awaitable if it is a coroutine, then raise an asyncio.TimeoutError.
+            
+            Parameters:
+            	awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
+            
+            Raises:
+            	asyncio.TimeoutError: Always raised by this function.
+            """
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()
@@ -4831,12 +4879,27 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         class _ImmediateAwaitable:
             def __await__(self) -> Generator[Any, None, None]:
+                """
+                Expose this object as awaitable by providing its awaiting generator.
+                
+                Returns:
+                    Generator: A generator used by the `await` expression; it yields control to the event loop and produces no value.
+                """
                 if False:  # pragma: no cover
                     yield
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
 
         def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
+            """
+            Close the given awaitable if it is a coroutine, then raise an asyncio.TimeoutError.
+            
+            Parameters:
+            	awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
+            
+            Raises:
+            	asyncio.TimeoutError: Always raised by this function.
+            """
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()
@@ -4943,6 +5006,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         def _noop(*_args: object, **_kwargs: object) -> None:
+            """
+            No-operation callable that accepts and ignores all positional and keyword arguments.
+            
+            Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
+            """
             pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -4981,7 +4981,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mock_future.cancel.return_value = True
         mock_future.done.return_value = False
         mock_future.result = Mock(side_effect=FuturesTimeoutError())
-        mock_run_coroutine_threadsafe.return_value = mock_future
+
+        def _submit(coro, _loop):
+            coro.close()
+            return mock_future
+
+        mock_run_coroutine_threadsafe.side_effect = _submit
 
         with patch("mmrelay.meshtastic_utils.event_loop", mock_loop):
             _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -17,9 +17,10 @@ import os
 import sys
 import threading
 import unittest
+from collections.abc import Generator
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
 from types import SimpleNamespace
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -4636,9 +4637,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address when is_connected is a bool (True)."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        def _noop(*_args, **_kwargs):
+        def _noop(*_args: object, **_kwargs: object) -> None:
             """Synchronous no-op used for sync disconnect mocks."""
-            return None
 
         mock_client = Mock()
         mock_client.is_connected = True  # bool, not callable
@@ -4662,9 +4662,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        def _noop(*_args, **_kwargs):
+        def _noop(*_args: object, **_kwargs: object) -> None:
             """Synchronous no-op used for sync disconnect mocks."""
-            return None
 
         mock_client = Mock()
         mock_client.is_connected = False  # bool, not callable
@@ -4686,8 +4685,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address treats unknown is_connected as False."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        def _noop(*_args, **_kwargs):
-            return None
+        def _noop(*_args: object, **_kwargs: object) -> None:
+            pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.side_effect = _noop
@@ -4711,8 +4710,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address sleeps after a successful disconnect."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        def _noop(*_args, **_kwargs):
-            return None
+        def _noop(*_args: object, **_kwargs: object) -> None:
+            pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.side_effect = _noop
@@ -4743,15 +4742,14 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         class _ImmediateAwaitable:
-            def __await__(self):
+            def __await__(self) -> Generator[Any, None, None]:
                 if False:  # pragma: no cover
                     yield
-                return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.return_value = None
 
-        def _timeout_wait_for(awaitable, timeout=None):
+        def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()
@@ -4786,12 +4784,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         class _ImmediateAwaitable:
-            def __await__(self):
+            def __await__(self) -> Generator[Any, None, None]:
                 if False:  # pragma: no cover
                     yield
-                return None
 
-        def _timeout_wait_for(awaitable, timeout=None):
+        def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()
@@ -4833,14 +4830,13 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
         class _ImmediateAwaitable:
-            def __await__(self):
+            def __await__(self) -> Generator[Any, None, None]:
                 if False:  # pragma: no cover
                     yield
-                return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
 
-        def _timeout_wait_for(awaitable, timeout=None):
+        def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
             raise asyncio.TimeoutError()
@@ -4946,8 +4942,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Repeated BLE disconnect errors should log the final failure warning."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        def _noop(*_args, **_kwargs):
-            return None
+        def _noop(*_args: object, **_kwargs: object) -> None:
+            pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.side_effect = _noop

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -4636,13 +4636,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address when is_connected is a bool (True)."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
-            """
-            Asynchronous no-op that ignores all positional and keyword arguments.
-
-            Returns:
-                None: Always returns None.
-            """
+        def _noop(*_args, **_kwargs):
+            """Synchronous no-op used for sync disconnect mocks."""
             return None
 
         mock_client = Mock()
@@ -4667,13 +4662,8 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
-            """
-            Asynchronous no-op that ignores all positional and keyword arguments.
-
-            Returns:
-                None: Always returns None.
-            """
+        def _noop(*_args, **_kwargs):
+            """Synchronous no-op used for sync disconnect mocks."""
             return None
 
         mock_client = Mock()
@@ -4775,7 +4765,13 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.side_effect = _noop
-        mock_wait_for.side_effect = asyncio.TimeoutError()
+
+        def _timeout_wait_for(awaitable, timeout=None):
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise asyncio.TimeoutError()
+
+        mock_wait_for.side_effect = _timeout_wait_for
 
         mock_client = Mock()
         mock_client.is_connected = True
@@ -4804,25 +4800,24 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address handles unexpected disconnect errors."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
-            """
-            Asynchronous no-op that ignores all positional and keyword arguments.
+        async def _sleep_noop(*_args, **_kwargs):
+            """Async no-op used for mocked asyncio.sleep."""
+            return None
 
-            Returns:
-                None: Always returns None.
-            """
+        def _disconnect_noop(*_args, **_kwargs):
+            """Sync no-op used for mocked disconnect calls."""
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
-        mock_sleep.side_effect = _noop
-        mock_wait_for.side_effect = lambda awaitable, _timeout=None: awaitable
+        mock_sleep.side_effect = _sleep_noop
+        mock_wait_for.side_effect = lambda awaitable, timeout=None: awaitable
         # Force an exception outside the inner retry loop to cover the
         # best-effort cleanup exception path.
         mock_logger.warning.side_effect = ValueError("forced warning failure")
 
         mock_client = Mock()
         mock_client.is_connected = True
-        mock_client.disconnect = Mock(side_effect=_noop)
+        mock_client.disconnect = Mock(side_effect=_disconnect_noop)
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -4859,7 +4854,13 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
-        mock_wait_for.side_effect = asyncio.TimeoutError()
+
+        def _timeout_wait_for(awaitable, timeout=None):
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise asyncio.TimeoutError()
+
+        mock_wait_for.side_effect = _timeout_wait_for
 
         mock_client = Mock()
         mock_client.is_connected = False

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -17,10 +17,10 @@ import os
 import sys
 import threading
 import unittest
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
 from types import SimpleNamespace
-from typing import Any, Callable, NoReturn
+from typing import Any, NoReturn
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -5011,7 +5011,6 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
             Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
             """
-            pass
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
         mock_sleep.side_effect = _noop

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -4686,13 +4686,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address treats unknown is_connected as False."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
-            """
-            Asynchronous no-op that ignores all positional and keyword arguments.
-
-            Returns:
-                None: Always returns None.
-            """
+        def _noop(*_args, **_kwargs):
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -4717,13 +4711,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address sleeps after a successful disconnect."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
-            """
-            Asynchronous no-op that ignores all positional and keyword arguments.
-
-            Returns:
-                None: Always returns None.
-            """
+        def _noop(*_args, **_kwargs):
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
@@ -4754,17 +4742,14 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address warns after repeated disconnect timeouts."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
-            """
-            Asynchronous no-op that ignores all positional and keyword arguments.
-
-            Returns:
-                None: Always returns None.
-            """
-            return None
+        class _ImmediateAwaitable:
+            def __await__(self):
+                if False:  # pragma: no cover
+                    yield
+                return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
-        mock_sleep.side_effect = _noop
+        mock_sleep.return_value = None
 
         def _timeout_wait_for(awaitable, timeout=None):
             if inspect.iscoroutine(awaitable):
@@ -4775,7 +4760,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = True
-        mock_client.disconnect = Mock(side_effect=_noop)
+        mock_client.disconnect = Mock(return_value=_ImmediateAwaitable())
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -4800,24 +4785,27 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address handles unexpected disconnect errors."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _sleep_noop(*_args, **_kwargs):
-            """Async no-op used for mocked asyncio.sleep."""
-            return None
+        class _ImmediateAwaitable:
+            def __await__(self):
+                if False:  # pragma: no cover
+                    yield
+                return None
 
-        def _disconnect_noop(*_args, **_kwargs):
-            """Sync no-op used for mocked disconnect calls."""
-            return None
+        def _timeout_wait_for(awaitable, timeout=None):
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise asyncio.TimeoutError()
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
-        mock_sleep.side_effect = _sleep_noop
-        mock_wait_for.side_effect = lambda awaitable, timeout=None: awaitable
+        mock_sleep.return_value = None
+        mock_wait_for.side_effect = _timeout_wait_for
         # Force an exception outside the inner retry loop to cover the
         # best-effort cleanup exception path.
         mock_logger.warning.side_effect = ValueError("forced warning failure")
 
         mock_client = Mock()
         mock_client.is_connected = True
-        mock_client.disconnect = Mock(side_effect=_disconnect_noop)
+        mock_client.disconnect = Mock(return_value=_ImmediateAwaitable())
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -4844,14 +4832,11 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Test _disconnect_ble_by_address logs when cleanup disconnect times out."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
-            """
-            Asynchronous no-op that ignores all positional and keyword arguments.
-
-            Returns:
-                None: Always returns None.
-            """
-            return None
+        class _ImmediateAwaitable:
+            def __await__(self):
+                if False:  # pragma: no cover
+                    yield
+                return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")
 
@@ -4864,7 +4849,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
 
         mock_client = Mock()
         mock_client.is_connected = False
-        mock_client.disconnect = Mock(side_effect=_noop)
+        mock_client.disconnect = Mock(return_value=_ImmediateAwaitable())
         mock_bleak.return_value = mock_client
 
         _disconnect_ble_by_address("AA:BB:CC:DD:EE:FF")
@@ -4961,7 +4946,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         """Repeated BLE disconnect errors should log the final failure warning."""
         from mmrelay.meshtastic_utils import _disconnect_ble_by_address
 
-        async def _noop(*_args, **_kwargs):
+        def _noop(*_args, **_kwargs):
             return None
 
         mock_get_running_loop.side_effect = RuntimeError("no loop")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -3338,7 +3338,7 @@ class TestAsyncHelperUtilities(unittest.TestCase):
 
         fake_task = self._ExceptionTask(raise_exc=asyncio.CancelledError())
 
-        def _submit(coro, loop=None):
+        def _submit(coro, loop=None) -> Any:
             coro.close()
             return fake_task
 
@@ -3361,7 +3361,7 @@ class TestAsyncHelperUtilities(unittest.TestCase):
 
         fake_task = self._ExceptionTask(raise_exc=RuntimeError("boom"))
 
-        def _submit(coro, loop=None):
+        def _submit(coro, loop=None) -> Any:
             coro.close()
             return fake_task
 
@@ -3384,7 +3384,7 @@ class TestAsyncHelperUtilities(unittest.TestCase):
 
         fake_task = self._ExceptionTask(return_exc=ValueError("Task failed"))
 
-        def _submit(coro, loop=None):
+        def _submit(coro, loop=None) -> Any:
             coro.close()
             return fake_task
 
@@ -3411,7 +3411,7 @@ class TestAsyncHelperUtilities(unittest.TestCase):
 
         fake_task = self._ExceptionTask(return_exc=asyncio.CancelledError())
 
-        def _submit(coro, loop=None):
+        def _submit(coro, loop=None) -> Any:
             coro.close()
             return fake_task
 
@@ -4982,7 +4982,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mock_future.done.return_value = False
         mock_future.result = Mock(side_effect=FuturesTimeoutError())
 
-        def _submit(coro, _loop):
+        def _submit(coro, _loop) -> Any:
             coro.close()
             return mock_future
 
@@ -5052,7 +5052,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         mock_future = Mock()
         mock_future.result.return_value = None
 
-        def _submit(coro, _loop):
+        def _submit(coro, _loop) -> Any:
             coro.close()
             return mock_future
 

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -4467,17 +4467,13 @@ class TestUncoveredMeshtasticUtils(unittest.TestCase):
         with patch("mmrelay.meshtastic_utils.connect_meshtastic") as mock_connect:
             # Run the async function - it should exit immediately due to shutting_down=True
             loop = asyncio.new_event_loop()
-            policy = asyncio.get_event_loop_policy()
-            previous_loop = None
-            try:
-                previous_loop = policy.get_event_loop()
-            except RuntimeError:
-                pass
-            policy.set_event_loop(loop)
             try:
                 result = loop.run_until_complete(reconnect())
             finally:
-                policy.set_event_loop(previous_loop)
+                with contextlib.suppress(RuntimeError):
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                with contextlib.suppress(RuntimeError, AttributeError):
+                    loop.run_until_complete(loop.shutdown_default_executor())
                 loop.close()
 
             # Should not have attempted connection since shutting_down is True
@@ -4495,17 +4491,13 @@ class TestUncoveredMeshtasticUtils(unittest.TestCase):
 
         # Run the async function with no config
         loop = asyncio.new_event_loop()
-        policy = asyncio.get_event_loop_policy()
-        previous_loop = None
-        try:
-            previous_loop = policy.get_event_loop()
-        except RuntimeError:
-            pass
-        policy.set_event_loop(loop)
         try:
             result = loop.run_until_complete(check_connection())
         finally:
-            policy.set_event_loop(previous_loop)
+            with contextlib.suppress(RuntimeError):
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            with contextlib.suppress(RuntimeError, AttributeError):
+                loop.run_until_complete(loop.shutdown_default_executor())
             loop.close()
 
         # Should return None when no config available

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -4640,7 +4640,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _noop(*_args: object, **_kwargs: object) -> None:
             """
             Synchronous no-op callable that accepts any positional and keyword arguments and does nothing.
-            
+
             Used as a replacement/mock for synchronous disconnect functions in tests; ignores all inputs and returns None.
             """
 
@@ -4669,7 +4669,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _noop(*_args: object, **_kwargs: object) -> None:
             """
             Synchronous no-op callable that accepts any positional and keyword arguments and does nothing.
-            
+
             Used as a replacement/mock for synchronous disconnect functions in tests; ignores all inputs and returns None.
             """
 
@@ -4696,7 +4696,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _noop(*_args: object, **_kwargs: object) -> None:
             """
             No-operation callable that accepts and ignores all positional and keyword arguments.
-            
+
             Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
             """
             pass
@@ -4726,7 +4726,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _noop(*_args: object, **_kwargs: object) -> None:
             """
             No-operation callable that accepts and ignores all positional and keyword arguments.
-            
+
             Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
             """
             pass
@@ -4763,7 +4763,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             def __await__(self) -> Generator[Any, None, None]:
                 """
                 Expose this object as awaitable by providing its awaiting generator.
-                
+
                 Returns:
                     Generator: A generator used by the `await` expression; it yields control to the event loop and produces no value.
                 """
@@ -4776,12 +4776,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
             """
             Close the given awaitable if it is a coroutine, then raise an asyncio.TimeoutError.
-            
+
             Parameters:
-            	awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
-            
+                awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
+
             Raises:
-            	asyncio.TimeoutError: Always raised by this function.
+                asyncio.TimeoutError: Always raised by this function.
             """
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
@@ -4820,7 +4820,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             def __await__(self) -> Generator[Any, None, None]:
                 """
                 Expose this object as awaitable by providing its awaiting generator.
-                
+
                 Returns:
                     Generator: A generator used by the `await` expression; it yields control to the event loop and produces no value.
                 """
@@ -4830,12 +4830,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
             """
             Close the given awaitable if it is a coroutine, then raise an asyncio.TimeoutError.
-            
+
             Parameters:
-            	awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
-            
+                awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
+
             Raises:
-            	asyncio.TimeoutError: Always raised by this function.
+                asyncio.TimeoutError: Always raised by this function.
             """
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
@@ -4881,7 +4881,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
             def __await__(self) -> Generator[Any, None, None]:
                 """
                 Expose this object as awaitable by providing its awaiting generator.
-                
+
                 Returns:
                     Generator: A generator used by the `await` expression; it yields control to the event loop and produces no value.
                 """
@@ -4893,12 +4893,12 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _timeout_wait_for(awaitable: object, **_kwargs: object) -> NoReturn:
             """
             Close the given awaitable if it is a coroutine, then raise an asyncio.TimeoutError.
-            
+
             Parameters:
-            	awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
-            
+                awaitable (object): The awaitable or coroutine to be closed; if it is a coroutine, it will be closed to free resources.
+
             Raises:
-            	asyncio.TimeoutError: Always raised by this function.
+                asyncio.TimeoutError: Always raised by this function.
             """
             if inspect.iscoroutine(awaitable):
                 awaitable.close()
@@ -5008,7 +5008,7 @@ class TestUncoveredMeshtasticUtilsPaths(unittest.TestCase):
         def _noop(*_args: object, **_kwargs: object) -> None:
             """
             No-operation callable that accepts and ignores all positional and keyword arguments.
-            
+
             Used as a generic placeholder callback or side-effect (for example, in mocks, timers, or disconnect helpers).
             """
             pass

--- a/tests/test_meshtastic_utils_coverage.py
+++ b/tests/test_meshtastic_utils_coverage.py
@@ -62,6 +62,7 @@ def reset_meshtastic_state(reset_meshtastic_globals):
     timeouts, health-probe tracking, clock skew/drain timers, and degraded/executor orphan counters)
     so tests run with a deterministic, isolated environment.
     """
+    _ = reset_meshtastic_globals
     # Additional resets specific to these tests
     mu.meshtastic_iface = None
     mu._metadata_future = None

--- a/tests/test_meshtastic_utils_coverage.py
+++ b/tests/test_meshtastic_utils_coverage.py
@@ -35,13 +35,13 @@ from tests.constants import TEST_BLE_MAC
 def _submit_done_reconnect_future(coro: object, _loop: object) -> Future[None]:
     """
     Create and return an already-completed Future after optionally closing a coroutine-like object.
-    
+
     If `coro` has a callable `close()` attribute, it will be invoked before creating the completed Future.
-    
+
     Parameters:
         coro: An object that may represent a coroutine; `close()` will be called if present and callable.
         _loop: Unused placeholder for an event loop (kept for compatibility).
-    
+
     Returns:
         A Future already completed with the value `None`.
     """
@@ -57,7 +57,7 @@ def _submit_done_reconnect_future(coro: object, _loop: object) -> Future[None]:
 def reset_meshtastic_state(reset_meshtastic_globals):
     """
     Reset mmrelay.meshtastic_utils module state to a clean baseline before each test.
-    
+
     Clears module-level globals used by the meshtastic relay (executors, futures, BLE state,
     timeouts, health-probe tracking, clock skew/drain timers, and degraded/executor orphan counters)
     so tests run with a deterministic, isolated environment.

--- a/tests/test_meshtastic_utils_coverage.py
+++ b/tests/test_meshtastic_utils_coverage.py
@@ -32,6 +32,15 @@ from mmrelay.constants.network import (
 from tests.constants import TEST_BLE_MAC
 
 
+def _submit_done_reconnect_future(coro: object, _loop: object) -> Future[None]:
+    close = getattr(coro, "close", None)
+    if callable(close):
+        close()
+    done_future: Future[None] = Future()
+    done_future.set_result(None)
+    return done_future
+
+
 @pytest.fixture(autouse=True)
 def reset_meshtastic_state(reset_meshtastic_globals):
     """Ensure clean state for each test."""
@@ -1683,28 +1692,21 @@ class TestConnectionLostHandlerClearingStaleBleFuture:
         mu.event_loop.is_closed.return_value = False
         mu.reconnecting = False
 
-        def _submit_reconnect_coro(coro, _loop):
-            close = getattr(coro, "close", None)
-            if callable(close):
-                close()
-            done_future = Mock(spec=Future)
-            done_future.cancel.return_value = True
-            done_future.done.return_value = True
-            return done_future
-
-        with patch("mmrelay.meshtastic_utils.reconnect"):
-            with patch(
+        with (
+            patch("mmrelay.meshtastic_utils.reconnect"),
+            patch(
                 "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
-                side_effect=_submit_reconnect_coro,
-            ):
-                with patch("mmrelay.meshtastic_utils.logger"):
-                    mu.on_lost_meshtastic_connection(detection_source="test source")
+                side_effect=_submit_done_reconnect_future,
+            ),
+            patch("mmrelay.meshtastic_utils.logger"),
+        ):
+            mu.on_lost_meshtastic_connection(detection_source="test source")
 
-                    assert mu._ble_future is None
-                    assert mu._ble_future_address is None
-                    assert mu._ble_future_started_at is None
-                    assert mu._ble_future_timeout_secs is None
-                    assert TEST_BLE_MAC not in mu._ble_timeout_counts
+            assert mu._ble_future is None
+            assert mu._ble_future_address is None
+            assert mu._ble_future_started_at is None
+            assert mu._ble_future_timeout_secs is None
+            assert TEST_BLE_MAC not in mu._ble_timeout_counts
 
     def test_on_lost_meshtastic_connection_clears_ble_timeout_counts(self):
         """Test _ble_timeout_counts is popped for the address."""
@@ -1721,25 +1723,18 @@ class TestConnectionLostHandlerClearingStaleBleFuture:
         mu.event_loop.is_closed.return_value = False
         mu.reconnecting = False
 
-        def _submit_reconnect_coro(coro, _loop):
-            close = getattr(coro, "close", None)
-            if callable(close):
-                close()
-            done_future = Mock(spec=Future)
-            done_future.cancel.return_value = True
-            done_future.done.return_value = True
-            return done_future
-
-        with patch("mmrelay.meshtastic_utils.reconnect"):
-            with patch(
+        with (
+            patch("mmrelay.meshtastic_utils.reconnect"),
+            patch(
                 "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
-                side_effect=_submit_reconnect_coro,
-            ):
-                with patch("mmrelay.meshtastic_utils.logger"):
-                    mu.on_lost_meshtastic_connection(detection_source="test source")
+                side_effect=_submit_done_reconnect_future,
+            ),
+            patch("mmrelay.meshtastic_utils.logger"),
+        ):
+            mu.on_lost_meshtastic_connection(detection_source="test source")
 
-                    assert "11:22:33:44:55:66" not in mu._ble_timeout_counts
-                    assert mu._ble_timeout_counts["OTHER:ADDRESS"] == 3
+            assert "11:22:33:44:55:66" not in mu._ble_timeout_counts
+            assert mu._ble_timeout_counts["OTHER:ADDRESS"] == 3
 
 
 class TestMetadataExecutorDegradedState:
@@ -1930,27 +1925,20 @@ class TestReconnectResetsDegradedStateWithoutDeadlock:
         mu.reconnecting = False
         mu.shutting_down = False
 
-        def _submit_reconnect_coro(coro, _loop):
-            close = getattr(coro, "close", None)
-            if callable(close):
-                close()
-            done_future = Mock(spec=Future)
-            done_future.cancel.return_value = True
-            done_future.done.return_value = True
-            return done_future
-
-        with patch("mmrelay.meshtastic_utils.reconnect"):
-            with patch(
+        with (
+            patch("mmrelay.meshtastic_utils.reconnect"),
+            patch(
                 "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
-                side_effect=_submit_reconnect_coro,
-            ):
-                with patch("mmrelay.meshtastic_utils.logger"):
-                    mu.on_lost_meshtastic_connection(detection_source="test source")
+                side_effect=_submit_done_reconnect_future,
+            ),
+            patch("mmrelay.meshtastic_utils.logger"),
+        ):
+            mu.on_lost_meshtastic_connection(detection_source="test source")
 
-                    assert len(mu._ble_executor_degraded_addresses) == 0
-                    assert len(mu._ble_executor_orphaned_workers_by_address) == 0
-                    assert mu._metadata_executor_degraded is False
-                assert mu._metadata_executor_orphaned_workers == 0
+            assert len(mu._ble_executor_degraded_addresses) == 0
+            assert len(mu._ble_executor_orphaned_workers_by_address) == 0
+            assert mu._metadata_executor_degraded is False
+        assert mu._metadata_executor_orphaned_workers == 0
 
 
 class TestShutdownClearsDegradedState:

--- a/tests/test_meshtastic_utils_coverage.py
+++ b/tests/test_meshtastic_utils_coverage.py
@@ -1957,7 +1957,7 @@ class TestReconnectResetsDegradedStateWithoutDeadlock:
             assert len(mu._ble_executor_degraded_addresses) == 0
             assert len(mu._ble_executor_orphaned_workers_by_address) == 0
             assert mu._metadata_executor_degraded is False
-        assert mu._metadata_executor_orphaned_workers == 0
+            assert mu._metadata_executor_orphaned_workers == 0
 
 
 class TestShutdownClearsDegradedState:

--- a/tests/test_meshtastic_utils_coverage.py
+++ b/tests/test_meshtastic_utils_coverage.py
@@ -1683,15 +1683,28 @@ class TestConnectionLostHandlerClearingStaleBleFuture:
         mu.event_loop.is_closed.return_value = False
         mu.reconnecting = False
 
-        with patch("mmrelay.meshtastic_utils.reconnect"):
-            with patch("mmrelay.meshtastic_utils.logger"):
-                mu.on_lost_meshtastic_connection(detection_source="test source")
+        def _submit_reconnect_coro(coro, _loop):
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            done_future = Mock(spec=Future)
+            done_future.cancel.return_value = True
+            done_future.done.return_value = True
+            return done_future
 
-                assert mu._ble_future is None
-                assert mu._ble_future_address is None
-                assert mu._ble_future_started_at is None
-                assert mu._ble_future_timeout_secs is None
-                assert TEST_BLE_MAC not in mu._ble_timeout_counts
+        with patch("mmrelay.meshtastic_utils.reconnect"):
+            with patch(
+                "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
+                side_effect=_submit_reconnect_coro,
+            ):
+                with patch("mmrelay.meshtastic_utils.logger"):
+                    mu.on_lost_meshtastic_connection(detection_source="test source")
+
+                    assert mu._ble_future is None
+                    assert mu._ble_future_address is None
+                    assert mu._ble_future_started_at is None
+                    assert mu._ble_future_timeout_secs is None
+                    assert TEST_BLE_MAC not in mu._ble_timeout_counts
 
     def test_on_lost_meshtastic_connection_clears_ble_timeout_counts(self):
         """Test _ble_timeout_counts is popped for the address."""
@@ -1708,12 +1721,25 @@ class TestConnectionLostHandlerClearingStaleBleFuture:
         mu.event_loop.is_closed.return_value = False
         mu.reconnecting = False
 
-        with patch("mmrelay.meshtastic_utils.reconnect"):
-            with patch("mmrelay.meshtastic_utils.logger"):
-                mu.on_lost_meshtastic_connection(detection_source="test source")
+        def _submit_reconnect_coro(coro, _loop):
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            done_future = Mock(spec=Future)
+            done_future.cancel.return_value = True
+            done_future.done.return_value = True
+            return done_future
 
-                assert "11:22:33:44:55:66" not in mu._ble_timeout_counts
-                assert mu._ble_timeout_counts["OTHER:ADDRESS"] == 3
+        with patch("mmrelay.meshtastic_utils.reconnect"):
+            with patch(
+                "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
+                side_effect=_submit_reconnect_coro,
+            ):
+                with patch("mmrelay.meshtastic_utils.logger"):
+                    mu.on_lost_meshtastic_connection(detection_source="test source")
+
+                    assert "11:22:33:44:55:66" not in mu._ble_timeout_counts
+                    assert mu._ble_timeout_counts["OTHER:ADDRESS"] == 3
 
 
 class TestMetadataExecutorDegradedState:
@@ -1904,13 +1930,26 @@ class TestReconnectResetsDegradedStateWithoutDeadlock:
         mu.reconnecting = False
         mu.shutting_down = False
 
-        with patch("mmrelay.meshtastic_utils.reconnect"):
-            with patch("mmrelay.meshtastic_utils.logger"):
-                mu.on_lost_meshtastic_connection(detection_source="test source")
+        def _submit_reconnect_coro(coro, _loop):
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            done_future = Mock(spec=Future)
+            done_future.cancel.return_value = True
+            done_future.done.return_value = True
+            return done_future
 
-                assert len(mu._ble_executor_degraded_addresses) == 0
-                assert len(mu._ble_executor_orphaned_workers_by_address) == 0
-                assert mu._metadata_executor_degraded is False
+        with patch("mmrelay.meshtastic_utils.reconnect"):
+            with patch(
+                "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
+                side_effect=_submit_reconnect_coro,
+            ):
+                with patch("mmrelay.meshtastic_utils.logger"):
+                    mu.on_lost_meshtastic_connection(detection_source="test source")
+
+                    assert len(mu._ble_executor_degraded_addresses) == 0
+                    assert len(mu._ble_executor_orphaned_workers_by_address) == 0
+                    assert mu._metadata_executor_degraded is False
                 assert mu._metadata_executor_orphaned_workers == 0
 
 

--- a/tests/test_meshtastic_utils_coverage.py
+++ b/tests/test_meshtastic_utils_coverage.py
@@ -33,6 +33,18 @@ from tests.constants import TEST_BLE_MAC
 
 
 def _submit_done_reconnect_future(coro: object, _loop: object) -> Future[None]:
+    """
+    Create and return an already-completed Future after optionally closing a coroutine-like object.
+    
+    If `coro` has a callable `close()` attribute, it will be invoked before creating the completed Future.
+    
+    Parameters:
+        coro: An object that may represent a coroutine; `close()` will be called if present and callable.
+        _loop: Unused placeholder for an event loop (kept for compatibility).
+    
+    Returns:
+        A Future already completed with the value `None`.
+    """
     close = getattr(coro, "close", None)
     if callable(close):
         close()
@@ -43,7 +55,13 @@ def _submit_done_reconnect_future(coro: object, _loop: object) -> Future[None]:
 
 @pytest.fixture(autouse=True)
 def reset_meshtastic_state(reset_meshtastic_globals):
-    """Ensure clean state for each test."""
+    """
+    Reset mmrelay.meshtastic_utils module state to a clean baseline before each test.
+    
+    Clears module-level globals used by the meshtastic relay (executors, futures, BLE state,
+    timeouts, health-probe tracking, clock skew/drain timers, and degraded/executor orphan counters)
+    so tests run with a deterministic, isolated environment.
+    """
     # Additional resets specific to these tests
     mu.meshtastic_iface = None
     mu._metadata_future = None

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -16,7 +16,6 @@ import asyncio
 import os
 import sys
 import unittest
-from concurrent.futures import Future
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
 from typing import NoReturn
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
@@ -77,7 +76,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     def setUp(self):
         """
         Reset mmrelay.meshtastic_utils module-level state to known defaults for tests.
-        
+
         Sets the following globals to default test values so each test runs in isolation:
         - meshtastic_client: None
         - _relay_active_client_id: None
@@ -296,8 +295,6 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         mock_interface = MagicMock()
 
-        from concurrent.futures import Future
-
         def _submit_coro_mock(coro, loop=None):
             """
             Run an awaitable immediately and return a concurrent.futures.Future completed with its outcome.
@@ -389,10 +386,10 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         ) -> "_DummyFuture":
             """
             Close the provided coroutine if one is given and return a shared dummy future.
-            
+
             Parameters:
                 coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
-            
+
             Returns:
                 _DummyFuture: The preconstructed shared future object `future`.
             """
@@ -458,10 +455,10 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         ) -> "_DummyFuture":
             """
             Close the provided coroutine if one is given and return a shared dummy future.
-            
+
             Parameters:
                 coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
-            
+
             Returns:
                 _DummyFuture: The preconstructed shared future object `future`.
             """
@@ -543,10 +540,10 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             def _submit_raises(coro: object, **_kwargs: object) -> NoReturn:
                 """
                 Close the given coroutine (if one) and unconditionally raise an exception indicating matrix relay failure.
-                
+
                 Parameters:
                     coro: A coroutine or any object; if `coro` is a coroutine it will be closed before raising.
-                
+
                 Raises:
                     Exception: Always raised with the message "Matrix relay failed".
                 """
@@ -742,15 +739,13 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             }
         mock_interface.nodes = large_nodes
 
-        from concurrent.futures import Future
-
         def _done_future(coro: object, **_kwargs: object) -> Future[None]:
             """
             Return a Future already completed with result None.
-            
+
             Parameters:
                 coro (object): The coroutine or object that was intended to run; if it is a coroutine, it will be closed.
-            
+
             Returns:
                 concurrent.futures.Future: A Future completed with a result of `None`.
             """
@@ -829,10 +824,10 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         ) -> "_DummyFuture":
             """
             Close the provided coroutine if one is given and return a shared dummy future.
-            
+
             Parameters:
                 coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
-            
+
             Returns:
                 _DummyFuture: The preconstructed shared future object `future`.
             """
@@ -903,10 +898,10 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         ) -> "_DummyFuture":
             """
             Close the provided coroutine if one is given and return a shared dummy future.
-            
+
             Parameters:
                 coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
-            
+
             Returns:
                 _DummyFuture: The preconstructed shared future object `future`.
             """
@@ -981,10 +976,10 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         ) -> "_DummyFuture":
             """
             Close the provided coroutine if one is given and return a shared dummy future.
-            
+
             Parameters:
                 coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
-            
+
             Returns:
                 _DummyFuture: The preconstructed shared future object `future`.
             """

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -103,6 +103,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         mmrelay.meshtastic_utils.reconnect_task = None
         mmrelay.meshtastic_utils.subscribed_to_messages = False
         mmrelay.meshtastic_utils.subscribed_to_connection_lost = False
+        mmrelay.meshtastic_utils._callbacks_tearing_down = False
 
     def test_serial_port_exists_permission_error(self):
         """
@@ -375,11 +376,16 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         }
         rooms = [{"meshtastic_channel": 0, "id": "!room:matrix"}]
 
+        def _submit_with_timeout_future(coro, loop=None):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            return future
+
         with (
             patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]),
             patch(
                 "mmrelay.meshtastic_utils._submit_coro",
-                side_effect=[future, MagicMock()],
+                side_effect=_submit_with_timeout_future,
             ) as mock_submit_coro,
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", rooms),
@@ -428,11 +434,16 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         }
         rooms = [{"meshtastic_channel": 0, "id": "!room:matrix"}]
 
+        def _submit_with_timeout_future(coro, loop=None):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            return future
+
         with (
             patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]),
             patch(
                 "mmrelay.meshtastic_utils._submit_coro",
-                side_effect=[future, MagicMock()],
+                side_effect=_submit_with_timeout_future,
             ) as mock_submit_coro,
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", rooms),
@@ -686,7 +697,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         from concurrent.futures import Future
 
-        def _done_future(*args, **kwargs):
+        def _done_future(coro, loop=None):
             """
             Create and return a Future already completed with result None.
 
@@ -695,6 +706,8 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             Returns:
                 concurrent.futures.Future: A Future whose result is set to `None`.
             """
+            if asyncio.iscoroutine(coro):
+                coro.close()
             f = Future()
             f.set_result(None)
             return f
@@ -762,9 +775,17 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "matrix_rooms": [{"meshtastic_channel": 0, "id": "!room:matrix"}],
         }
 
+        def _submit_with_timeout_future(coro, loop=None):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            return future
+
         with (
             patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]),
-            patch("mmrelay.meshtastic_utils._submit_coro", return_value=future),
+            patch(
+                "mmrelay.meshtastic_utils._submit_coro",
+                side_effect=_submit_with_timeout_future,
+            ),
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", config["matrix_rooms"]),
             patch("mmrelay.meshtastic_utils.get_longname", return_value="TestNode"),
@@ -819,9 +840,17 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "matrix_rooms": [{"meshtastic_channel": 0, "id": "!room:matrix"}],
         }
 
+        def _submit_with_timeout_future(coro, loop=None):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            return future
+
         with (
             patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]),
-            patch("mmrelay.meshtastic_utils._submit_coro", return_value=future),
+            patch(
+                "mmrelay.meshtastic_utils._submit_coro",
+                side_effect=_submit_with_timeout_future,
+            ),
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", config["matrix_rooms"]),
             patch("mmrelay.meshtastic_utils.get_longname", return_value="TestNode"),
@@ -880,9 +909,17 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "matrix_rooms": [{"meshtastic_channel": 0, "id": "!room:matrix"}],
         }
 
+        def _submit_with_timeout_future(coro, loop=None):
+            if asyncio.iscoroutine(coro):
+                coro.close()
+            return future
+
         with (
             patch("mmrelay.plugin_loader.load_plugins", return_value=[plugin]),
-            patch("mmrelay.meshtastic_utils._submit_coro", return_value=future),
+            patch(
+                "mmrelay.meshtastic_utils._submit_coro",
+                side_effect=_submit_with_timeout_future,
+            ),
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", config["matrix_rooms"]),
             patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -16,7 +16,9 @@ import asyncio
 import os
 import sys
 import unittest
+from concurrent.futures import Future
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
+from typing import NoReturn
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 from meshtastic.mesh_interface import BROADCAST_NUM
@@ -379,7 +381,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         }
         rooms = [{"meshtastic_channel": 0, "id": "!room:matrix"}]
 
-        def _submit_with_timeout_future(coro, loop=None):
+        def _submit_with_timeout_future(
+            coro: object, **_kwargs: object
+        ) -> "_DummyFuture":
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -437,7 +441,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         }
         rooms = [{"meshtastic_channel": 0, "id": "!room:matrix"}]
 
-        def _submit_with_timeout_future(coro, loop=None):
+        def _submit_with_timeout_future(
+            coro: object, **_kwargs: object
+        ) -> "_DummyFuture":
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -513,7 +519,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             }
             mmrelay.meshtastic_utils.event_loop = MagicMock()
 
-            def _submit_raises(coro, loop=None):
+            def _submit_raises(coro: object, **_kwargs: object) -> NoReturn:
                 if asyncio.iscoroutine(coro):
                     coro.close()
                 raise Exception("Matrix relay failed")
@@ -708,7 +714,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         from concurrent.futures import Future
 
-        def _done_future(coro, loop=None):
+        def _done_future(coro: object, **_kwargs: object) -> Future[None]:
             """
             Create and return a Future already completed with result None.
 
@@ -787,7 +793,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "matrix_rooms": [{"meshtastic_channel": 0, "id": "!room:matrix"}],
         }
 
-        def _submit_with_timeout_future(coro, loop=None):
+        def _submit_with_timeout_future(
+            coro: object, **_kwargs: object
+        ) -> "_DummyFuture":
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -850,7 +858,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "matrix_rooms": [{"meshtastic_channel": 0, "id": "!room:matrix"}],
         }
 
-        def _submit_with_timeout_future(coro, loop=None):
+        def _submit_with_timeout_future(
+            coro: object, **_kwargs: object
+        ) -> "_DummyFuture":
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -917,7 +927,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "matrix_rooms": [{"meshtastic_channel": 0, "id": "!room:matrix"}],
         }
 
-        def _submit_with_timeout_future(coro, loop=None):
+        def _submit_with_timeout_future(
+            coro: object, **_kwargs: object
+        ) -> "_DummyFuture":
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -297,6 +297,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         mock_interface = MagicMock()
 
+        class _PluginFailure(RuntimeError):
+            """Test-specific plugin failure."""
+
         def _submit_coro_mock(coro, loop=None):
             """
             Run an awaitable immediately and return a concurrent.futures.Future completed with its outcome.
@@ -315,7 +318,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
                 # Execute the coroutine to trigger the exception
                 result = asyncio.run(coro)
                 f.set_result(result)
-            except Exception as e:
+            except _PluginFailure as e:
                 f.set_exception(e)
             finally:
                 if asyncio.iscoroutine(coro):
@@ -330,7 +333,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             mock_plugin = MagicMock()
             mock_plugin.plugin_name = "test_plugin"
             mock_plugin.handle_meshtastic_message = AsyncMock(
-                side_effect=Exception("Plugin failed")
+                side_effect=_PluginFailure("Plugin failed")
             )
             mock_load_plugins.return_value = [mock_plugin]
             mock_submit_coro.side_effect = _submit_coro_mock
@@ -539,19 +542,22 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             }
             mmrelay.meshtastic_utils.event_loop = MagicMock()
 
+            class _MatrixRelayFailure(RuntimeError):
+                """Test-specific Matrix relay failure."""
+
             def _submit_raises(coro: object, **_kwargs: object) -> NoReturn:
                 """
-                Close the given coroutine (if one) and unconditionally raise an exception indicating matrix relay failure.
+                Close the given coroutine (if one) and raise Matrix relay failure.
 
                 Parameters:
-                    coro: A coroutine or any object; if `coro` is a coroutine it will be closed before raising.
+                    coro: A coroutine or any object; if coroutine it will be closed before raising.
 
                 Raises:
-                    Exception: Always raised with the message "Matrix relay failed".
+                    _MatrixRelayFailure: Always raised.
                 """
                 if asyncio.iscoroutine(coro):
                     coro.close()
-                raise Exception("Matrix relay failed")
+                raise _MatrixRelayFailure("Matrix relay failed")
 
             mock_submit_coro.side_effect = _submit_raises
             on_meshtastic_message(packet, mock_interface)

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -557,7 +557,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
                 """
                 if asyncio.iscoroutine(coro):
                     coro.close()
-                raise _MatrixRelayFailure("Matrix relay failed")
+                raise _MatrixRelayFailure
 
             mock_submit_coro.side_effect = _submit_raises
             on_meshtastic_message(packet, mock_interface)

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -16,6 +16,7 @@ import asyncio
 import os
 import sys
 import unittest
+from concurrent.futures import Future as FuturesFuture
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
 from typing import NoReturn
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
@@ -44,34 +45,35 @@ from mmrelay.meshtastic_utils import (
 )
 
 
+class _DummyFuture:
+    """Helper class to simulate a future that records timeout values and raises an exception."""
+
+    def __init__(self, exc: BaseException) -> None:
+        """
+        Initialize the object with an exception and an empty call history.
+
+        Parameters:
+            exc (BaseException): The exception instance to store for later inspection or re-raising.
+        """
+        self.exc = exc
+        self.calls: list[float | None] = []
+
+    def result(self, timeout: float | None = None) -> None:
+        """
+        Record the provided timeout value and raise the stored exception.
+
+        Parameters:
+            timeout (float | None): Timeout passed in; appended to self.calls for later inspection.
+
+        Raises:
+            Any: Re-raising the exception stored in self.exc.
+        """
+        self.calls.append(timeout)
+        raise self.exc
+
+
 class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
     """Test cases for Meshtastic utilities edge cases and error handling."""
-
-    class _DummyFuture:
-        """Helper class to simulate a future that records timeout values and raises an exception."""
-
-        def __init__(self, exc: BaseException) -> None:
-            """
-            Initialize the object with an exception and an empty call history.
-
-            Parameters:
-                exc (BaseException): The exception instance to store for later inspection or re-raising.
-            """
-            self.exc = exc
-            self.calls: list[float | None] = []
-
-        def result(self, timeout: float | None = None) -> None:
-            """
-            Record the provided timeout value and raise the stored exception.
-
-            Parameters:
-                timeout (float | None): Timeout passed in; appended to self.calls for later inspection.
-
-            Raises:
-                Any: Re-raises the exception stored in self.exc.
-            """
-            self.calls.append(timeout)
-            raise self.exc
 
     def setUp(self):
         """
@@ -308,7 +310,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             Returns:
                 concurrent.futures.Future: A Future already completed with the coroutine's result or exception.
             """
-            f = Future()
+            f = FuturesFuture()
             try:
                 # Execute the coroutine to trigger the exception
                 result = asyncio.run(coro)
@@ -366,7 +368,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         interface.nodes = {}
 
         timeout_exc = ConcurrentTimeoutError("Plugin timeout")
-        future = self._DummyFuture(timeout_exc)
+        future = _DummyFuture(timeout_exc)
 
         plugin = MagicMock()
         plugin.plugin_name = "timeout_plugin"
@@ -435,7 +437,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         interface.nodes = {}
 
         timeout_exc = ConcurrentTimeoutError("Plugin timeout")
-        future = self._DummyFuture(timeout_exc)
+        future = _DummyFuture(timeout_exc)
 
         plugin = MagicMock()
         plugin.plugin_name = "timeout_plugin"
@@ -739,7 +741,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             }
         mock_interface.nodes = large_nodes
 
-        def _done_future(coro: object, **_kwargs: object) -> Future[None]:
+        def _done_future(coro: object, **_kwargs: object) -> FuturesFuture[None]:
             """
             Return a Future already completed with result None.
 
@@ -751,7 +753,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             """
             if asyncio.iscoroutine(coro):
                 coro.close()
-            f = Future()
+            f = FuturesFuture()
             f.set_result(None)
             return f
 
@@ -808,7 +810,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "!12345678": {"user": {"id": "!12345678", "longName": "TestNode"}}
         }
 
-        future = self._DummyFuture(ConcurrentTimeoutError("Plugin timeout"))
+        future = _DummyFuture(ConcurrentTimeoutError("Plugin timeout"))
 
         plugin = MagicMock()
         plugin.plugin_name = "test_plugin"
@@ -882,7 +884,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         interface.myInfo = MagicMock()
         interface.myInfo.my_node_num = 12345
 
-        future = self._DummyFuture(ConcurrentTimeoutError("Plugin timeout"))
+        future = _DummyFuture(ConcurrentTimeoutError("Plugin timeout"))
 
         plugin = MagicMock()
         plugin.plugin_name = "test_plugin"
@@ -961,7 +963,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             "!12345678": {"user": {"id": "!12345678", "longName": "TestNode"}}
         }
 
-        future = self._DummyFuture(ConcurrentTimeoutError("Plugin timeout"))
+        future = _DummyFuture(ConcurrentTimeoutError("Plugin timeout"))
         plugin = MagicMock()
         plugin.plugin_name = "telemetry_plugin"
         plugin.handle_meshtastic_message = AsyncMock(return_value=True)

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -17,7 +17,7 @@ import os
 import sys
 import unittest
 from concurrent.futures import TimeoutError as ConcurrentTimeoutError
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 from meshtastic.mesh_interface import BROADCAST_NUM
 
@@ -313,6 +313,9 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
                 f.set_result(result)
             except Exception as e:
                 f.set_exception(e)
+            finally:
+                if asyncio.iscoroutine(coro):
+                    coro.close()
             return f
 
         with (
@@ -392,7 +395,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             patch("mmrelay.meshtastic_utils.get_longname", return_value="Long"),
             patch("mmrelay.meshtastic_utils.get_shortname", return_value="Short"),
             patch("mmrelay.matrix_utils.get_matrix_prefix", return_value=""),
-            patch("mmrelay.matrix_utils.matrix_relay", AsyncMock(return_value=None)),
+            patch("mmrelay.matrix_utils.matrix_relay", Mock(return_value=None)),
             patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
@@ -450,7 +453,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             patch("mmrelay.meshtastic_utils.get_longname", return_value="Long"),
             patch("mmrelay.meshtastic_utils.get_shortname", return_value="Short"),
             patch("mmrelay.matrix_utils.get_matrix_prefix", return_value=""),
-            patch("mmrelay.matrix_utils.matrix_relay", AsyncMock(return_value=None)),
+            patch("mmrelay.matrix_utils.matrix_relay", Mock(return_value=None)),
             patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
@@ -713,11 +716,12 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             return f
 
         with (
+            patch("mmrelay.plugin_loader.load_plugins", return_value=[]),
             patch("mmrelay.meshtastic_utils.logger"),
             patch("mmrelay.meshtastic_utils._submit_coro") as mock_submit_coro,
             patch("mmrelay.meshtastic_utils.is_running_as_service", return_value=True),
             patch("mmrelay.matrix_utils.matrix_client", None),
-            patch("mmrelay.matrix_utils.matrix_relay", new_callable=AsyncMock),
+            patch("mmrelay.matrix_utils.matrix_relay", Mock(return_value=None)),
         ):
             mock_submit_coro.side_effect = _done_future
             # Should handle large node lists without crashing
@@ -791,9 +795,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             patch("mmrelay.meshtastic_utils.get_longname", return_value="TestNode"),
             patch("mmrelay.meshtastic_utils.get_shortname", return_value="TN"),
             patch("mmrelay.matrix_utils.get_matrix_prefix", return_value=""),
-            patch(
-                "mmrelay.matrix_utils.matrix_relay", new_callable=AsyncMock
-            ) as mock_matrix_relay,
+            patch("mmrelay.matrix_utils.matrix_relay", Mock()) as mock_matrix_relay,
             patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
@@ -856,9 +858,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             patch("mmrelay.meshtastic_utils.get_longname", return_value="TestNode"),
             patch("mmrelay.meshtastic_utils.get_shortname", return_value="TN"),
             patch("mmrelay.matrix_utils.get_matrix_prefix", return_value=""),
-            patch(
-                "mmrelay.matrix_utils.matrix_relay", new_callable=AsyncMock
-            ) as mock_matrix_relay,
+            patch("mmrelay.matrix_utils.matrix_relay", Mock()) as mock_matrix_relay,
             patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
@@ -964,11 +964,11 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         plugin1 = MagicMock()
         plugin1.plugin_name = "first_plugin"
-        plugin1.handle_meshtastic_message = AsyncMock(return_value=False)
+        plugin1.handle_meshtastic_message = Mock(return_value=False)
 
         plugin2 = MagicMock()
         plugin2.plugin_name = "second_plugin"
-        plugin2.handle_meshtastic_message = AsyncMock(return_value=True)
+        plugin2.handle_meshtastic_message = Mock(return_value=True)
 
         config = {
             "meshtastic": {"meshnet_name": "test"},
@@ -982,9 +982,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", config["matrix_rooms"]),
             patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
-            patch(
-                "mmrelay.matrix_utils.matrix_relay", new_callable=AsyncMock
-            ) as mock_matrix_relay,
+            patch("mmrelay.matrix_utils.matrix_relay", Mock()) as mock_matrix_relay,
         ):
             on_meshtastic_message(packet, interface)
 
@@ -1021,11 +1019,11 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         plugin1 = MagicMock()
         plugin1.plugin_name = "position_plugin"
-        plugin1.handle_meshtastic_message = AsyncMock(return_value=True)
+        plugin1.handle_meshtastic_message = Mock(return_value=True)
 
         plugin2 = MagicMock()
         plugin2.plugin_name = "other_plugin"
-        plugin2.handle_meshtastic_message = AsyncMock(return_value=False)
+        plugin2.handle_meshtastic_message = Mock(return_value=False)
 
         config = {
             "meshtastic": {"meshnet_name": "test"},
@@ -1039,9 +1037,7 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             patch("mmrelay.meshtastic_utils.config", config),
             patch("mmrelay.meshtastic_utils.matrix_rooms", config["matrix_rooms"]),
             patch("mmrelay.meshtastic_utils.event_loop", MagicMock()),
-            patch(
-                "mmrelay.matrix_utils.matrix_relay", new_callable=AsyncMock
-            ) as mock_matrix_relay,
+            patch("mmrelay.matrix_utils.matrix_relay", Mock()) as mock_matrix_relay,
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
             on_meshtastic_message(packet, interface)

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -495,7 +495,10 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         with (
             patch("mmrelay.plugin_loader.load_plugins", return_value=[]),
             patch("mmrelay.meshtastic_utils._submit_coro") as mock_submit_coro,
-            patch("mmrelay.matrix_utils.matrix_relay"),
+            patch(
+                "mmrelay.matrix_utils.matrix_relay",
+                AsyncMock(return_value=None),
+            ),
             patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         ):
             # Set up required globals for the function to run
@@ -510,7 +513,12 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             }
             mmrelay.meshtastic_utils.event_loop = MagicMock()
 
-            mock_submit_coro.side_effect = Exception("Matrix relay failed")
+            def _submit_raises(coro, loop=None):
+                if asyncio.iscoroutine(coro):
+                    coro.close()
+                raise Exception("Matrix relay failed")
+
+            mock_submit_coro.side_effect = _submit_raises
             on_meshtastic_message(packet, mock_interface)
             mock_logger.exception.assert_called()
 

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -76,18 +76,21 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
     def setUp(self):
         """
-        Reset mmrelay.meshtastic_utils global state so each test runs in isolation.
-
-        Resets the following module-level variables to their default test values:
-        - meshtastic_client -> None
-        - reconnecting -> False
-        - config -> None
-        - matrix_rooms -> []
-        - shutting_down -> False
-        - event_loop -> None
-        - reconnect_task -> None
-        - subscribed_to_messages -> False
-        - subscribed_to_connection_lost -> False
+        Reset mmrelay.meshtastic_utils module-level state to known defaults for tests.
+        
+        Sets the following globals to default test values so each test runs in isolation:
+        - meshtastic_client: None
+        - _relay_active_client_id: None
+        - _relay_reconnect_prestart_bootstrap_deadline_monotonic_secs: None
+        - reconnecting: False
+        - config: None
+        - matrix_rooms: []
+        - shutting_down: False
+        - event_loop: None
+        - reconnect_task: None
+        - subscribed_to_messages: False
+        - subscribed_to_connection_lost: False
+        - _callbacks_tearing_down: False
         """
         # Reset global state
         import mmrelay.meshtastic_utils
@@ -384,6 +387,15 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         def _submit_with_timeout_future(
             coro: object, **_kwargs: object
         ) -> "_DummyFuture":
+            """
+            Close the provided coroutine if one is given and return a shared dummy future.
+            
+            Parameters:
+                coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
+            
+            Returns:
+                _DummyFuture: The preconstructed shared future object `future`.
+            """
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -444,6 +456,15 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         def _submit_with_timeout_future(
             coro: object, **_kwargs: object
         ) -> "_DummyFuture":
+            """
+            Close the provided coroutine if one is given and return a shared dummy future.
+            
+            Parameters:
+                coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
+            
+            Returns:
+                _DummyFuture: The preconstructed shared future object `future`.
+            """
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -520,6 +541,15 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
             mmrelay.meshtastic_utils.event_loop = MagicMock()
 
             def _submit_raises(coro: object, **_kwargs: object) -> NoReturn:
+                """
+                Close the given coroutine (if one) and unconditionally raise an exception indicating matrix relay failure.
+                
+                Parameters:
+                    coro: A coroutine or any object; if `coro` is a coroutine it will be closed before raising.
+                
+                Raises:
+                    Exception: Always raised with the message "Matrix relay failed".
+                """
                 if asyncio.iscoroutine(coro):
                     coro.close()
                 raise Exception("Matrix relay failed")
@@ -716,12 +746,13 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
 
         def _done_future(coro: object, **_kwargs: object) -> Future[None]:
             """
-            Create and return a Future already completed with result None.
-
-            Useful in tests to simulate an already-finished asynchronous operation.
-
+            Return a Future already completed with result None.
+            
+            Parameters:
+                coro (object): The coroutine or object that was intended to run; if it is a coroutine, it will be closed.
+            
             Returns:
-                concurrent.futures.Future: A Future whose result is set to `None`.
+                concurrent.futures.Future: A Future completed with a result of `None`.
             """
             if asyncio.iscoroutine(coro):
                 coro.close()
@@ -796,6 +827,15 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         def _submit_with_timeout_future(
             coro: object, **_kwargs: object
         ) -> "_DummyFuture":
+            """
+            Close the provided coroutine if one is given and return a shared dummy future.
+            
+            Parameters:
+                coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
+            
+            Returns:
+                _DummyFuture: The preconstructed shared future object `future`.
+            """
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -861,6 +901,15 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         def _submit_with_timeout_future(
             coro: object, **_kwargs: object
         ) -> "_DummyFuture":
+            """
+            Close the provided coroutine if one is given and return a shared dummy future.
+            
+            Parameters:
+                coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
+            
+            Returns:
+                _DummyFuture: The preconstructed shared future object `future`.
+            """
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future
@@ -930,6 +979,15 @@ class TestMeshtasticUtilsEdgeCases(unittest.TestCase):
         def _submit_with_timeout_future(
             coro: object, **_kwargs: object
         ) -> "_DummyFuture":
+            """
+            Close the provided coroutine if one is given and return a shared dummy future.
+            
+            Parameters:
+                coro: A coroutine object or any callable; if `coro` is an actual coroutine it will be closed before returning.
+            
+            Returns:
+                _DummyFuture: The preconstructed shared future object `future`.
+            """
             if asyncio.iscoroutine(coro):
                 coro.close()
             return future

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -892,7 +892,7 @@ class TestMigrateDatabase:
         with patch("sqlite3.connect") as mock_connect:
             mock_conn = MagicMock()
             mock_conn.execute.return_value.fetchone.return_value = ["corrupted"]
-            mock_connect.return_value = mock_conn
+            mock_connect.return_value.__enter__.return_value = mock_conn
 
             with pytest.raises(MigrationError, match="integrity check failed"):
                 migrate_database([legacy_root], new_home)

--- a/tests/test_migrate_coverage.py
+++ b/tests/test_migrate_coverage.py
@@ -8,6 +8,7 @@ follow pytest conventions and document the purpose of each test case.
 Inline comments explain test assertions and expected behavior for clarity.
 """
 
+import contextlib
 import os
 import shutil
 import sqlite3
@@ -229,7 +230,7 @@ class TestMigrateAdditionalCoverage:
         new_db_dir = new_home / "database"
         new_db_dir.mkdir(parents=True)
         target_db = new_db_dir / DATABASE_FILENAME
-        with sqlite3.connect(target_db):
+        with contextlib.closing(sqlite3.connect(target_db)):
             pass
 
         symlink_root = tmp_path / "symlink_root"
@@ -259,13 +260,13 @@ class TestMigrateAdditionalCoverage:
         legacy_root_old = tmp_path / "legacy_old"
         legacy_root_old.mkdir()
         old_db = legacy_root_old / DATABASE_FILENAME
-        with sqlite3.connect(old_db):
+        with contextlib.closing(sqlite3.connect(old_db)):
             pass
 
         legacy_root_new = tmp_path / "legacy_new"
         legacy_root_new.mkdir()
         most_recent = legacy_root_new / DATABASE_FILENAME
-        with sqlite3.connect(most_recent):
+        with contextlib.closing(sqlite3.connect(most_recent)):
             pass
         extra_sidecar = legacy_root_new / "meshtastic.sqlite-wal"
         extra_sidecar.write_text("", encoding="utf-8")
@@ -1244,7 +1245,7 @@ class TestMigrateDatabaseEdgeCases:
         with mock.patch("sqlite3.connect") as mock_connect:
             mock_conn = mock.MagicMock()
             mock_conn.execute.return_value.fetchone.return_value = ["corrupted"]
-            mock_connect.return_value = mock_conn
+            mock_connect.return_value.__enter__.return_value = mock_conn
 
             with pytest.raises(MigrationError) as exc_info:
                 migrate_database([legacy_root_dir], new_home, dry_run=False, force=True)

--- a/tests/test_migrate_coverage.py
+++ b/tests/test_migrate_coverage.py
@@ -1189,7 +1189,7 @@ class TestMigrateDatabaseEdgeCases:
         with mock.patch("sqlite3.connect") as mock_connect:
             mock_conn = mock.MagicMock()
             mock_conn.execute.return_value.fetchone.return_value = ["corrupted"]
-            mock_connect.return_value.__enter__.return_value = mock_conn
+            mock_connect.return_value = mock_conn
 
             with pytest.raises(MigrationError) as exc_info:
                 migrate_database([legacy_root_dir], new_home, dry_run=False, force=True)
@@ -1245,7 +1245,7 @@ class TestMigrateDatabaseEdgeCases:
         with mock.patch("sqlite3.connect") as mock_connect:
             mock_conn = mock.MagicMock()
             mock_conn.execute.return_value.fetchone.return_value = ["corrupted"]
-            mock_connect.return_value.__enter__.return_value = mock_conn
+            mock_connect.return_value = mock_conn
 
             with pytest.raises(MigrationError) as exc_info:
                 migrate_database([legacy_root_dir], new_home, dry_run=False, force=True)

--- a/tests/test_migrate_hardening.py
+++ b/tests/test_migrate_hardening.py
@@ -1,5 +1,6 @@
 """Tests for migration hardening: staging, already-migrated guards, and backups."""
 
+import contextlib
 import sqlite3
 from pathlib import Path
 from unittest.mock import patch
@@ -146,10 +147,11 @@ def test_database_migration_success(tmp_path: Path) -> None:
     assert migrated_db_path.exists()
     assert not db_path.exists()
 
-    with sqlite3.connect(migrated_db_path) as conn:
-        row = conn.execute(
-            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='test'"
-        ).fetchone()
+    with contextlib.closing(sqlite3.connect(migrated_db_path)) as conn:
+        with conn as managed_conn:
+            row = managed_conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='test'"
+            ).fetchone()
     assert row is not None
     assert row[0] == 1
 
@@ -161,9 +163,9 @@ def test_database_migration_move_failure_preserves_legacy_source(
     legacy_root = tmp_path / "legacy"
     legacy_root.mkdir()
     db_path = legacy_root / DATABASE_FILENAME
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("CREATE TABLE test (id INTEGER)")
-        conn.commit()
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        with conn:
+            conn.execute("CREATE TABLE test (id INTEGER)")
 
     new_home = tmp_path / "home"
 

--- a/tests/test_migrate_hardening.py
+++ b/tests/test_migrate_hardening.py
@@ -114,11 +114,11 @@ def test_staging_pattern_credentials(tmp_path: Path):
     new_home = tmp_path / "home"
 
     # Mock _finalize_move to fail after staging
-    with patch(
-        "mmrelay.migrate._finalize_move", side_effect=OSError("Finalize failed")
+    with (
+        patch("mmrelay.migrate._finalize_move", side_effect=OSError("Finalize failed")),
+        pytest.raises(Exception, match="Finalize failed"),
     ):
-        with pytest.raises(Exception, match="Finalize failed"):
-            migrate_credentials([legacy_root], new_home)
+        migrate_credentials([legacy_root], new_home)
 
     # Final destination should NOT exist
     assert not (new_home / "matrix" / CREDENTIALS_FILENAME).exists()
@@ -147,11 +147,13 @@ def test_database_migration_success(tmp_path: Path) -> None:
     assert migrated_db_path.exists()
     assert not db_path.exists()
 
-    with contextlib.closing(sqlite3.connect(migrated_db_path)) as conn:
-        with conn as managed_conn:
-            row = managed_conn.execute(
-                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='test'"
-            ).fetchone()
+    with (
+        contextlib.closing(sqlite3.connect(migrated_db_path)) as conn,
+        conn as managed_conn,
+    ):
+        row = managed_conn.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='test'"
+        ).fetchone()
     assert row is not None
     assert row[0] == 1
 
@@ -163,15 +165,16 @@ def test_database_migration_move_failure_preserves_legacy_source(
     legacy_root = tmp_path / "legacy"
     legacy_root.mkdir()
     db_path = legacy_root / DATABASE_FILENAME
-    with contextlib.closing(sqlite3.connect(db_path)) as conn:
-        with conn:
-            conn.execute("CREATE TABLE test (id INTEGER)")
+    with contextlib.closing(sqlite3.connect(db_path)) as conn, conn:
+        conn.execute("CREATE TABLE test (id INTEGER)")
 
     new_home = tmp_path / "home"
 
-    with patch("mmrelay.migrate.shutil.move", side_effect=OSError("move failed")):
-        with pytest.raises(MigrationError, match="move failed"):
-            migrate_database([legacy_root], new_home)
+    with (
+        patch("mmrelay.migrate.shutil.move", side_effect=OSError("move failed")),
+        pytest.raises(MigrationError, match="move failed"),
+    ):
+        migrate_database([legacy_root], new_home)
 
     assert db_path.exists()
     assert not (new_home / "database" / DATABASE_FILENAME).exists()
@@ -189,7 +192,14 @@ def test_migration_failure_reports_paths(
     new_home = tmp_path / "home"
     new_home.mkdir()
 
-    with patch("mmrelay.migrate.resolve_all_paths") as mock_resolve:
+    with (
+        patch("mmrelay.migrate.resolve_all_paths") as mock_resolve,
+        patch("mmrelay.migrate._is_mmrelay_running", return_value=False),
+        patch(
+            "mmrelay.migrate._finalize_move",
+            side_effect=OSError("Staging remains"),
+        ),
+    ):
         mock_resolve.return_value = {
             "home": str(new_home),
             "legacy_sources": [str(legacy_root)],
@@ -200,20 +210,11 @@ def test_migration_failure_reports_paths(
             "store_dir": str(new_home / "matrix" / "store"),
         }
 
-        # Mock running instance check to return False (no running instance)
-        with patch("mmrelay.migrate._is_mmrelay_running", return_value=False):
-            # Mock finalize to fail
-            with patch(
-                "mmrelay.migrate._finalize_move", side_effect=OSError("Staging remains")
-            ):
-                result = perform_migration(dry_run=False)
-                assert result["success"] is False
+        result = perform_migration(dry_run=False)
+        assert result["success"] is False
 
-                # Check that error info is present in the result
-                assert "error" in result or "migrations" in result
+        assert "error" in result or "migrations" in result
 
-                # Check that migrations list contains the failed step
-                if "migrations" in result:
-                    step_names = [m.get("type") for m in result["migrations"]]
-                    # At least one step should have been attempted (credentials or config)
-                    assert len(step_names) > 0
+        if "migrations" in result:
+            step_names = [m.get("type") for m in result["migrations"]]
+            assert len(step_names) > 0


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR expands CI Python support to 3.13 and 3.14 and addresses several coroutine lifecycle and SQLite connection-handling issues that caused test instability. Changes touch CI workflow and project metadata, test infrastructure and many tests, and a handful of production modules to harden async behavior and resource cleanup. Coverage uploads are moved to run on Python 3.13 and CI no longer cancels other matrix jobs when one fails.

## Key Changes

### Features & Support
- Added Python 3.13 and 3.14 to the CI test matrix and project classifiers (pyproject.toml).
- Set CI matrix strategy.fail-fast: false so matrix runs continue after individual failures.
- Moved Codecov upload to run on Python 3.13 in CI; Python 3.14 is treated identically to all other versions.

### Fixes
- Fixed coroutine-leak issues by making test mocks and helpers close coroutine objects before raising or returning, preventing unawaited-coroutine warnings across many tests.
- Improved _submit_coro fallback: prefer asyncio.Runner (when available) and wrap event-loop shutdown steps with contextlib.suppress to avoid shutdown errors.
- Hardened SQLite usage by replacing some `with sqlite3.connect(...) as conn:` patterns with contextlib.closing(...) and managed aliases to ensure explicit close/PRAGMA execution in CLI, migration, and tests.
- Improved manager-close semantics: _close_manager_safely now re-raises KeyboardInterrupt, SystemExit, and RuntimeError while logging sqlite3/OSError on failure; _get_db_manager defers closing the previous manager until after releasing the lock.

### Refactors & Improvements
- DatabaseManager: added __del__ that calls close() with exceptions suppressed; added debug logging around connection registration and pool size; refactored close() to use a fresh thread-local snapshot for safer per-thread cleanup.
- Test harness:
  - Added sqlite3 connection provenance tracking (_ConnectionProvenance) and a session-scoped autouse fixture to report leaked connections on test failures.
  - Tuned asyncmock cleanup to use gc.collect(0) with periodic full GC runs.
  - Introduced helpers like _managed_sqlite_connection and _ImmediateAwaitable; standardized mock patterns to avoid creating leaked coroutine objects.
  - Added or expanded multiple test modules covering the above changes (e.g., tests for DatabaseManager.__del__, _submit_coro fallback, CLI system-health journal_mode).
- Documentation: added "Coroutine Leak Prevention Patterns" to TESTING_GUIDE.md with explicit mocking and awaitable-handling guidance.
- Misc: updated .gitignore to ignore /.worktrees/, removed a debug step from CI workflow, and updated various docstrings and imports.

## Breaking Changes or Migration Notes

- No runtime-breaking API changes. Tests and CI behavior are the primary surface of change.
- CI behavior: coverage artifact upload target moved to Python 3.13; all Python versions (including 3.14) are treated uniformly with fail-fast disabled.
- Test authors: follow the new testing guide patterns (close coroutine objects in mocks or use immediate awaitables) to avoid unawaited-coroutine warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->