### PR TITLE
Delay connect-time metadata probe until after startup drain window + harden timer lifecycle

### DIFF
--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -45,6 +45,8 @@ __all__ = [
     "serial_port_exists",
 ]
 
+CONNECT_PROBE_POST_DRAIN_DELAY_SECS: float = 2.0
+
 
 class BLEDiscoveryTransientError(Exception):
     """Retryable BLE discovery/setup failure that should not consume timeout budget."""
@@ -230,7 +232,7 @@ def _schedule_connect_time_calibration_probe(
     if drain_deadline is not None:
         remaining = drain_deadline - facade.time.monotonic()
         if remaining > 0:
-            delay = remaining + 2.0
+            delay = remaining + CONNECT_PROBE_POST_DRAIN_DELAY_SECS
             facade.logger.debug(
                 "Delaying connect-time metadata probe by %.1fs until after startup drain window",
                 delay,
@@ -242,6 +244,13 @@ def _schedule_connect_time_calibration_probe(
                     old_timer.cancel()
 
             def _delayed_submit_with_stale_guard() -> None:
+                if facade.shutting_down:
+                    facade.logger.debug(
+                        "Skipping delayed connect-time metadata probe; shutdown in progress"
+                    )
+                    if facade._pending_connect_time_probe_timer is timer:
+                        facade._pending_connect_time_probe_timer = None
+                    return
                 active_client = facade.meshtastic_client
                 active_client_id = facade._relay_active_client_id
                 if active_client is not client and (

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -2,6 +2,7 @@ import contextlib
 import functools
 import inspect
 import math
+import threading
 from concurrent.futures import Future
 from typing import Any, NoReturn
 
@@ -191,36 +192,55 @@ def _schedule_connect_time_calibration_probe(
         )
         return
 
-    try:
-        probe_future = facade._submit_metadata_probe(
-            functools.partial(
-                facade._probe_device_connection,
-                client,
-                timeout_secs,
+    def _submit_probe() -> None:
+        try:
+            probe_future = facade._submit_metadata_probe(
+                functools.partial(
+                    facade._probe_device_connection,
+                    client,
+                    timeout_secs,
+                )
             )
-        )
-    except facade.MetadataExecutorDegradedError:
-        facade.logger.debug(
-            "Skipping connect-time metadata probe; metadata executor is degraded"
-        )
-        return
-    except RuntimeError as exc:
-        facade.logger.debug(
-            "Skipping connect-time metadata probe; submission failed",
-            exc_info=exc,
-        )
-        return
+        except facade.MetadataExecutorDegradedError:
+            facade.logger.debug(
+                "Skipping connect-time metadata probe; metadata executor is degraded"
+            )
+            return
+        except RuntimeError as exc:
+            facade.logger.debug(
+                "Skipping connect-time metadata probe; submission failed",
+                exc_info=exc,
+            )
+            return
 
-    if probe_future is None:
-        facade.logger.debug(
-            "Skipping connect-time metadata probe; metadata probe already in progress"
-        )
-        return
+        if probe_future is None:
+            facade.logger.debug(
+                "Skipping connect-time metadata probe; metadata probe already in progress"
+            )
+            return
 
-    facade.logger.debug(
-        "Scheduled one-shot connect-time metadata probe (timeout=%.1fs)",
-        timeout_secs,
-    )
+        facade.logger.debug(
+            "Scheduled one-shot connect-time metadata probe (timeout=%.1fs)",
+            timeout_secs,
+        )
+
+    with facade._relay_rx_time_clock_skew_lock:
+        drain_deadline = facade._relay_startup_drain_deadline_monotonic_secs
+
+    if drain_deadline is not None:
+        remaining = drain_deadline - facade.time.monotonic()
+        if remaining > 0:
+            delay = remaining + 2.0
+            facade.logger.debug(
+                "Delaying connect-time metadata probe by %.1fs until after startup drain window",
+                delay,
+            )
+            timer = threading.Timer(delay, _submit_probe)
+            timer.daemon = True
+            timer.start()
+            return
+
+    _submit_probe()
 
 
 def _rollback_connect_attempt_state(

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -235,8 +235,28 @@ def _schedule_connect_time_calibration_probe(
                 "Delaying connect-time metadata probe by %.1fs until after startup drain window",
                 delay,
             )
-            timer = threading.Timer(delay, _submit_probe)
+
+            old_timer = facade._pending_connect_time_probe_timer
+            if old_timer is not None:
+                with contextlib.suppress(Exception):
+                    old_timer.cancel()
+
+            def _delayed_submit_with_stale_guard() -> None:
+                active_client = facade.meshtastic_client
+                active_client_id = facade._relay_active_client_id
+                if active_client is not client and (
+                    active_client_id is None or active_client_id != id(client)
+                ):
+                    facade.logger.debug(
+                        "Skipping delayed connect-time metadata probe; active client changed since scheduling"
+                    )
+                    return
+                facade._pending_connect_time_probe_timer = None
+                _submit_probe()
+
+            timer = threading.Timer(delay, _delayed_submit_with_stale_guard)
             timer.daemon = True
+            facade._pending_connect_time_probe_timer = timer
             timer.start()
             return
 
@@ -306,6 +326,12 @@ def _rollback_connect_attempt_state(
     if startup_drain_timer_to_cancel is not None:
         with contextlib.suppress(AttributeError, RuntimeError, TypeError):
             startup_drain_timer_to_cancel.cancel()
+
+    pending_probe_timer = facade._pending_connect_time_probe_timer
+    facade._pending_connect_time_probe_timer = None
+    if pending_probe_timer is not None:
+        with contextlib.suppress(Exception):
+            pending_probe_timer.cancel()
 
     return False
 

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -238,18 +238,14 @@ def _schedule_connect_time_calibration_probe(
                 delay,
             )
 
-            old_timer = facade._pending_connect_time_probe_timer
-            if old_timer is not None:
-                with contextlib.suppress(Exception):
-                    old_timer.cancel()
-
             def _delayed_submit_with_stale_guard() -> None:
                 if facade.shutting_down:
                     facade.logger.debug(
                         "Skipping delayed connect-time metadata probe; shutdown in progress"
                     )
-                    if facade._pending_connect_time_probe_timer is timer:
-                        facade._pending_connect_time_probe_timer = None
+                    with facade._relay_rx_time_clock_skew_lock:
+                        if facade._pending_connect_time_probe_timer is timer:
+                            facade._pending_connect_time_probe_timer = None
                     return
                 active_client = facade.meshtastic_client
                 active_client_id = facade._relay_active_client_id
@@ -259,13 +255,24 @@ def _schedule_connect_time_calibration_probe(
                     facade.logger.debug(
                         "Skipping delayed connect-time metadata probe; active client changed since scheduling"
                     )
+                    with facade._relay_rx_time_clock_skew_lock:
+                        if facade._pending_connect_time_probe_timer is timer:
+                            facade._pending_connect_time_probe_timer = None
                     return
-                facade._pending_connect_time_probe_timer = None
+                with facade._relay_rx_time_clock_skew_lock:
+                    if facade._pending_connect_time_probe_timer is timer:
+                        facade._pending_connect_time_probe_timer = None
                 _submit_probe()
 
             timer = threading.Timer(delay, _delayed_submit_with_stale_guard)
             timer.daemon = True
-            facade._pending_connect_time_probe_timer = timer
+            old_timer = None
+            with facade._relay_rx_time_clock_skew_lock:
+                old_timer = facade._pending_connect_time_probe_timer
+                facade._pending_connect_time_probe_timer = timer
+            if old_timer is not None:
+                with contextlib.suppress(Exception):
+                    old_timer.cancel()
             timer.start()
             return
 
@@ -336,8 +343,10 @@ def _rollback_connect_attempt_state(
         with contextlib.suppress(AttributeError, RuntimeError, TypeError):
             startup_drain_timer_to_cancel.cancel()
 
-    pending_probe_timer = facade._pending_connect_time_probe_timer
-    facade._pending_connect_time_probe_timer = None
+    pending_probe_timer = None
+    with facade._relay_rx_time_clock_skew_lock:
+        pending_probe_timer = facade._pending_connect_time_probe_timer
+        facade._pending_connect_time_probe_timer = None
     if pending_probe_timer is not None:
         with contextlib.suppress(Exception):
             pending_probe_timer.cancel()

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -1,3 +1,4 @@
+import contextlib
 import threading
 from typing import Any, Iterable
 
@@ -311,8 +312,10 @@ def on_lost_meshtastic_connection(
         facade.meshtastic_client = None
         facade._relay_active_client_id = None
 
-        pending_probe_timer = facade._pending_connect_time_probe_timer
-        facade._pending_connect_time_probe_timer = None
+        pending_probe_timer = None
+        with facade._relay_rx_time_clock_skew_lock:
+            pending_probe_timer = facade._pending_connect_time_probe_timer
+            facade._pending_connect_time_probe_timer = None
         if pending_probe_timer is not None:
             with contextlib.suppress(Exception):
                 pending_probe_timer.cancel()

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -311,6 +311,12 @@ def on_lost_meshtastic_connection(
         facade.meshtastic_client = None
         facade._relay_active_client_id = None
 
+        pending_probe_timer = facade._pending_connect_time_probe_timer
+        facade._pending_connect_time_probe_timer = None
+        if pending_probe_timer is not None:
+            with contextlib.suppress(Exception):
+                pending_probe_timer.cancel()
+
         ble_future, stale_exec, stale_addr = _clear_stale_ble_future_for_reconnect(
             detection_source
         )

--- a/src/mmrelay/meshtastic/health.py
+++ b/src/mmrelay/meshtastic/health.py
@@ -383,9 +383,21 @@ def _handle_probe_ack_callback(local_node: Any, packet: Any) -> None:
 
     decoded = packet.get("decoded") if isinstance(packet, dict) else None
     routing = decoded.get("routing") if isinstance(decoded, dict) else None
+    request_id = decoded.get("requestId") if isinstance(decoded, dict) else None
+    port_num = decoded.get("portnum") if isinstance(decoded, dict) else None
+    facade.logger.debug(
+        "[HEALTH_CHECK] Probe ACK callback invoked: portnum=%s requestId=%s has_routing=%s",
+        port_num,
+        request_id,
+        routing is not None,
+    )
     if isinstance(routing, dict):
         error_reason = routing.get("errorReason")
         if error_reason and error_reason != "NONE":
+            facade.logger.debug(
+                "[HEALTH_CHECK] Probe ACK callback routing errorReason=%s",
+                error_reason,
+            )
             if hasattr(ack_state, "receivedNak"):
                 ack_state.receivedNak = True
                 return
@@ -459,6 +471,12 @@ def _probe_device_connection(
         ack_state = getattr(getattr(local_node, "iface", None), "_acknowledgment", None)
     if ack_state is not None:
         facade._reset_probe_ack_state(ack_state)
+
+    facade.logger.debug(
+        "[HEALTH_CHECK] Sending metadata probe: ack_state=%s local_node=%s",
+        "available" if ack_state is not None else "unavailable",
+        "available" if local_node is not None else "unavailable",
+    )
 
     request = facade.admin_pb2.AdminMessage()
     request.get_device_metadata_request = True

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -195,6 +195,8 @@ _relay_rx_time_clock_skew_lock = threading.Lock()
 _relay_startup_drain_deadline_monotonic_secs: float | None = None
 # Timer used to decouple startup-drain expiry from packet arrival.
 _relay_startup_drain_expiry_timer: threading.Timer | None = None
+# Tracks the pending delayed connect-time metadata probe timer for cancellation on disconnect/rollback.
+_pending_connect_time_probe_timer: threading.Timer | None = None
 # Signals whether startup drain has completed for readiness publication.
 _relay_startup_drain_complete_event = threading.Event()
 _relay_startup_drain_complete_event.set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1260,9 +1260,7 @@ def reset_meshtastic_globals():
     _cancel_and_join_timer_like(startup_drain_timer, timeout=0.2)
     mu._relay_startup_drain_expiry_timer = None
     pending_connect_probe_timer = getattr(mu, "_pending_connect_time_probe_timer", None)
-    if pending_connect_probe_timer is not None:
-        with contextlib.suppress(Exception):
-            pending_connect_probe_timer.cancel()
+    _cancel_and_join_timer_like(pending_connect_probe_timer, timeout=0.2)
     mu._pending_connect_time_probe_timer = None
     startup_drain_complete_event = getattr(
         mu, "_relay_startup_drain_complete_event", None
@@ -1320,6 +1318,11 @@ def reset_meshtastic_globals():
         startup_drain_timer = getattr(mu, "_relay_startup_drain_expiry_timer", None)
         _cancel_and_join_timer_like(startup_drain_timer, timeout=0.2)
         mu._relay_startup_drain_expiry_timer = None
+        pending_connect_probe_timer = getattr(
+            mu, "_pending_connect_time_probe_timer", None
+        )
+        _cancel_and_join_timer_like(pending_connect_probe_timer, timeout=0.2)
+        mu._pending_connect_time_probe_timer = None
         mu.reconnect_task = None
         mu.reconnect_task_future = None
         mu._metadata_future = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1185,6 +1185,9 @@ def reset_meshtastic_globals():
         "_relay_startup_drain_expiry_timer": getattr(
             mu, "_relay_startup_drain_expiry_timer", None
         ),
+        "_pending_connect_time_probe_timer": getattr(
+            mu, "_pending_connect_time_probe_timer", None
+        ),
         "_relay_startup_drain_complete_event": getattr(
             mu, "_relay_startup_drain_complete_event", None
         ),
@@ -1256,6 +1259,11 @@ def reset_meshtastic_globals():
     startup_drain_timer = getattr(mu, "_relay_startup_drain_expiry_timer", None)
     _cancel_and_join_timer_like(startup_drain_timer, timeout=0.2)
     mu._relay_startup_drain_expiry_timer = None
+    pending_connect_probe_timer = getattr(mu, "_pending_connect_time_probe_timer", None)
+    if pending_connect_probe_timer is not None:
+        with contextlib.suppress(Exception):
+            pending_connect_probe_timer.cancel()
+    mu._pending_connect_time_probe_timer = None
     startup_drain_complete_event = getattr(
         mu, "_relay_startup_drain_complete_event", None
     )

--- a/tests/test_meshtastic_events.py
+++ b/tests/test_meshtastic_events.py
@@ -213,6 +213,47 @@ class TestOnLostMeshtasticConnection:
             for call in mock_logger_error.call_args_list
         )
 
+    def test_cancels_pending_connect_time_probe_timer(self):
+        from mmrelay.meshtastic.events import on_lost_meshtastic_connection
+
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = MagicMock()
+        mu._relay_active_client_id = None
+        mu.meshtastic_iface = None
+        mu._ble_future = None
+        mu._ble_future_address = None
+        mu._ble_executor_degraded_addresses = set()
+
+        mock_timer = MagicMock()
+        mu._pending_connect_time_probe_timer = mock_timer
+
+        mock_loop = MagicMock()
+        mock_loop.is_closed.return_value = False
+        mock_loop.is_running.return_value = True
+        mu.event_loop = mock_loop
+
+        scheduled_reconnect_task = MagicMock()
+
+        def _schedule_coroutine(coro, _loop):
+            coro.close()
+            return scheduled_reconnect_task
+
+        with (
+            patch.object(mu, "_disconnect_ble_interface"),
+            patch.object(mu, "reset_executor_degraded_state"),
+            patch.object(
+                mu.asyncio,
+                "run_coroutine_threadsafe",
+                side_effect=_schedule_coroutine,
+            ),
+        ):
+            on_lost_meshtastic_connection()
+
+        mock_timer.cancel.assert_called_once()
+        assert mu._pending_connect_time_probe_timer is None
+        mu.reconnecting = False
+
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestOnMeshtasticMessage:

--- a/tests/test_meshtastic_health.py
+++ b/tests/test_meshtastic_health.py
@@ -244,6 +244,7 @@ class TestHandleProbeAckCallback:
 
         local_node = MagicMock()
         ack = local_node.iface._acknowledgment
+        ack.receivedNak = False
         local_node.iface.localNode.nodeNum = 1234
         packet = {"decoded": {"routing": {}}, "from": 1234}
         _handle_probe_ack_callback(local_node, packet)
@@ -255,6 +256,7 @@ class TestHandleProbeAckCallback:
 
         local_node = MagicMock()
         ack = local_node.iface._acknowledgment
+        ack.receivedNak = False
         local_node.iface.localNode.nodeNum = 1234
         packet = {"decoded": {"routing": {"errorReason": "NONE"}}, "from": 1234}
         _handle_probe_ack_callback(local_node, packet)

--- a/tests/test_meshtastic_health.py
+++ b/tests/test_meshtastic_health.py
@@ -239,7 +239,7 @@ class TestHandleProbeAckCallback:
         _handle_probe_ack_callback(local_node, {"decoded": {}, "from": 1234})
         assert ack.receivedImplAck is True
 
-    def test_routing_error_reason_none_falls_through(self):
+    def test_routing_without_error_reason_falls_through(self):
         from mmrelay.meshtastic.health import _handle_probe_ack_callback
 
         local_node = MagicMock()

--- a/tests/test_meshtastic_health.py
+++ b/tests/test_meshtastic_health.py
@@ -239,6 +239,28 @@ class TestHandleProbeAckCallback:
         _handle_probe_ack_callback(local_node, {"decoded": {}, "from": 1234})
         assert ack.receivedImplAck is True
 
+    def test_routing_error_reason_none_falls_through(self):
+        from mmrelay.meshtastic.health import _handle_probe_ack_callback
+
+        local_node = MagicMock()
+        ack = local_node.iface._acknowledgment
+        local_node.iface.localNode.nodeNum = 1234
+        packet = {"decoded": {"routing": {}}, "from": 1234}
+        _handle_probe_ack_callback(local_node, packet)
+        assert ack.receivedNak is False
+        assert ack.receivedImplAck is True
+
+    def test_routing_error_reason_none_string_falls_through(self):
+        from mmrelay.meshtastic.health import _handle_probe_ack_callback
+
+        local_node = MagicMock()
+        ack = local_node.iface._acknowledgment
+        local_node.iface.localNode.nodeNum = 1234
+        packet = {"decoded": {"routing": {"errorReason": "NONE"}}, "from": 1234}
+        _handle_probe_ack_callback(local_node, packet)
+        assert ack.receivedNak is False
+        assert ack.receivedImplAck is True
+
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestWaitForProbeAck:

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -791,7 +791,13 @@ def test_connect_meshtastic_schedules_one_shot_probe_when_periodic_health_disabl
         patch(
             "mmrelay.meshtastic_utils._probe_device_connection"
         ) as mock_probe_device_connection,
+        patch(
+            "mmrelay.meshtastic_utils.time.monotonic",
+            return_value=1_000.0,
+        ),
     ):
+        mu._startup_packet_drain_applied = True
+        mu._relay_startup_drain_deadline_monotonic_secs = None
         config = {
             "meshtastic": {
                 "connection_type": CONNECTION_TYPE_TCP,
@@ -831,7 +837,13 @@ def test_connect_meshtastic_probe_invalid_override_inherits_parent_enabled():
             return_value={"firmware_version": "unknown", "success": False},
         ),
         patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
+        patch(
+            "mmrelay.meshtastic_utils.time.monotonic",
+            return_value=1_000.0,
+        ),
     ):
+        mu._startup_packet_drain_applied = True
+        mu._relay_startup_drain_deadline_monotonic_secs = None
         config = {
             "meshtastic": {
                 "connection_type": CONNECTION_TYPE_TCP,
@@ -905,7 +917,13 @@ def test_connect_meshtastic_probe_inherits_parent_when_override_omitted():
         patch(
             "mmrelay.meshtastic_utils._probe_device_connection"
         ) as mock_probe_device_connection,
+        patch(
+            "mmrelay.meshtastic_utils.time.monotonic",
+            return_value=1_000.0,
+        ),
     ):
+        mu._startup_packet_drain_applied = True
+        mu._relay_startup_drain_deadline_monotonic_secs = None
         config = {
             "meshtastic": {
                 "connection_type": CONNECTION_TYPE_TCP,

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1537,3 +1537,35 @@ def test_rollback_cancels_pending_connect_time_probe_timer():
 
     mock_timer.cancel.assert_called_once()
     assert mu._pending_connect_time_probe_timer is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_time_probe_submits_immediately_when_drain_expired():
+    """When drain deadline is set but has already passed, probe should submit immediately."""
+    mock_client = MagicMock()
+    mock_client.localNode = MagicMock()
+    mock_client.sendData = MagicMock()
+
+    now = 1_100.0
+    drain_deadline = 1_000.0
+
+    mu._relay_startup_drain_deadline_monotonic_secs = drain_deadline
+
+    with (
+        patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
+    ):
+        mu._schedule_connect_time_calibration_probe(
+            mock_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+    mock_submit_probe.assert_called_once()
+    assert mu._pending_connect_time_probe_timer is None

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1,6 +1,7 @@
 import threading
 import time
 from collections.abc import Callable
+from concurrent.futures import Future
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -21,6 +22,14 @@ from mmrelay.constants.network import (
     STARTUP_PACKET_DRAIN_SECS,
 )
 from mmrelay.meshtastic_utils import connect_meshtastic, on_lost_meshtastic_connection
+
+
+def _schedule_reconnect_closing_coro(coro, loop=None):
+    """Close the reconnect coroutine to prevent unawaited-coroutine leaks."""
+    coro.close()
+    fut = Future()
+    fut.set_result(None)
+    return fut
 
 
 def test_connect_meshtastic_returns_existing_client(reset_meshtastic_globals):
@@ -1101,6 +1110,10 @@ def test_on_lost_meshtastic_connection_ignores_bad_fd(reset_meshtastic_globals):
     with (
         patch("mmrelay.meshtastic_utils.logger") as mock_logger,
         patch("mmrelay.meshtastic_utils.event_loop") as mock_loop,
+        patch(
+            "mmrelay.meshtastic_utils.asyncio.run_coroutine_threadsafe",
+            side_effect=_schedule_reconnect_closing_coro,
+        ),
     ):
         mock_loop.is_closed.return_value = False
         on_lost_meshtastic_connection(detection_source="test")

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -27,7 +27,7 @@ from mmrelay.meshtastic_utils import connect_meshtastic, on_lost_meshtastic_conn
 
 def _schedule_reconnect_closing_coro(
     coro: Coroutine[Any, Any, Any],
-    loop: asyncio.AbstractEventLoop | None = None,
+    loop: asyncio.AbstractEventLoop | None = None,  # noqa: ARG001
 ) -> Future[None]:
     """Close the reconnect coroutine to prevent unawaited-coroutine leaks."""
     coro.close()
@@ -1424,6 +1424,19 @@ def test_connect_time_probe_delayed_when_drain_window_active():
     mu._pending_connect_time_probe_timer = None
 
 
+class _FakeTimer:
+    def __init__(self, delay, function, *args, **kwargs):
+        self.function = function
+        self.delay = delay
+        self.finished = threading.Event()
+
+    def start(self):
+        pass
+
+    def cancel(self):
+        self.finished.set()
+
+
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 def test_connect_time_probe_stale_delayed_callback_skipped():
     """Delayed probe callback should skip submission when active client has changed."""
@@ -1439,6 +1452,7 @@ def test_connect_time_probe_stale_delayed_callback_skipped():
     mu._relay_active_client_id = id(mock_client)
 
     with (
+        patch("mmrelay.meshtastic.connection.threading.Timer", _FakeTimer),
         patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
         patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
     ):
@@ -1454,14 +1468,13 @@ def test_connect_time_probe_stale_delayed_callback_skipped():
             },
         )
 
-    assert mu._pending_connect_time_probe_timer is not None
+    timer = mu._pending_connect_time_probe_timer
+    assert timer is not None
+    assert isinstance(timer, _FakeTimer)
 
-    # Simulate client change before timer fires
     mu.meshtastic_client = None
     mu._relay_active_client_id = None
 
-    # Fire the timer callback directly
-    timer = mu._pending_connect_time_probe_timer
     timer.function()
 
     mock_submit_probe.assert_not_called()
@@ -1483,6 +1496,7 @@ def test_connect_time_probe_delayed_callback_skips_on_shutdown():
     mu._relay_active_client_id = id(mock_client)
 
     with (
+        patch("mmrelay.meshtastic.connection.threading.Timer", _FakeTimer),
         patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
         patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
     ):
@@ -1498,10 +1512,11 @@ def test_connect_time_probe_delayed_callback_skips_on_shutdown():
             },
         )
 
-    assert mu._pending_connect_time_probe_timer is not None
+    timer = mu._pending_connect_time_probe_timer
+    assert timer is not None
+    assert isinstance(timer, _FakeTimer)
 
     mu.shutting_down = True
-    timer = mu._pending_connect_time_probe_timer
     timer.function()
 
     mock_submit_probe.assert_not_called()

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1515,8 +1515,8 @@ def test_connect_time_probe_new_schedule_cancels_old_timer():
     second_timer = mu._pending_connect_time_probe_timer
     assert second_timer is not None
     assert second_timer is not first_timer
-    # The first timer's internal canceled flag should be set
-    assert first_timer.cancelled()
+    # The first timer's internal finished flag should be set (cancel() sets it)
+    assert first_timer.finished.is_set()
     second_timer.cancel()
     mu._pending_connect_time_probe_timer = None
 

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1525,6 +1525,50 @@ def test_connect_time_probe_delayed_callback_skips_on_shutdown():
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_time_probe_delayed_callback_fires_successfully():
+    """Delayed probe callback should submit probe and clear timer when client still matches."""
+    mock_client = MagicMock()
+    mock_client.localNode = MagicMock()
+    mock_client.sendData = MagicMock()
+
+    now = 1_000.0
+    drain_deadline = now + 0.01
+
+    mu._relay_startup_drain_deadline_monotonic_secs = drain_deadline
+    mu.meshtastic_client = mock_client
+    mu._relay_active_client_id = id(mock_client)
+
+    with (
+        patch("mmrelay.meshtastic.connection.threading.Timer", _FakeTimer),
+        patch(
+            "mmrelay.meshtastic_utils._submit_metadata_probe", return_value=MagicMock()
+        ) as mock_submit_probe,
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
+    ):
+        mu._schedule_connect_time_calibration_probe(
+            mock_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+        timer = mu._pending_connect_time_probe_timer
+        assert timer is not None
+        assert isinstance(timer, _FakeTimer)
+
+        timer.function()
+
+        mock_submit_probe.assert_called_once()
+
+    assert mu._pending_connect_time_probe_timer is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
 def test_connect_time_probe_new_schedule_cancels_old_timer():
     """Scheduling a new delayed probe should cancel the previously pending timer."""
     mock_client = MagicMock()

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1,8 +1,9 @@
+import asyncio
 import threading
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
-from typing import Any
+from typing import Any, Coroutine
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,10 +25,13 @@ from mmrelay.constants.network import (
 from mmrelay.meshtastic_utils import connect_meshtastic, on_lost_meshtastic_connection
 
 
-def _schedule_reconnect_closing_coro(coro, loop=None):
+def _schedule_reconnect_closing_coro(
+    coro: Coroutine[Any, Any, Any],
+    loop: asyncio.AbstractEventLoop | None = None,
+) -> Future[None]:
     """Close the reconnect coroutine to prevent unawaited-coroutine leaks."""
     coro.close()
-    fut = Future()
+    fut: Future[None] = Future()
     fut.set_result(None)
     return fut
 
@@ -1462,6 +1466,47 @@ def test_connect_time_probe_stale_delayed_callback_skipped():
 
     mock_submit_probe.assert_not_called()
     mu._pending_connect_time_probe_timer = None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_time_probe_delayed_callback_skips_on_shutdown():
+    """Delayed probe callback should skip submission when shutting_down is True."""
+    mock_client = MagicMock()
+    mock_client.localNode = MagicMock()
+    mock_client.sendData = MagicMock()
+
+    now = 1_000.0
+    drain_deadline = now + 0.01
+
+    mu._relay_startup_drain_deadline_monotonic_secs = drain_deadline
+    mu.meshtastic_client = mock_client
+    mu._relay_active_client_id = id(mock_client)
+
+    with (
+        patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
+    ):
+        mu._schedule_connect_time_calibration_probe(
+            mock_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+    assert mu._pending_connect_time_probe_timer is not None
+
+    mu.shutting_down = True
+    timer = mu._pending_connect_time_probe_timer
+    timer.function()
+
+    mock_submit_probe.assert_not_called()
+    mu._pending_connect_time_probe_timer = None
+    mu.shutting_down = False
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1383,3 +1383,157 @@ class TestBleDegradedStateSubmissionBlocking:
             if call.args and "BLE connection established" in str(call.args[0])
         ]
         assert info_calls, "Expected 'BLE connection established' log message"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_time_probe_delayed_when_drain_window_active():
+    """Connect-time probe should be delayed via Timer when startup drain window is active."""
+    mock_client = MagicMock()
+    mock_client.localNode = MagicMock()
+    mock_client.sendData = MagicMock()
+
+    now = 1_000.0
+    drain_deadline = now + 10.0
+
+    mu._relay_startup_drain_deadline_monotonic_secs = drain_deadline
+
+    with (
+        patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
+    ):
+        mu._schedule_connect_time_calibration_probe(
+            mock_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+    mock_submit_probe.assert_not_called()
+    assert mu._pending_connect_time_probe_timer is not None
+    assert isinstance(mu._pending_connect_time_probe_timer, threading.Timer)
+    mu._pending_connect_time_probe_timer.cancel()
+    mu._pending_connect_time_probe_timer = None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_time_probe_stale_delayed_callback_skipped():
+    """Delayed probe callback should skip submission when active client has changed."""
+    mock_client = MagicMock()
+    mock_client.localNode = MagicMock()
+    mock_client.sendData = MagicMock()
+
+    now = 1_000.0
+    drain_deadline = now + 0.01
+
+    mu._relay_startup_drain_deadline_monotonic_secs = drain_deadline
+    mu.meshtastic_client = mock_client
+    mu._relay_active_client_id = id(mock_client)
+
+    with (
+        patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
+    ):
+        mu._schedule_connect_time_calibration_probe(
+            mock_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+    assert mu._pending_connect_time_probe_timer is not None
+
+    # Simulate client change before timer fires
+    mu.meshtastic_client = None
+    mu._relay_active_client_id = None
+
+    # Fire the timer callback directly
+    timer = mu._pending_connect_time_probe_timer
+    timer.function()
+
+    mock_submit_probe.assert_not_called()
+    mu._pending_connect_time_probe_timer = None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_time_probe_new_schedule_cancels_old_timer():
+    """Scheduling a new delayed probe should cancel the previously pending timer."""
+    mock_client = MagicMock()
+    mock_client.localNode = MagicMock()
+    mock_client.sendData = MagicMock()
+
+    now = 1_000.0
+    drain_deadline = now + 10.0
+
+    mu._relay_startup_drain_deadline_monotonic_secs = drain_deadline
+
+    with (
+        patch("mmrelay.meshtastic_utils._submit_metadata_probe"),
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
+    ):
+        mu._schedule_connect_time_calibration_probe(
+            mock_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+    first_timer = mu._pending_connect_time_probe_timer
+    assert first_timer is not None
+
+    # Schedule again - should cancel the first timer
+    with (
+        patch("mmrelay.meshtastic_utils._submit_metadata_probe"),
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now + 1.0),
+    ):
+        mu._schedule_connect_time_calibration_probe(
+            mock_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+    second_timer = mu._pending_connect_time_probe_timer
+    assert second_timer is not None
+    assert second_timer is not first_timer
+    # The first timer's internal canceled flag should be set
+    assert first_timer.cancelled()
+    second_timer.cancel()
+    mu._pending_connect_time_probe_timer = None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_rollback_cancels_pending_connect_time_probe_timer():
+    """Rollback should cancel and clear the pending delayed connect-time probe timer."""
+    mock_timer = MagicMock()
+    mu._pending_connect_time_probe_timer = mock_timer
+
+    mu._rollback_connect_attempt_state(
+        client=None,
+        client_assigned_for_this_connect=False,
+        startup_drain_armed_for_this_connect=False,
+        startup_drain_applied_for_this_connect=False,
+        reconnect_bootstrap_armed_for_this_connect=False,
+    )
+
+    mock_timer.cancel.assert_called_once()
+    assert mu._pending_connect_time_probe_timer is None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR changes Meshtastic metadata-probe scheduling to avoid interfering with startup connection bursts by deferring connect-time calibration probes until any configured startup-drain window has elapsed. It also improves probe/health-check logging to include request IDs, port numbers, and routing error reasons, and updates tests to make probe scheduling deterministic and to eliminate unawaited-coroutine warnings.

## Key Changes

Features
- Startup-drain aware probe scheduling: when a startup-drain deadline (_relay_startup_drain_deadline_monotonic_secs) is set and in the future, connect-time metadata probes are deferred via a one-shot daemon threading.Timer for remaining_deadline + CONNECT_PROBE_POST_DRAIN_DELAY_SECS; otherwise probes are submitted immediately.
- Stale-guarding of delayed probes: timer callbacks check for shutdown and active-client changes and clear the pending-timer handle before submitting.
- New module-level timer tracking: introduced _pending_connect_time_probe_timer to allow cancellation when connections are rolled back or lost.

Refactors / Implementation
- Encapsulated probe submission logic in an inner _submit_probe() helper inside _schedule_connect_time_calibration_probe to centralize exception handling and early-exit behavior.
- Changed probe-in-progress detection to check probe_future immediately after submission attempt and return early if a probe is already active.
- Added CONNECT_PROBE_POST_DRAIN_DELAY_SECS constant and imported threading; used _relay_rx_time_clock_skew_lock for thread-safe access to startup drain state.
- _rollback_connect_attempt_state and on_lost_meshtastic_connection now cancel and clear pending delayed probe timers as part of cleanup.

Logging / Health-checks
- Enhanced _handle_probe_ack_callback to extract decoded.requestId and portnum and to log routing presence and routing.errorReason (when not "NONE"), improving observability of NAK conditions and ACK handling.
- Added debug logging in _probe_device_connection to indicate whether ack_state and local_node are present immediately before sending a metadata probe.

Tests
- Tests updated to make probe scheduling deterministic by patching mmrelay.meshtastic_utils.time.monotonic and explicitly setting startup-drain globals (_startup_packet_drain_applied, _relay_startup_drain_deadline_monotonic_secs) prior to calling connect_meshtastic.
- Added unit tests covering delayed probe scheduling and the timer callback’s stale-guard behavior (skip when active client changes, when shutting down, or when timer is cancelled).
- Introduced test helper _schedule_reconnect_closing_coro(coro, loop=None) to immediately close provided coroutines and return a resolved Future to prevent unawaited coroutine warnings.
- Mocked asyncio.run_coroutine_threadsafe in one test (“ignores bad fd” on_lost_meshtastic_connection) to avoid "coroutine was never awaited" warnings while preserving control flow expectations.
- tests/conftest.py now snapshots and resets the new _pending_connect_time_probe_timer between tests, cancelling it if present.

Fixes
- Prevents metadata probes from interfering with connection bursts during startup by deferring probes until after the configured drain window.
- Eliminates test-suite warnings about unawaited coroutines by explicitly closing or mocking problematic coroutines in tests.

Breaking changes / Migration notes

- None to public APIs. All changes are internal to Meshtastic probe scheduling, logging, and tests; no external interface or exported function signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->