### PR TITLE
Refine config path resolution, add lifecycle coverage, and Docker validation

### DIFF
--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -67,6 +67,7 @@ jobs:
             VCS_REF=${{ env.GIT_SHA }}
             VERSION=${{ env.VERSION }}
           cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Smoke test — verify image runs
         run: docker run --rm mmrelay:validate mmrelay --version

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -8,7 +8,7 @@ on:
       - .github/workflows/docker-validate.yml
       - .github/workflows/docker-publish.yml
       - Dockerfile
-      - docker-compose*
+      - "**/docker-compose*"
       - src/**
       - pyproject.toml
 

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -1,0 +1,82 @@
+name: Docker Build Validation
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, develop, "**-review"]
+    paths:
+      - .github/workflows/docker-validate.yml
+      - .github/workflows/docker-publish.yml
+      - Dockerfile
+      - docker-compose*
+      - src/**
+      - pyproject.toml
+
+concurrency:
+  group: docker-validate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Extract version and build info
+        id: get_version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="$(
+            python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
+          )"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Extracted version: $VERSION"
+
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "BUILD_DATE=$BUILD_DATE" >> "$GITHUB_ENV"
+
+          GIT_SHA=$(git rev-parse --short HEAD)
+          echo "GIT_SHA=$GIT_SHA" >> "$GITHUB_ENV"
+
+          echo "FILE_VERSION=$VERSION-dev-$GIT_SHA" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        with:
+          driver-opts: |
+            network=host
+
+      - name: Build Docker image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          tags: mmrelay:validate
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            VCS_REF=${{ env.GIT_SHA }}
+            VERSION=${{ env.VERSION }}
+          cache-from: type=gha
+          outputs: type=docker,dest=/tmp/mmrelay-docker.tar
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: MMRelay_docker_${{ env.FILE_VERSION }}
+          path: /tmp/mmrelay-docker.tar
+
+      - name: Smoke test — load and run image
+        run: |
+          echo "Loading built image..."
+          docker load -i /tmp/mmrelay-docker.tar
+          echo "Running mmrelay --version..."
+          docker run --rm mmrelay:validate mmrelay --version

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           name: MMRelay_docker_${{ env.FILE_VERSION }}
           path: /tmp/mmrelay-docker.tar
+          retention-days: 7
 
       - name: Smoke test — load and run image
         run: |

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -60,24 +60,13 @@ jobs:
           context: .
           platforms: linux/amd64
           push: false
+          load: true
           tags: mmrelay:validate
           build-args: |
             BUILD_DATE=${{ env.BUILD_DATE }}
             VCS_REF=${{ env.GIT_SHA }}
             VERSION=${{ env.VERSION }}
           cache-from: type=gha
-          outputs: type=docker,dest=/tmp/mmrelay-docker.tar
 
-      - name: Upload Docker image artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: MMRelay_docker_${{ env.FILE_VERSION }}
-          path: /tmp/mmrelay-docker.tar
-          retention-days: 7
-
-      - name: Smoke test — load and run image
-        run: |
-          echo "Loading built image..."
-          docker load -i /tmp/mmrelay-docker.tar
-          echo "Running mmrelay --version..."
-          docker run --rm mmrelay:validate mmrelay --version
+      - name: Smoke test — verify image runs
+        run: docker run --rm mmrelay:validate mmrelay --version

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,28 @@
-# Virtual environments - different agents use different locations
+# Local environment and editor settings
 venv/
 .venv/
 .pyenv
 .vscode
+.env
 config.yaml
+
+# Python caches and packaging metadata
 __pycache__/
-.aider*
 *.pyc
 *.pyo
 *.pyd
 *$py.class
-src/mmrelay.egg-info
+src/mmrelay.egg-info/
+
+# Tool state and local automation files
+.aider*
 .opencode/
 .codex
-/build/
-/.ci-artifacts/
 coderabbit_actionable_items.md
 
-# Docker files (use samples from src/mmrelay/tools/)
-docker-compose.yaml
-docker-compose.override.yaml
-.env
-
-# Coverage files
+# Build and test outputs
+/build/
+/.ci-artifacts/
 .coverage
 .coverage.*
 htmlcov/
@@ -31,7 +31,11 @@ junit.xml
 .pytest_cache/
 MagicMock/
 
-# Generated Kubernetes manifests (user-specific, not to be committed)
+# Docker overrides and local compose files
+docker-compose.yaml
+docker-compose.override.yaml
+
+# Generated Kubernetes manifests
 /k8s/
 
 # Git worktrees

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,7 +18,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.129.0
+    - renovate@43.136.1
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - mypy@1.20.1
@@ -29,7 +29,7 @@ lint:
     - actionlint@1.7.12
     - bandit@1.9.4
     - black@26.3.1
-    - checkov@3.2.521
+    - checkov@3.2.524
     - git-diff-check
     - isort@8.0.1
     - markdownlint@0.48.0

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -1,3 +1,5 @@
+"""Configuration loading, path resolution, and credential management for MMRelay."""
+
 import asyncio
 import functools
 import json
@@ -68,7 +70,10 @@ if TYPE_CHECKING:
 
 
 class CredentialsPathError(OSError):
+    """Raised when no candidate credentials paths are available."""
+
     def __init__(self) -> None:
+        """Create a CredentialsPathError with a fixed diagnostic message."""
         super().__init__("No candidate credentials paths available")
 
 
@@ -156,6 +161,7 @@ def _expand_path(path: str) -> str:
 
 
 def _emit_legacy_credentials_warning(credentials_path: str) -> None:
+    """Log a deprecation warning for credentials found at a legacy filesystem location."""
     logger.warning(
         "Credentials found in legacy location: %s. "
         "Please run 'mmrelay migrate' to move to new unified structure. "

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -86,6 +86,11 @@ def _warn_on_legacy_path_overrides(config: dict[str, Any] | None) -> None:
 
     These overrides are scheduled for removal; ``MMRELAY_HOME`` is the
     supported way to control data paths.
+
+    Precedence: MMRELAY_CREDENTIALS_PATH env var > top-level credentials_path >
+    matrix.credentials_path > default MMRELAY_HOME-derived path.  MMRELAY_HOME
+    is the preferred unified path model; the others are deprecated compatibility
+    shims.
     """
     global _legacy_path_override_warning_shown
     if _legacy_path_override_warning_shown:

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -355,6 +355,9 @@ def get_explicit_credentials_path(config: Mapping[str, Any] | None) -> str | Non
     Returns:
         str | None: The configured credentials path string, or `None` if not set.
 
+    Precedence: MMRELAY_CREDENTIALS_PATH env var > top-level credentials_path > matrix.credentials_path.
+    All three sources are deprecated in favor of MMRELAY_HOME. Warnings are emitted once per process.
+
     Raises:
         InvalidCredentialsPathTypeError: If a found `credentials_path` value exists but is not a string.
     """
@@ -425,6 +428,9 @@ def get_plugin_data_dir(
     Returns:
         str: Absolute path to the resolved plugins directory or the plugin-specific data directory.
     """
+    # Note: This is the side-effect-bearing wrapper. The pure path resolver lives in
+    # mmrelay.paths.get_plugin_data_dir(). This version ensures directories exist and
+    # infers plugin_type from relay_config when not explicitly provided.
     plugins_data_dir = str(get_plugins_dir())
     os.makedirs(plugins_data_dir, exist_ok=True)
 
@@ -1423,64 +1429,6 @@ def load_config(
         else:
             logger.error(msg_suggest_generate_config())
     return {}
-
-
-def _resolve_credentials_path(
-    path_override: str | None, *, allow_relay_config_sources: bool
-) -> tuple[str, str]:
-    """
-    Resolve the filesystem path to credentials.json and its containing directory.
-
-    If an explicit path_override is provided (file or directory), or if allow_relay_config_sources
-    is True and an override is present via the MMRELAY_CREDENTIALS_PATH environment variable,
-    relay_config["credentials_path"], or relay_config["matrix"]["credentials_path"], that value
-    is resolved and normalized. If the resolved candidate refers to a directory (including when
-    it ends with a path separator) `credentials.json` is appended. When no override is found,
-    the function returns the default credentials path under the application's home MATRIX_DIRNAME.
-
-    Parameters:
-        path_override (str | None): Explicit file or directory path supplied by the caller.
-            If this points to a directory (or ends with a path separator), `credentials.json`
-            will be appended. Tilde-expansion and absolute path normalization are applied.
-        allow_relay_config_sources (bool): If True, also consider MMRELAY_CREDENTIALS_PATH and
-            the relay_config keys `credentials_path` and `matrix.credentials_path` as candidate
-            overrides when path_override is None.
-
-    Returns:
-        tuple[str, str]: (credentials_path, config_dir) where `credentials_path` is the
-        absolute path to the credentials.json file and `config_dir` is the directory that
-        will contain that file.
-    """
-    candidate = path_override
-
-    if not candidate and allow_relay_config_sources:
-        candidate = os.getenv("MMRELAY_CREDENTIALS_PATH")
-        if not candidate:
-            candidate = relay_config.get("credentials_path")
-        if not candidate:
-            matrix_config = relay_config.get(CONFIG_SECTION_MATRIX, {})
-            if isinstance(matrix_config, dict):
-                candidate = matrix_config.get("credentials_path")
-
-    if candidate:
-        candidate = os.path.abspath(os.path.expanduser(candidate))
-        path_is_dir = os.path.isdir(candidate)
-        if not path_is_dir:
-            path_is_dir = bool(
-                candidate.endswith(os.path.sep)
-                or (os.path.altsep and candidate.endswith(os.path.altsep))
-            )
-        if path_is_dir:
-            candidate = os.path.join(candidate, CREDENTIALS_FILENAME)
-        config_dir = os.path.dirname(candidate)
-        if not config_dir:
-            config_dir = str(get_home_dir())
-            candidate = os.path.join(config_dir, os.path.basename(candidate))
-        return candidate, config_dir
-
-    base_dir = str(get_home_dir())
-    matrix_dir = os.path.join(base_dir, MATRIX_DIRNAME)
-    return os.path.join(matrix_dir, CREDENTIALS_FILENAME), matrix_dir
 
 
 def validate_yaml_syntax(

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -6,6 +6,7 @@ import ntpath
 import os
 import re
 import sys
+import threading
 import warnings
 from collections.abc import Mapping as MappingABC
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, cast
@@ -73,9 +74,12 @@ class CredentialsPathError(OSError):
 
 # Track whether we've already emitted legacy path override warnings
 _legacy_path_override_warning_shown = False
+_legacy_path_override_warning_lock = threading.Lock()
 
 
-def _warn_on_legacy_path_overrides(config: dict[str, Any] | None) -> None:
+def _warn_on_legacy_path_overrides(
+    config: Mapping[str, Any] | dict[str, Any] | None,
+) -> None:
     """Emit deprecation warnings for legacy credentials_path / store_path overrides.
 
     Warns once per process when any of the following are present:
@@ -91,43 +95,51 @@ def _warn_on_legacy_path_overrides(config: dict[str, Any] | None) -> None:
     matrix.credentials_path > default MMRELAY_HOME-derived path.  MMRELAY_HOME
     is the preferred unified path model; the others are deprecated compatibility
     shims.
+
+    This is the sole owner of the ``_legacy_path_override_warning_shown`` flag;
+    all callers (including ``get_explicit_credentials_path``) must delegate
+    warning emission here so that every active legacy override is enumerated
+    regardless of call order.
     """
     global _legacy_path_override_warning_shown
-    if _legacy_path_override_warning_shown:
-        return
+    with _legacy_path_override_warning_lock:
+        if _legacy_path_override_warning_shown:
+            return
 
-    warnings_to_emit: list[str] = []
+        warnings_to_emit: list[str] = []
 
-    if os.getenv("MMRELAY_CREDENTIALS_PATH"):
-        warnings_to_emit.append("MMRELAY_CREDENTIALS_PATH environment variable is set")
-
-    if isinstance(config, dict):
-        if config.get("credentials_path"):
+        if os.getenv("MMRELAY_CREDENTIALS_PATH"):
             warnings_to_emit.append(
-                "top-level 'credentials_path' config key is present"
+                "MMRELAY_CREDENTIALS_PATH environment variable is set"
             )
-        matrix_section = config.get(CONFIG_SECTION_MATRIX)
-        if isinstance(matrix_section, dict):
-            if matrix_section.get("credentials_path"):
-                warnings_to_emit.append(
-                    "'matrix.credentials_path' config key is present"
-                )
-            for section in ("e2ee", "encryption"):
-                sub = matrix_section.get(section)
-                if isinstance(sub, dict) and sub.get("store_path"):
-                    warnings_to_emit.append(
-                        f"'matrix.{section}.store_path' config key is present"
-                    )
 
-    if warnings_to_emit:
-        _legacy_path_override_warning_shown = True
-        logger.warning(
-            "Legacy path override(s) detected and will be ignored in a future version: %s. "
-            "Use MMRELAY_HOME to control all data paths. "
-            "Support for these overrides will be removed in v%s.",
-            "; ".join(warnings_to_emit),
-            DEPRECATION_VERSIONS[1],
-        )
+        if isinstance(config, MappingABC):
+            if config.get("credentials_path"):
+                warnings_to_emit.append(
+                    "top-level 'credentials_path' config key is present"
+                )
+            matrix_section = config.get(CONFIG_SECTION_MATRIX)
+            if isinstance(matrix_section, MappingABC):
+                if matrix_section.get("credentials_path"):
+                    warnings_to_emit.append(
+                        "'matrix.credentials_path' config key is present"
+                    )
+                for section in ("e2ee", "encryption"):
+                    sub = matrix_section.get(section)
+                    if isinstance(sub, MappingABC) and sub.get("store_path"):
+                        warnings_to_emit.append(
+                            f"'matrix.{section}.store_path' config key is present"
+                        )
+
+        if warnings_to_emit:
+            _legacy_path_override_warning_shown = True
+            logger.warning(
+                "Legacy path override(s) detected and will be ignored in a future version: %s. "
+                "Use MMRELAY_HOME to control all data paths. "
+                "Support for these overrides will be removed in v%s.",
+                "; ".join(warnings_to_emit),
+                DEPRECATION_VERSIONS[1],
+            )
 
 
 def _expand_path(path: str) -> str:
@@ -368,16 +380,7 @@ def get_explicit_credentials_path(config: Mapping[str, Any] | None) -> str | Non
     """
     env_path = os.getenv("MMRELAY_CREDENTIALS_PATH")
     if env_path:
-        global _legacy_path_override_warning_shown
-        if not _legacy_path_override_warning_shown:
-            _legacy_path_override_warning_shown = True
-            logger.warning(
-                "MMRELAY_CREDENTIALS_PATH environment variable is set. "
-                "This override is deprecated and will be ignored in a future version. "
-                "Use MMRELAY_HOME to control all data paths. "
-                "Support will be removed in v%s.",
-                DEPRECATION_VERSIONS[1],
-            )
+        _warn_on_legacy_path_overrides(config)
         return env_path
     if not isinstance(config, MappingABC):
         return None

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -71,6 +71,60 @@ class CredentialsPathError(OSError):
         super().__init__("No candidate credentials paths available")
 
 
+# Track whether we've already emitted legacy path override warnings
+_legacy_path_override_warning_shown = False
+
+
+def _warn_on_legacy_path_overrides(config: dict[str, Any] | None) -> None:
+    """Emit deprecation warnings for legacy credentials_path / store_path overrides.
+
+    Warns once per process when any of the following are present:
+    - top-level ``credentials_path`` in config
+    - ``matrix.credentials_path`` in config
+    - ``matrix.e2ee.store_path`` or ``matrix.encryption.store_path`` in config
+    - ``MMRELAY_CREDENTIALS_PATH`` environment variable
+
+    These overrides are scheduled for removal; ``MMRELAY_HOME`` is the
+    supported way to control data paths.
+    """
+    global _legacy_path_override_warning_shown
+    if _legacy_path_override_warning_shown:
+        return
+
+    warnings_to_emit: list[str] = []
+
+    if os.getenv("MMRELAY_CREDENTIALS_PATH"):
+        warnings_to_emit.append("MMRELAY_CREDENTIALS_PATH environment variable is set")
+
+    if isinstance(config, dict):
+        if config.get("credentials_path"):
+            warnings_to_emit.append(
+                "top-level 'credentials_path' config key is present"
+            )
+        matrix_section = config.get(CONFIG_SECTION_MATRIX)
+        if isinstance(matrix_section, dict):
+            if matrix_section.get("credentials_path"):
+                warnings_to_emit.append(
+                    "'matrix.credentials_path' config key is present"
+                )
+            for section in ("e2ee", "encryption"):
+                sub = matrix_section.get(section)
+                if isinstance(sub, dict) and sub.get("store_path"):
+                    warnings_to_emit.append(
+                        f"'matrix.{section}.store_path' config key is present"
+                    )
+
+    if warnings_to_emit:
+        _legacy_path_override_warning_shown = True
+        logger.warning(
+            "Legacy path override(s) detected and will be ignored in a future version: %s. "
+            "Use MMRELAY_HOME to control all data paths. "
+            "Support for these overrides will be removed in v%s.",
+            "; ".join(warnings_to_emit),
+            DEPRECATION_VERSIONS[1],
+        )
+
+
 def _expand_path(path: str) -> str:
     """
     Expand a filesystem path, resolving a leading '~' and returning the absolute path.
@@ -306,6 +360,16 @@ def get_explicit_credentials_path(config: Mapping[str, Any] | None) -> str | Non
     """
     env_path = os.getenv("MMRELAY_CREDENTIALS_PATH")
     if env_path:
+        global _legacy_path_override_warning_shown
+        if not _legacy_path_override_warning_shown:
+            _legacy_path_override_warning_shown = True
+            logger.warning(
+                "MMRELAY_CREDENTIALS_PATH environment variable is set. "
+                "This override is deprecated and will be ignored in a future version. "
+                "Use MMRELAY_HOME to control all data paths. "
+                "Support will be removed in v%s.",
+                DEPRECATION_VERSIONS[1],
+            )
         return env_path
     if not isinstance(config, MappingABC):
         return None
@@ -1295,6 +1359,7 @@ def load_config(
                 relay_config = {}
             # Apply environment variable overrides
             relay_config = apply_env_config_overrides(relay_config)
+            _warn_on_legacy_path_overrides(relay_config)
             return relay_config
         except (yaml.YAMLError, PermissionError, OSError):
             logger.exception(f"Error loading config file {config_file}")
@@ -1328,6 +1393,7 @@ def load_config(
                     relay_config = {}
                 # Apply environment variable overrides
                 relay_config = apply_env_config_overrides(relay_config)
+                _warn_on_legacy_path_overrides(relay_config)
                 return relay_config
             except (yaml.YAMLError, PermissionError, OSError):
                 logger.exception(f"Error loading config file {path}")

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -39,6 +39,7 @@ from mmrelay.config import (
     save_credentials,
     set_config,
 )
+from mmrelay.paths import get_credentials_path
 
 
 class TestConfigEdgeCases(unittest.TestCase):
@@ -1225,6 +1226,20 @@ class TestLegacyPathOverrideWarnings(unittest.TestCase):
                     }
                 )
                 assert result == "/top/path"
+
+    def test_precedence_default_path_when_no_deprecated_overrides(self):
+        from mmrelay.config import get_explicit_credentials_path
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("mmrelay.config.logger") as mock_logger:
+                result = get_explicit_credentials_path({})
+                assert result is None
+
+                search_paths = get_credentials_search_paths(include_base_data=True)
+                default_creds = str(get_credentials_path())
+                assert default_creds in search_paths
+
+                mock_logger.warning.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -1073,6 +1073,11 @@ class TestLegacyPathOverrideWarnings(unittest.TestCase):
 
         mmrelay.config._legacy_path_override_warning_shown = False
 
+    def tearDown(self):
+        import mmrelay.config
+
+        mmrelay.config._legacy_path_override_warning_shown = False
+
     def test_warn_on_mmrelay_credentials_path_env_var(self):
         from mmrelay.config import _warn_on_legacy_path_overrides
 
@@ -1148,7 +1153,7 @@ class TestLegacyPathOverrideWarnings(unittest.TestCase):
     def test_no_warning_when_no_legacy_overrides(self):
         from mmrelay.config import _warn_on_legacy_path_overrides
 
-        with patch.dict(os.environ, {}, clear=False):
+        with patch.dict(os.environ, {}, clear=True):
             with patch("mmrelay.config.logger") as mock_logger:
                 _warn_on_legacy_path_overrides({})
                 mock_logger.warning.assert_not_called()
@@ -1156,21 +1161,22 @@ class TestLegacyPathOverrideWarnings(unittest.TestCase):
     def test_no_warning_with_mmrelay_home_only(self):
         from mmrelay.config import _warn_on_legacy_path_overrides
 
-        with patch.dict(os.environ, {"MMRELAY_HOME": "/home/mmrelay"}):
+        with patch.dict(os.environ, {"MMRELAY_HOME": "/home/mmrelay"}, clear=True):
             with patch("mmrelay.config.logger") as mock_logger:
                 _warn_on_legacy_path_overrides({})
                 mock_logger.warning.assert_not_called()
 
     def test_warning_includes_removal_version(self):
         from mmrelay.config import _warn_on_legacy_path_overrides
+        from mmrelay.constants.config import DEPRECATION_VERSIONS
 
         config = {"credentials_path": "/some/path"}
         with patch("mmrelay.config.logger") as mock_logger:
             _warn_on_legacy_path_overrides(config)
             warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
             assert any(
-                "1.4" in msg for msg in warning_calls
-            ), f"No warning mentioning 1.4 in {warning_calls}"
+                DEPRECATION_VERSIONS[1] in msg for msg in warning_calls
+            ), f"No warning mentioning {DEPRECATION_VERSIONS[1]} in {warning_calls}"
 
     def test_get_explicit_credentials_path_warns_on_env_var(self):
         from mmrelay.config import get_explicit_credentials_path
@@ -1240,6 +1246,49 @@ class TestLegacyPathOverrideWarnings(unittest.TestCase):
                 assert default_creds in search_paths
 
                 mock_logger.warning.assert_not_called()
+
+    def test_call_order_env_var_first_does_not_suppress_config_warnings(self):
+        from mmrelay.config import (
+            _warn_on_legacy_path_overrides,
+            get_explicit_credentials_path,
+        )
+
+        config = {
+            "credentials_path": "/config/path",
+            "matrix": {"e2ee": {"store_path": "/store/path"}},
+        }
+        with patch("mmrelay.config.logger") as mock_logger:
+            with patch.dict(
+                os.environ, {"MMRELAY_CREDENTIALS_PATH": "/env/creds.json"}
+            ):
+                result = get_explicit_credentials_path(config)
+                assert result == "/env/creds.json"
+
+            _warn_on_legacy_path_overrides(config)
+
+            assert mock_logger.warning.call_count == 1
+            warning_msg = str(mock_logger.warning.call_args)
+            assert "MMRELAY_CREDENTIALS_PATH" in warning_msg
+            assert "credentials_path" in warning_msg
+            assert "e2ee" in warning_msg
+
+    def test_call_order_warn_helper_first_does_not_suppress_env_var_path(self):
+        from mmrelay.config import (
+            _warn_on_legacy_path_overrides,
+            get_explicit_credentials_path,
+        )
+
+        config = {"credentials_path": "/config/path"}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+
+            with patch.dict(
+                os.environ, {"MMRELAY_CREDENTIALS_PATH": "/env/creds.json"}
+            ):
+                result = get_explicit_credentials_path(config)
+                assert result == "/env/creds.json"
+
+            assert mock_logger.warning.call_count == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -1055,82 +1055,6 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         assert is_valid is False
         assert parsed is None
 
-    @patch("mmrelay.config.relay_config", {"credentials_path": "/custom/creds.json"})
-    @patch("os.path.isdir", return_value=False)
-    @patch("os.path.abspath", side_effect=lambda x: x)
-    @patch("os.path.expanduser", side_effect=lambda x: x)
-    def test_resolve_credentials_path_relay_config(
-        self, mock_expand, mock_abs, mock_isdir
-    ):
-        from mmrelay.config import _resolve_credentials_path
-
-        result = _resolve_credentials_path(None, allow_relay_config_sources=True)
-        assert result[0] == "/custom/creds.json"
-
-    @patch(
-        "mmrelay.config.relay_config", {"matrix": {"credentials_path": "/matrix/creds"}}
-    )
-    @patch("os.path.isdir", return_value=False)
-    @patch("os.path.abspath", side_effect=lambda x: x)
-    @patch("os.path.expanduser", side_effect=lambda x: x)
-    def test_resolve_credentials_path_matrix_section(
-        self, mock_expand, mock_abs, mock_isdir
-    ):
-        from mmrelay.config import _resolve_credentials_path
-
-        result = _resolve_credentials_path(None, allow_relay_config_sources=True)
-        assert result[0] == "/matrix/creds"
-
-    @patch("mmrelay.config.relay_config", {})
-    @patch("mmrelay.config.get_home_dir", return_value=Path("/home/user"))
-    def test_resolve_credentials_path_default(self, mock_home):
-        from mmrelay.config import _resolve_credentials_path
-
-        result = _resolve_credentials_path(None, allow_relay_config_sources=False)
-        assert "matrix" in result[1]
-        assert CREDENTIALS_FILENAME in result[0]
-
-    @patch("mmrelay.config.relay_config", {})
-    @patch("os.path.isdir", return_value=True)
-    @patch("os.path.abspath", side_effect=lambda x: x)
-    @patch("os.path.expanduser", side_effect=lambda x: x)
-    def test_resolve_credentials_path_directory_appends_filename(
-        self, mock_expand, mock_abs, mock_isdir
-    ):
-        from mmrelay.config import _resolve_credentials_path
-
-        result = _resolve_credentials_path(
-            "/some/dir", allow_relay_config_sources=False
-        )
-        assert result[0].endswith(CREDENTIALS_FILENAME)
-
-    @patch("mmrelay.config.relay_config", {})
-    @patch("os.path.isdir", return_value=False)
-    @patch("mmrelay.config.get_home_dir", return_value=Path("/home"))
-    def test_resolve_credentials_path_empty_dirname(self, mock_home, mock_isdir):
-        from mmrelay.config import _resolve_credentials_path
-
-        result = _resolve_credentials_path(
-            "creds.json", allow_relay_config_sources=False
-        )
-        assert result[0].endswith("creds.json")
-
-    @patch("mmrelay.config.relay_config", {})
-    @patch("os.path.isdir", return_value=False)
-    @patch(
-        "os.path.abspath",
-        side_effect=lambda x: "/abs/" + x if not x.startswith("/") else x,
-    )
-    @patch("os.path.expanduser", side_effect=lambda x: x)
-    @patch("os.getenv", return_value="/env/creds.json")
-    def test_resolve_credentials_path_env_var(
-        self, mock_env, mock_expand, mock_abs, mock_isdir
-    ):
-        from mmrelay.config import _resolve_credentials_path
-
-        result = _resolve_credentials_path(None, allow_relay_config_sources=True)
-        assert "env" in result[0]
-
     def test_backward_compat_alias(self):
         from mmrelay.config import (
             get_candidate_credentials_paths,
@@ -1140,6 +1064,167 @@ class TestConfigAdditionalCoverage(unittest.TestCase):
         result1 = get_candidate_credentials_paths(include_base_data=False)
         result2 = get_credentials_search_paths(include_base_data=False)
         assert result1 == result2
+
+
+class TestLegacyPathOverrideWarnings(unittest.TestCase):
+    def setUp(self):
+        import mmrelay.config
+
+        mmrelay.config._legacy_path_override_warning_shown = False
+
+    def test_warn_on_mmrelay_credentials_path_env_var(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        with patch.dict(os.environ, {"MMRELAY_CREDENTIALS_PATH": "/some/path"}):
+            with patch("mmrelay.config.logger") as mock_logger:
+                _warn_on_legacy_path_overrides(None)
+                warning_calls = [
+                    str(call) for call in mock_logger.warning.call_args_list
+                ]
+                assert any(
+                    "MMRELAY_CREDENTIALS_PATH" in msg for msg in warning_calls
+                ), f"No warning mentioning MMRELAY_CREDENTIALS_PATH in {warning_calls}"
+                assert any(
+                    "MMRELAY_HOME" in msg for msg in warning_calls
+                ), f"No warning mentioning MMRELAY_HOME in {warning_calls}"
+
+    def test_warn_on_top_level_credentials_path_config(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        config = {"credentials_path": "/some/path"}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+            warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+            assert any(
+                "credentials_path" in msg for msg in warning_calls
+            ), f"No warning mentioning credentials_path in {warning_calls}"
+            assert any(
+                "MMRELAY_HOME" in msg for msg in warning_calls
+            ), f"No warning mentioning MMRELAY_HOME in {warning_calls}"
+
+    def test_warn_on_matrix_credentials_path_config(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        config = {"matrix": {"credentials_path": "/some/path"}}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+            warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+            assert any(
+                "matrix.credentials_path" in msg for msg in warning_calls
+            ), f"No warning mentioning matrix.credentials_path in {warning_calls}"
+
+    def test_warn_on_matrix_e2ee_store_path_config(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        config = {"matrix": {"e2ee": {"store_path": "/some/path"}}}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+            warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+            assert any(
+                "e2ee" in msg and "store_path" in msg for msg in warning_calls
+            ), f"No warning mentioning e2ee store_path in {warning_calls}"
+
+    def test_warn_on_matrix_encryption_store_path_config(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        config = {"matrix": {"encryption": {"store_path": "/some/path"}}}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+            warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+            assert any(
+                "encryption" in msg and "store_path" in msg for msg in warning_calls
+            ), f"No warning mentioning encryption store_path in {warning_calls}"
+
+    def test_warning_emitted_once_per_process(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        config = {"credentials_path": "/some/path"}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+            _warn_on_legacy_path_overrides(config)
+            assert mock_logger.warning.call_count == 1
+
+    def test_no_warning_when_no_legacy_overrides(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        with patch.dict(os.environ, {}, clear=False):
+            with patch("mmrelay.config.logger") as mock_logger:
+                _warn_on_legacy_path_overrides({})
+                mock_logger.warning.assert_not_called()
+
+    def test_no_warning_with_mmrelay_home_only(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        with patch.dict(os.environ, {"MMRELAY_HOME": "/home/mmrelay"}):
+            with patch("mmrelay.config.logger") as mock_logger:
+                _warn_on_legacy_path_overrides({})
+                mock_logger.warning.assert_not_called()
+
+    def test_warning_includes_removal_version(self):
+        from mmrelay.config import _warn_on_legacy_path_overrides
+
+        config = {"credentials_path": "/some/path"}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+            warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+            assert any(
+                "1.4" in msg for msg in warning_calls
+            ), f"No warning mentioning 1.4 in {warning_calls}"
+
+    def test_get_explicit_credentials_path_warns_on_env_var(self):
+        from mmrelay.config import get_explicit_credentials_path
+
+        with patch.dict(os.environ, {"MMRELAY_CREDENTIALS_PATH": "/env/creds.json"}):
+            with patch("mmrelay.config.logger") as mock_logger:
+                result = get_explicit_credentials_path(None)
+                assert result == "/env/creds.json"
+                warning_calls = [
+                    str(call) for call in mock_logger.warning.call_args_list
+                ]
+                assert any(
+                    "MMRELAY_CREDENTIALS_PATH" in msg for msg in warning_calls
+                ), f"No warning mentioning MMRELAY_CREDENTIALS_PATH in {warning_calls}"
+                assert any(
+                    "MMRELAY_HOME" in msg for msg in warning_calls
+                ), f"No warning mentioning MMRELAY_HOME in {warning_calls}"
+
+    def test_get_explicit_credentials_path_no_double_warn(self):
+        from mmrelay.config import (
+            _warn_on_legacy_path_overrides,
+            get_explicit_credentials_path,
+        )
+
+        config = {"credentials_path": "/some/path"}
+        with patch("mmrelay.config.logger") as mock_logger:
+            _warn_on_legacy_path_overrides(config)
+            with patch.dict(
+                os.environ, {"MMRELAY_CREDENTIALS_PATH": "/env/creds.json"}
+            ):
+                get_explicit_credentials_path(None)
+            assert mock_logger.warning.call_count == 1
+
+    def test_precedence_env_var_over_config(self):
+        from mmrelay.config import get_explicit_credentials_path
+
+        with patch.dict(os.environ, {"MMRELAY_CREDENTIALS_PATH": "/env/path"}):
+            with patch("mmrelay.config.logger"):
+                result = get_explicit_credentials_path(
+                    {"credentials_path": "/config/path"}
+                )
+                assert result == "/env/path"
+
+    def test_precedence_top_level_over_matrix_section(self):
+        from mmrelay.config import get_explicit_credentials_path
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("mmrelay.config.logger"):
+                result = get_explicit_credentials_path(
+                    {
+                        "credentials_path": "/top/path",
+                        "matrix": {"credentials_path": "/matrix/path"},
+                    }
+                )
+                assert result == "/top/path"
 
 
 if __name__ == "__main__":

--- a/tests/test_meshtastic_utils_connect_paths.py
+++ b/tests/test_meshtastic_utils_connect_paths.py
@@ -1673,3 +1673,110 @@ def test_connect_time_probe_submits_immediately_when_drain_expired():
 
     mock_submit_probe.assert_called_once()
     assert mu._pending_connect_time_probe_timer is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+def test_connect_time_probe_reconnect_shutdown_lifecycle():
+    """Full scenario: delayed probe survives reconnect and shutdown without stale submissions.
+
+    This is a higher-level sequence test that validates the interaction between
+    connect-time metadata probes, delayed timers, client changes (reconnect),
+    and shutdown. It protects against regressions where a stale timer callback
+    submits a probe for a disconnected client or submits after shutdown begins.
+
+    Sequence:
+      1. Startup drain is active -> probe is delayed via Timer.
+      2. A connect-time metadata probe is scheduled for later.
+      3. Connection/client changes before the delayed callback runs.
+      4. The old delayed callback runs and is ignored as stale.
+      5. A new client/timer is installed.
+      6. Shutdown begins before the new delayed callback runs.
+      7. The new delayed callback is also suppressed.
+      8. No stale _submit_metadata_probe call occurs.
+      9. Pending timer state is cleaned up correctly.
+    """
+    first_client = MagicMock()
+    first_client.localNode = MagicMock()
+    first_client.sendData = MagicMock()
+
+    second_client = MagicMock()
+    second_client.localNode = MagicMock()
+    second_client.sendData = MagicMock()
+
+    now = 1_000.0
+    drain_deadline = now + 5.0
+
+    mu._relay_startup_drain_deadline_monotonic_secs = drain_deadline
+    mu.meshtastic_client = first_client
+    mu._relay_active_client_id = id(first_client)
+    mu.shutting_down = False
+
+    with (
+        patch("mmrelay.meshtastic.connection.threading.Timer", _FakeTimer),
+        patch("mmrelay.meshtastic_utils._submit_metadata_probe") as mock_submit_probe,
+        patch("mmrelay.meshtastic_utils.time.monotonic", return_value=now),
+    ):
+        # 1. Startup drain is active -> probe is delayed via Timer.
+        mu._schedule_connect_time_calibration_probe(
+            first_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+        # 2. A connect-time metadata probe is scheduled for later.
+        first_timer = mu._pending_connect_time_probe_timer
+        assert first_timer is not None
+        assert isinstance(first_timer, _FakeTimer)
+        mock_submit_probe.assert_not_called()
+
+        # 3. Connection/client changes before the delayed callback runs.
+        mu.meshtastic_client = second_client
+        mu._relay_active_client_id = id(second_client)
+
+        # 4. The old delayed callback runs and is ignored as stale.
+        first_timer.function()
+        mock_submit_probe.assert_not_called()
+        # Timer should clear itself when it detects stale client
+        assert mu._pending_connect_time_probe_timer is None
+
+        # 5. A new client/timer is installed.
+        mu._schedule_connect_time_calibration_probe(
+            second_client,
+            connection_type=CONNECTION_TYPE_TCP,
+            active_config={
+                "meshtastic": {
+                    "connection_type": CONNECTION_TYPE_TCP,
+                    "host": "127.0.0.1",
+                    "health_check": {"enabled": True, "connect_probe_enabled": True},
+                }
+            },
+        )
+
+        second_timer = mu._pending_connect_time_probe_timer
+        assert second_timer is not None
+        assert isinstance(second_timer, _FakeTimer)
+        assert second_timer is not first_timer
+        # The first timer fired as stale and cleared itself; it was not explicitly
+        # cancelled because its reference was already removed from the guard.
+        mock_submit_probe.assert_not_called()
+
+        # 6. Shutdown begins before the new delayed callback runs.
+        mu.shutting_down = True
+
+        # 7. The new delayed callback is also suppressed.
+        second_timer.function()
+        mock_submit_probe.assert_not_called()
+
+        # 8. No stale _submit_metadata_probe call occurred at any point.
+        assert mock_submit_probe.call_count == 0
+
+        # 9. Pending timer state is cleaned up correctly.
+        assert mu._pending_connect_time_probe_timer is None
+
+    mu.shutting_down = False

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -330,7 +330,10 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     def test_command_aliases_valid(self):
         """Valid alias pointing to a known command should be stored and resolved."""
-        self.plugin.config = {"units": WEATHER_UNITS_METRIC, "command_aliases": {"meteo": "daily"}}
+        self.plugin.config = {
+            "units": WEATHER_UNITS_METRIC,
+            "command_aliases": {"meteo": "daily"},
+        }
         self.plugin._load_command_aliases()
         self.assertIn("meteo", self.plugin._command_aliases)
         self.assertEqual(self.plugin._command_aliases["meteo"], "daily")
@@ -339,27 +342,39 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     def test_command_aliases_invalid_target_warns(self):
         """Alias pointing to an unknown command should be ignored with a warning."""
-        self.plugin.config = {"units": WEATHER_UNITS_METRIC, "command_aliases": {"foo": "nonexistent"}}
+        self.plugin.config = {
+            "units": WEATHER_UNITS_METRIC,
+            "command_aliases": {"foo": "nonexistent"},
+        }
         self.plugin._load_command_aliases()
         self.assertNotIn("foo", self.plugin._command_aliases)
         self.plugin.logger.warning.assert_called()
 
     def test_command_aliases_case_insensitive(self):
         """Alias keys and targets should be normalized to lowercase."""
-        self.plugin.config = {"units": WEATHER_UNITS_METRIC, "command_aliases": {"METEO": "DAILY"}}
+        self.plugin.config = {
+            "units": WEATHER_UNITS_METRIC,
+            "command_aliases": {"METEO": "DAILY"},
+        }
         self.plugin._load_command_aliases()
         self.assertIn("meteo", self.plugin._command_aliases)
         self.assertEqual(self.plugin._command_aliases["meteo"], "daily")
 
     def test_normalize_mode_resolves_alias(self):
         """_normalize_mode should resolve a configured alias to its canonical target."""
-        self.plugin.config = {"units": WEATHER_UNITS_METRIC, "command_aliases": {"meteo": "daily"}}
+        self.plugin.config = {
+            "units": WEATHER_UNITS_METRIC,
+            "command_aliases": {"meteo": "daily"},
+        }
         self.plugin._load_command_aliases()
         self.assertEqual(self.plugin._normalize_mode("meteo"), "daily")
 
     def test_parse_mesh_command_resolves_alias(self):
         """_parse_mesh_command should resolve a mesh alias to the canonical command."""
-        self.plugin.config = {"units": WEATHER_UNITS_METRIC, "command_aliases": {"meteo": "daily"}}
+        self.plugin.config = {
+            "units": WEATHER_UNITS_METRIC,
+            "command_aliases": {"meteo": "daily"},
+        }
         self.plugin._load_command_aliases()
         cmd, args = self.plugin._parse_mesh_command("!meteo 10.0 20.0")
         self.assertEqual(cmd, "daily")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR tightens how credentials paths are resolved and warned about, improves lifecycle test coverage for Meshtastic connection probes, and replaces an old Docker validation flow in CI with a simpler, faster workflow that loads images into the runner for smoke tests.

Features
- New CI workflow: docker-validate
  - Builds a local Docker image (linux/amd64) without pushing
  - Loads the image into the local Docker daemon and runs a smoke test (`mmrelay --version`)
  - Uses glob patterns for docker-compose file matching and removes the export/upload tarball step

Refactors
- Credentials path resolution and deprecation handling
  - Removed internal helper `_resolve_credentials_path()` (unused)
  - Centralized legacy-path deprecation logic into `_warn_on_legacy_path_overrides(...)`
  - Introduced process-wide, thread-safe one-time warning state using `_legacy_path_override_warning_shown` + lock
  - Updated `get_explicit_credentials_path(...)` and `load_config(...)` to call the new warning helper at appropriate times
  - Clarified and documented credentials precedence: environment (`MMRELAY_CREDENTIALS_PATH`) > top-level config > matrix config > default (`MMRELAY_HOME`)
  - Adjusted type hints (e.g., Mapping) for robustness

Fixes / Tests
- Expanded and hardened tests around credential-path behavior and warnings
  - Tests assert deprecation warnings are emitted for legacy inputs: `MMRELAY_CREDENTIALS_PATH`, `credentials_path`, `matrix.credentials_path`, and `matrix.e2ee|encryption.store_path`
  - Ensures the warning is emitted at most once per process and that warning behavior is correct regardless of call order
  - Validates explicit env-var precedence and that defaults still appear in search paths when appropriate
- Added lifecycle test for Meshtastic connection probe timers
  - Simulates delayed connect-time metadata probe during startup drain
  - Verifies stale timer callbacks are suppressed after client replacement (reconnect)
  - Verifies pending callbacks are suppressed on shutdown
  - Ensures no probe submission or timer leakage occurs

Documentation / Misc
- .gitignore updated to add patterns for `.env`, `config.yaml`, and more precise entries for build/artifact paths
- Trunk lint runtime versions updated
- Minor test formatting changes (weather plugin tests) only

Breaking changes / Migration notes
- No functional breaking changes expected. The only API surface change is the removal of the internal `_resolve_credentials_path()` helper (it was not part of the public API). Consumers should rely on documented public functions and the `MMRELAY_HOME`-based model. If external code referenced `_resolve_credentials_path()`, it must be updated to use public config APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->