### PR TITLE
Centralize Matrix command parser, remove py-staticmaps monkeypatch, clean up BLE typing

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,7 +18,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.138.0
+    - renovate@43.136.1
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - mypy@1.20.1

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,7 +18,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.136.1
+    - renovate@43.138.0
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - mypy@1.20.1

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -349,7 +349,8 @@ def _parse_matrix_message_command(
         return None
 
     if require_mention:
-        assert bot_mxid is not None
+        if bot_mxid is None:
+            return None
 
         # Pass 1: require exact MXID mention semantics across all body variants.
         # This tier includes plain-body MXID prefixes and formatted-body mention

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -348,23 +348,34 @@ def _parse_matrix_message_command(
     if not candidate_bodies:
         return None
 
-    for body in candidate_bodies:
-        if require_mention:
-            assert bot_mxid is not None
+    if require_mention:
+        assert bot_mxid is not None
+
+        # Pass 1: require exact MXID mention semantics across all body variants.
+        # This tier includes plain-body MXID prefixes and formatted-body mention
+        # pills that normalize to MXID prefixes.
+        for body in candidate_bodies:
             suffix = _consume_mxid_mention_prefix(body, bot_mxid)
-            if suffix is not None:
+            if suffix is None:
+                continue
+            parsed = _match_bang_command(suffix, command_lookup)
+            if parsed is not None:
+                return parsed
+
+        # Pass 2: fall back to anchored display-name prefixes only if MXID tier
+        # produced no result from any candidate body.
+        if bot_display_name:
+            for body in candidate_bodies:
+                suffix = _consume_display_name_prefix(body, bot_display_name)
+                if suffix is None:
+                    continue
                 parsed = _match_bang_command(suffix, command_lookup)
                 if parsed is not None:
                     return parsed
-                continue
-            if bot_display_name:
-                suffix = _consume_display_name_prefix(body, bot_display_name)
-                if suffix is not None:
-                    parsed = _match_bang_command(suffix, command_lookup)
-                    if parsed is not None:
-                        return parsed
-            continue
 
+        return None
+
+    for body in candidate_bodies:
         parsed = _match_bang_command(body, command_lookup)
         if parsed is not None:
             return parsed

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -202,6 +202,18 @@ def _resolve_bot_mxid() -> str | None:
     return mxid or None
 
 
+def _resolve_bot_display_name() -> str | None:
+    """Return the configured bot display name as a safe string, if available."""
+    name = facade.bot_user_name
+    if not name:
+        return None
+    try:
+        display_name = str(name).strip()
+    except Exception:  # noqa: BLE001
+        return None
+    return display_name or None
+
+
 def _consume_mxid_mention_prefix(message: str, bot_mxid: str) -> str | None:
     """
     Consume an exact bot MXID mention prefix and return the remaining text.
@@ -214,6 +226,44 @@ def _consume_mxid_mention_prefix(message: str, bot_mxid: str) -> str | None:
         return None
 
     remainder = message[len(bot_mxid) :]
+    if not remainder:
+        return None
+
+    if remainder[0].isspace():
+        return remainder.lstrip()
+
+    if remainder[0] == ":":
+        if len(remainder) < 2 or not remainder[1].isspace():
+            return None
+        return remainder[1:].lstrip()
+
+    return None
+
+
+def _consume_display_name_prefix(message: str, display_name: str) -> str | None:
+    """
+    Consume a display-name mention prefix and return the remaining text.
+
+    This is a controlled fallback for Matrix clients that render mention pills
+    with only the display name in the plain-text body.  Matching is
+    case-insensitive and strictly anchored to the start of the message.
+
+    Accepted forms:
+    - ``DisplayName !cmd``  (whitespace separator)
+    - ``DisplayName: !cmd`` (colon + whitespace separator)
+
+    Rejected forms:
+    - ``DisplayName!cmd``  (no separator)
+    - ``words DisplayName !cmd`` (not at start)
+    - partial prefix matches
+    """
+    if not display_name:
+        return None
+
+    if not message.lower().startswith(display_name.lower()):
+        return None
+
+    remainder = message[len(display_name) :]
     if not remainder:
         return None
 
@@ -262,12 +312,24 @@ def _parse_matrix_message_command(
     """
     Parse a Matrix message and return the matched command plus arguments.
 
-    Mention policy:
-    - Mention target must match the configured bot MXID exactly.
-    - Supported forms are ``@bot:server !cmd`` and ``@bot:server: !cmd``.
-    - Compact ``@bot:server!cmd`` and display-name prefixes do not match.
-    - For ``formatted_body``, mention pills are matched by MXID link target rather
-      than visible display text.
+    Mention matching is tried in priority order:
+
+    A. **MXID mention** (exact match on ``@bot:server``):
+       - ``@bot:server !cmd`` or ``@bot:server: !cmd``
+       - Compact ``@bot:server!cmd`` is rejected.
+
+    B. **Mention pill** (via ``formatted_body`` HTML):
+       - ``<a href="matrix:…/@bot:server">DisplayName</a>: !cmd``
+       - Matched by MXID link target, not visible text.
+
+    C. **Display-name fallback** (only when A and B fail):
+       - ``BotName !cmd`` or ``BotName: !cmd``
+       - Case-insensitive, anchored at start, no arbitrary prefixes.
+       - Intended for clients that strip MXID from the plain-text body.
+
+    Display-name matching never overrides an MXID or pill match.  Matching
+    is anchored to the start of the message; arbitrary prose before the
+    command is not accepted.
 
     Command matching is case-insensitive; command canonicalization follows
     ``commands`` input.
@@ -280,6 +342,8 @@ def _parse_matrix_message_command(
     if require_mention and not bot_mxid:
         return None
 
+    bot_display_name = _resolve_bot_display_name() if require_mention else None
+
     candidate_bodies = _extract_candidate_bodies(message, bot_mxid=bot_mxid)
     if not candidate_bodies:
         return None
@@ -288,11 +352,17 @@ def _parse_matrix_message_command(
         if require_mention:
             assert bot_mxid is not None
             suffix = _consume_mxid_mention_prefix(body, bot_mxid)
-            if suffix is None:
+            if suffix is not None:
+                parsed = _match_bang_command(suffix, command_lookup)
+                if parsed is not None:
+                    return parsed
                 continue
-            parsed = _match_bang_command(suffix, command_lookup)
-            if parsed is not None:
-                return parsed
+            if bot_display_name:
+                suffix = _consume_display_name_prefix(body, bot_display_name)
+                if suffix is not None:
+                    parsed = _match_bang_command(suffix, command_lookup)
+                    if parsed is not None:
+                        return parsed
             continue
 
         parsed = _match_bang_command(body, command_lookup)

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, cast
+from urllib.parse import unquote
 
 from nio import (
     AsyncClient,
@@ -34,13 +35,67 @@ class ParsedMatrixCommand:
     args: str
 
 
-def _normalize_formatted_body_for_command_detection(formatted_body: Any) -> str:
+def _extract_anchor_href(anchor_attrs: str) -> str | None:
+    """Return the href value from an anchor tag attributes string."""
+    href_match = re.search(
+        r"""(?is)\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))""",
+        anchor_attrs,
+    )
+    if href_match is None:
+        return None
+    for group in href_match.groups():
+        if group is not None:
+            href = group.strip()
+            return href or None
+    return None
+
+
+def _extract_matrix_mxid_from_href(href: str) -> str | None:
+    """
+    Extract a Matrix MXID from common mention-link href formats.
+
+    Supported patterns include matrix.to permalinks and direct/URI-style MXID
+    references. Returns ``None`` when the href does not cleanly resolve to an
+    MXID token.
+    """
+    decoded_href = unquote(html.unescape(href)).strip()
+    if not decoded_href:
+        return None
+
+    matrix_to_match = re.search(
+        r"(?i)matrix\.to/#/(?P<target>[^?#]+)",
+        decoded_href,
+    )
+    if matrix_to_match is not None:
+        target = unquote(matrix_to_match.group("target")).lstrip("/")
+        return target if target.startswith("@") else None
+
+    if decoded_href.startswith("matrix:"):
+        target = unquote(decoded_href[len("matrix:") :]).lstrip("/")
+        if target.startswith("u/"):
+            target = target[2:]
+            if target and not target.startswith("@"):
+                target = f"@{target}"
+        target = target.split("?", maxsplit=1)[0]
+        return target if target.startswith("@") else None
+
+    if decoded_href.startswith("@"):
+        return decoded_href.split("?", maxsplit=1)[0]
+
+    return None
+
+
+def _normalize_formatted_body_for_command_detection(
+    formatted_body: Any, *, bot_mxid: str | None
+) -> str:
     """
     Convert Matrix ``formatted_body`` HTML into conservative plain text for matching.
 
     The normalization removes reply blocks and tags, unescapes HTML entities, and
-    collapses whitespace. It is intentionally minimal and only used for command
-    detection, not for rendering.
+    collapses whitespace. For anchor tags, only links that resolve to the configured
+    bot MXID are preserved (as the MXID token itself); all other anchors are
+    discarded. This keeps mention matching strict while still supporting Matrix
+    mention pills that display a human-friendly name.
     """
     if not isinstance(formatted_body, str) or not formatted_body:
         return ""
@@ -50,11 +105,26 @@ def _normalize_formatted_body_for_command_detection(formatted_body: Any) -> str:
         " ",
         formatted_body,
     )
+
+    def _replace_anchor(match: re.Match[str]) -> str:
+        if not bot_mxid:
+            return " "
+        anchor_attrs = match.group("attrs")
+        href = _extract_anchor_href(anchor_attrs)
+        if href is None:
+            return " "
+        mxid_target = _extract_matrix_mxid_from_href(href)
+        return bot_mxid if mxid_target == bot_mxid else " "
+
+    normalized = re.sub(
+        r"(?is)<a\b(?P<attrs>[^>]*)>.*?</a>",
+        _replace_anchor,
+        normalized,
+    )
     normalized = re.sub(r"(?i)<br\s*/?>", " ", normalized)
     normalized = re.sub(r"<[^>]+>", " ", normalized)
     normalized = html.unescape(normalized)
-    normalized = re.sub(r"\s+", " ", normalized).strip()
-    return re.sub(r"\s+([:;,])", r"\1", normalized)
+    return re.sub(r"\s+", " ", normalized).strip()
 
 
 def _build_command_lookup(commands: Iterable[str]) -> dict[str, str]:
@@ -80,6 +150,8 @@ def _extract_candidate_bodies(
     message: (
         str | RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote
     ),
+    *,
+    bot_mxid: str | None,
 ) -> list[str]:
     """Return plain/normalized message variants used for command matching."""
     if isinstance(message, str):
@@ -99,7 +171,8 @@ def _extract_candidate_bodies(
         content.get("formatted_body", "") if isinstance(content, dict) else ""
     )
     normalized_formatted = _normalize_formatted_body_for_command_detection(
-        formatted_body
+        formatted_body,
+        bot_mxid=bot_mxid,
     )
     if normalized_formatted and normalized_formatted not in bodies:
         bodies.append(normalized_formatted)
@@ -129,7 +202,7 @@ def _consume_mxid_mention_prefix(message: str, bot_mxid: str) -> str | None:
 
     Supported mention separators between MXID and command:
     - one or more whitespace characters
-    - one of `:`, `;`, `,` immediately followed by whitespace
+    - a single `:` immediately followed by whitespace
     """
     if not message.startswith(bot_mxid):
         return None
@@ -141,7 +214,7 @@ def _consume_mxid_mention_prefix(message: str, bot_mxid: str) -> str | None:
     if remainder[0].isspace():
         return remainder.lstrip()
 
-    if remainder[0] in ":;,":
+    if remainder[0] == ":":
         if len(remainder) < 2 or not remainder[1].isspace():
             return None
         return remainder[1:].lstrip()
@@ -185,9 +258,10 @@ def _parse_matrix_message_command(
 
     Mention policy:
     - Mention target must match the configured bot MXID exactly.
-    - Supported forms are ``@bot:server !cmd`` and ``@bot:server: !cmd`` (also
-      ``,``/``;`` separators with required following whitespace).
+    - Supported forms are ``@bot:server !cmd`` and ``@bot:server: !cmd``.
     - Compact ``@bot:server!cmd`` and display-name prefixes do not match.
+    - For ``formatted_body``, mention pills are matched by MXID link target rather
+      than visible display text.
 
     Command matching is case-insensitive; command canonicalization follows
     ``commands`` input.
@@ -196,16 +270,17 @@ def _parse_matrix_message_command(
     if not command_lookup:
         return None
 
-    candidate_bodies = _extract_candidate_bodies(message)
+    bot_mxid = _resolve_bot_mxid()
+    if require_mention and not bot_mxid:
+        return None
+
+    candidate_bodies = _extract_candidate_bodies(message, bot_mxid=bot_mxid)
     if not candidate_bodies:
         return None
 
-    bot_mxid = _resolve_bot_mxid()
-
     for body in candidate_bodies:
         if require_mention:
-            if not bot_mxid:
-                return None
+            assert bot_mxid is not None
             suffix = _consume_mxid_mention_prefix(body, bot_mxid)
             if suffix is None:
                 continue

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -87,9 +87,11 @@ def _extract_candidate_bodies(
         return [stripped] if stripped else []
 
     bodies: list[str] = []
-    plain_body = (getattr(message, "body", "") or "").strip()
-    if plain_body:
-        bodies.append(plain_body)
+    plain_raw = getattr(message, "body", "")
+    if isinstance(plain_raw, str):
+        plain_body = plain_raw.strip()
+        if plain_body:
+            bodies.append(plain_body)
 
     source = getattr(message, "source", {})
     content = source.get("content", {}) if isinstance(source, dict) else {}

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -36,17 +36,23 @@ class ParsedMatrixCommand:
 
 
 def _extract_anchor_href(anchor_attrs: str) -> str | None:
-    """Return the href value from an anchor tag attributes string."""
-    href_match = re.search(
-        r"""(?is)\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))""",
+    """
+    Return the value of an exact ``href`` attribute from an anchor tag.
+
+    The attribute name must be exactly ``href`` (case-insensitive). Attributes
+    such as ``data-href`` or ``aria-href`` are ignored.
+    """
+    for attr_match in re.finditer(
+        r"""(?is)(?:^|\s)(?P<name>[^\s=/>]+)\s*=\s*(?:"(?P<dq>[^"]*)"|'(?P<sq>[^']*)'|(?P<uq>[^\s>]+))""",
         anchor_attrs,
-    )
-    if href_match is None:
-        return None
-    for group in href_match.groups():
-        if group is not None:
-            href = group.strip()
-            return href or None
+    ):
+        if attr_match.group("name").casefold() != "href":
+            continue
+        for group_name in ("dq", "sq", "uq"):
+            value = attr_match.group(group_name)
+            if value is not None:
+                href = value.strip()
+                return href or None
     return None
 
 
@@ -86,7 +92,7 @@ def _extract_matrix_mxid_from_href(href: str) -> str | None:
 
 
 def _normalize_formatted_body_for_command_detection(
-    formatted_body: Any, *, bot_mxid: str | None
+    formatted_body: object, *, bot_mxid: str | None
 ) -> str:
     """
     Convert Matrix ``formatted_body`` HTML into conservative plain text for matching.

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -1,5 +1,8 @@
 import asyncio
+import html
 import re
+from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any, cast
 
 from nio import (
@@ -21,6 +24,207 @@ __all__ = [
     "_get_meshtastic_interface_and_channel",
     "_handle_detection_sensor_packet",
 ]
+
+
+@dataclass(frozen=True)
+class ParsedMatrixCommand:
+    """Normalized result for a parsed Matrix command invocation."""
+
+    command: str
+    args: str
+
+
+def _normalize_formatted_body_for_command_detection(formatted_body: Any) -> str:
+    """
+    Convert Matrix ``formatted_body`` HTML into conservative plain text for matching.
+
+    The normalization removes reply blocks and tags, unescapes HTML entities, and
+    collapses whitespace. It is intentionally minimal and only used for command
+    detection, not for rendering.
+    """
+    if not isinstance(formatted_body, str) or not formatted_body:
+        return ""
+
+    normalized = re.sub(
+        r"(?is)<mx-reply>.*?</mx-reply>",
+        " ",
+        formatted_body,
+    )
+    normalized = re.sub(r"(?i)<br\s*/?>", " ", normalized)
+    normalized = re.sub(r"<[^>]+>", " ", normalized)
+    normalized = html.unescape(normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return re.sub(r"\s+([:;,])", r"\1", normalized)
+
+
+def _build_command_lookup(commands: Iterable[str]) -> dict[str, str]:
+    """Build case-insensitive command lookup preserving canonical spellings."""
+    command_lookup: dict[str, str] = {}
+    for command in commands:
+        if not isinstance(command, str):
+            continue
+        normalized = command.strip()
+        if not normalized:
+            continue
+        if normalized.startswith("!"):
+            normalized = normalized[1:]
+        if not normalized:
+            continue
+        key = normalized.casefold()
+        if key not in command_lookup:
+            command_lookup[key] = normalized
+    return command_lookup
+
+
+def _extract_candidate_bodies(
+    message: (
+        str | RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote
+    ),
+) -> list[str]:
+    """Return plain/normalized message variants used for command matching."""
+    if isinstance(message, str):
+        stripped = message.strip()
+        return [stripped] if stripped else []
+
+    bodies: list[str] = []
+    plain_body = (getattr(message, "body", "") or "").strip()
+    if plain_body:
+        bodies.append(plain_body)
+
+    source = getattr(message, "source", {})
+    content = source.get("content", {}) if isinstance(source, dict) else {}
+    formatted_body = (
+        content.get("formatted_body", "") if isinstance(content, dict) else ""
+    )
+    normalized_formatted = _normalize_formatted_body_for_command_detection(
+        formatted_body
+    )
+    if normalized_formatted and normalized_formatted not in bodies:
+        bodies.append(normalized_formatted)
+    return bodies
+
+
+def _resolve_bot_mxid() -> str | None:
+    """Return the configured bot MXID as a safe string, if available."""
+    identifier = facade.bot_user_id
+    if not identifier:
+        return None
+    try:
+        mxid = str(identifier).strip()
+    except Exception as exc:  # noqa: BLE001 - broken __str__ should not crash parsing
+        facade.logger.debug(
+            "Failed to stringify bot MXID %r for command parsing: %s",
+            identifier,
+            type(exc).__name__,
+        )
+        return None
+    return mxid or None
+
+
+def _consume_mxid_mention_prefix(message: str, bot_mxid: str) -> str | None:
+    """
+    Consume an exact bot MXID mention prefix and return the remaining text.
+
+    Supported mention separators between MXID and command:
+    - one or more whitespace characters
+    - one of `:`, `;`, `,` immediately followed by whitespace
+    """
+    if not message.startswith(bot_mxid):
+        return None
+
+    remainder = message[len(bot_mxid) :]
+    if not remainder:
+        return None
+
+    if remainder[0].isspace():
+        return remainder.lstrip()
+
+    if remainder[0] in ":;,":
+        if len(remainder) < 2 or not remainder[1].isspace():
+            return None
+        return remainder[1:].lstrip()
+
+    return None
+
+
+def _match_bang_command(
+    message: str, command_lookup: dict[str, str]
+) -> ParsedMatrixCommand | None:
+    """Parse a leading ``!command`` plus optional args from a message body."""
+    if not message:
+        return None
+
+    command_alternatives = sorted(command_lookup.values(), key=len, reverse=True)
+    command_pattern = "|".join(re.escape(command) for command in command_alternatives)
+    match = re.match(
+        rf"^!(?P<command>{command_pattern})(?=$|\s)(?:\s+(?P<args>.*))?$",
+        message,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None
+
+    matched_command = match.group("command")
+    canonical = command_lookup.get(matched_command.casefold(), matched_command)
+    args = (match.group("args") or "").strip()
+    return ParsedMatrixCommand(command=canonical, args=args)
+
+
+def _parse_matrix_message_command(
+    message: (
+        str | RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote
+    ),
+    commands: Iterable[str],
+    *,
+    require_mention: bool = False,
+) -> ParsedMatrixCommand | None:
+    """
+    Parse a Matrix message and return the matched command plus arguments.
+
+    Mention policy:
+    - Mention target must match the configured bot MXID exactly.
+    - Supported forms are ``@bot:server !cmd`` and ``@bot:server: !cmd`` (also
+      ``,``/``;`` separators with required following whitespace).
+    - Compact ``@bot:server!cmd`` and display-name prefixes do not match.
+
+    Command matching is case-insensitive; command canonicalization follows
+    ``commands`` input.
+    """
+    command_lookup = _build_command_lookup(commands)
+    if not command_lookup:
+        return None
+
+    candidate_bodies = _extract_candidate_bodies(message)
+    if not candidate_bodies:
+        return None
+
+    bot_mxid = _resolve_bot_mxid()
+
+    for body in candidate_bodies:
+        if require_mention:
+            if not bot_mxid:
+                return None
+            suffix = _consume_mxid_mention_prefix(body, bot_mxid)
+            if suffix is None:
+                continue
+            parsed = _match_bang_command(suffix, command_lookup)
+            if parsed is not None:
+                return parsed
+            continue
+
+        parsed = _match_bang_command(body, command_lookup)
+        if parsed is not None:
+            return parsed
+
+        if bot_mxid:
+            suffix = _consume_mxid_mention_prefix(body, bot_mxid)
+            if suffix is None:
+                continue
+            parsed = _match_bang_command(suffix, command_lookup)
+            if parsed is not None:
+                return parsed
+
+    return None
 
 
 def _estimate_clock_rollback_ms(
@@ -88,7 +292,8 @@ def bot_command(
     """
     Determine whether a Matrix event addresses the bot with the given command.
 
-    Checks the event's plain and HTML-formatted bodies. Matches when the message either starts with `!<command>` (only allowed when `require_mention` is False) or begins with an explicit mention of the bot (bot MXID or display name) optionally followed by punctuation/whitespace and then `!<command>`.
+    Uses the shared Matrix command parser against both plain ``body`` and
+    normalized ``formatted_body`` content. Mentions are MXID-only.
 
     Parameters:
         command (str): Command name to detect (without the leading `!`).
@@ -98,44 +303,17 @@ def bot_command(
     Returns:
         bool: `True` if the message addresses the bot with the given command, `False` otherwise.
     """
-    full_message = (getattr(event, "body", "") or "").strip()
     if not command:
         return False
-    content = event.source.get("content", {})
-    formatted_body = content.get("formatted_body", "")
 
-    text_content = re.sub(r"<[^>]+>", "", formatted_body).strip()
-
-    bodies = [full_message, text_content]
-
-    bare_pattern = rf"^!{re.escape(command)}(?:\s|$)"
-
-    if not require_mention and any(
-        re.match(bare_pattern, body, re.IGNORECASE) for body in bodies if body
-    ):
-        return True
-
-    mention_parts: list[str] = []
-    for ident in (facade.bot_user_id, facade.bot_user_name):
-        if ident:
-            try:
-                mention_parts.append(re.escape(str(ident)))
-            except Exception as exc:  # noqa: BLE001 - str() may invoke broken __str__
-                facade.logger.debug(
-                    "Failed to escape identifier %r for bot_command pattern: %s",
-                    ident,
-                    type(exc).__name__,
-                )
-                continue
-
-    if not mention_parts:
-        return False
-
-    pattern = (
-        rf"^(?:{'|'.join(mention_parts)})[,:;]?\s*!" rf"{re.escape(command)}(?:\s|$)"
+    return (
+        _parse_matrix_message_command(
+            event,
+            (command,),
+            require_mention=require_mention,
+        )
+        is not None
     )
-
-    return any(re.match(pattern, body, re.IGNORECASE) for body in bodies if body)
 
 
 async def _connect_meshtastic() -> Any:

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -17,6 +17,8 @@ from nio import (
 import mmrelay.matrix_utils as facade
 
 __all__ = [
+    "ParsedMatrixCommand",
+    "_parse_matrix_message_command",
     "_estimate_clock_rollback_ms",
     "_refresh_bot_start_timestamps",
     "get_displayname",
@@ -285,6 +287,7 @@ def _match_bang_command(
     if not message:
         return None
 
+    # Sort longest-first so the alternation group matches the longest candidate.
     command_alternatives = sorted(command_lookup.values(), key=len, reverse=True)
     command_pattern = "|".join(re.escape(command) for command in command_alternatives)
     match = re.match(
@@ -349,9 +352,6 @@ def _parse_matrix_message_command(
         return None
 
     if require_mention:
-        if bot_mxid is None:
-            return None
-
         # Pass 1: require exact MXID mention semantics across all body variants.
         # This tier includes plain-body MXID prefixes and formatted-body mention
         # pills that normalize to MXID prefixes.

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -353,6 +353,7 @@ from mmrelay.matrix.command_bridge import (
     _estimate_clock_rollback_ms,
     _get_meshtastic_interface_and_channel,
     _handle_detection_sensor_packet,
+    _parse_matrix_message_command,
     _refresh_bot_start_timestamps,
     bot_command,
     get_displayname,

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import math
 import threading
+from collections.abc import Callable
 from concurrent.futures import Future
 from typing import Any, NoReturn
 
@@ -744,8 +745,10 @@ def _connect_meshtastic_impl(
                             # can potentially block indefinitely if BlueZ is in a bad state.
                             def create_ble_interface(
                                 kwargs: dict[str, Any],
-                                interface_cls: Any = ble_interface_cls,
-                            ) -> Any:
+                                interface_cls: Callable[
+                                    ..., object
+                                ] = ble_interface_cls,
+                            ) -> object:
                                 """
                                 Create a BLEInterface configured for Meshtastic BLE connections.
 

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -6,10 +6,6 @@ import threading
 from concurrent.futures import Future
 from typing import Any, NoReturn
 
-from meshtastic.ble_interface import (
-    BLEInterface,  # pyright: ignore[reportPrivateImportUsage]
-)
-
 import mmrelay.meshtastic_utils as facade
 from mmrelay.constants.config import (
     CONFIG_KEY_CONNECT_PROBE_ENABLED,
@@ -668,10 +664,15 @@ def _connect_meshtastic_impl(
                             facade.logger.debug(
                                 f"Creating new BLE interface for {ble_address} (sanitized: {sanitized_address})"
                             )
+                            ble_interface_cls = (
+                                facade.meshtastic.ble_interface.BLEInterface
+                            )  # pyright: ignore[reportPrivateImportUsage]
                             # Detect whether this BLEInterface implementation supports
                             # explicit auto_reconnect control.
                             try:
-                                ble_init_sig = inspect.signature(BLEInterface.__init__)
+                                ble_init_sig = inspect.signature(
+                                    ble_interface_cls.__init__
+                                )
                             except (TypeError, ValueError):
                                 ble_init_sig = None
                                 fallback_to_compat_mode = True
@@ -753,7 +754,7 @@ def _connect_meshtastic_impl(
                                 Returns:
                                     BLEInterface: A newly constructed Meshtastic BLEInterface instance.
                                 """
-                                return BLEInterface(**kwargs)
+                                return ble_interface_cls(**kwargs)
 
                             # Guard against overlapping BLE tasks: if a previous BLE operation is
                             # still running (often due to a hung BlueZ/DBus call), we skip queuing

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -6,6 +6,10 @@ import threading
 from concurrent.futures import Future
 from typing import Any, NoReturn
 
+from meshtastic.ble_interface import (
+    BLEInterface,  # pyright: ignore[reportPrivateImportUsage]
+)
+
 import mmrelay.meshtastic_utils as facade
 from mmrelay.constants.config import (
     CONFIG_KEY_CONNECT_PROBE_ENABLED,
@@ -667,9 +671,7 @@ def _connect_meshtastic_impl(
                             # Detect whether this BLEInterface implementation supports
                             # explicit auto_reconnect control.
                             try:
-                                ble_init_sig = inspect.signature(
-                                    facade.meshtastic.ble_interface.BLEInterface.__init__
-                                )
+                                ble_init_sig = inspect.signature(BLEInterface.__init__)
                             except (TypeError, ValueError):
                                 ble_init_sig = None
                                 fallback_to_compat_mode = True
@@ -751,9 +753,7 @@ def _connect_meshtastic_impl(
                                 Returns:
                                     BLEInterface: A newly constructed Meshtastic BLEInterface instance.
                                 """
-                                return facade.meshtastic.ble_interface.BLEInterface(
-                                    **kwargs
-                                )
+                                return BLEInterface(**kwargs)
 
                             # Guard against overlapping BLE tasks: if a previous BLE operation is
                             # still running (often due to a hung BlueZ/DBus call), we skip queuing

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -744,6 +744,7 @@ def _connect_meshtastic_impl(
                             # can potentially block indefinitely if BlueZ is in a bad state.
                             def create_ble_interface(
                                 kwargs: dict[str, Any],
+                                interface_cls: Any = ble_interface_cls,
                             ) -> Any:
                                 """
                                 Create a BLEInterface configured for Meshtastic BLE connections.
@@ -754,7 +755,7 @@ def _connect_meshtastic_impl(
                                 Returns:
                                     BLEInterface: A newly constructed Meshtastic BLEInterface instance.
                                 """
-                                return ble_interface_cls(**kwargs)
+                                return interface_cls(**kwargs)
 
                             # Guard against overlapping BLE tasks: if a previous BLE operation is
                             # still running (often due to a hung BlueZ/DBus call), we skip queuing

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -2,7 +2,7 @@ import contextlib
 import threading
 from typing import Any, Iterable
 
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 
 import mmrelay.meshtastic_utils as facade
 from mmrelay.constants.config import (

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -701,6 +701,19 @@ class BasePlugin(ABC):
         Returns:
             The matching command string if a command matches the event, `None` otherwise.
         """
+        parsed = self.get_matching_matrix_command_with_args(event)
+        return parsed[0] if parsed is not None else None
+
+    def get_matching_matrix_command_with_args(
+        self,
+        event: RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote,
+    ) -> tuple[str, str] | None:
+        """
+        Return the matched Matrix command and parsed args for an event.
+
+        This is the preferred parser entrypoint for plugin handlers so command
+        detection and argument extraction share one parse result.
+        """
         from mmrelay.matrix_utils import _parse_matrix_message_command
 
         parsed = _parse_matrix_message_command(
@@ -708,7 +721,9 @@ class BasePlugin(ABC):
             self.get_matrix_commands(),
             require_mention=self.get_require_bot_mention(),
         )
-        return parsed.command if parsed is not None else None
+        if parsed is None:
+            return None
+        return parsed.command, parsed.args
 
     async def send_matrix_message(
         self,
@@ -929,18 +944,21 @@ class BasePlugin(ABC):
         Returns:
             `True` if the event invokes one of the plugin's Matrix commands, `False` otherwise.
         """
-        from mmrelay.matrix_utils import _parse_matrix_message_command
+        return self.get_matching_matrix_command_with_args(event) is not None
 
-        return (
-            _parse_matrix_message_command(
-                event,
-                self.get_matrix_commands(),
-                require_mention=self.get_require_bot_mention(),
-            )
-            is not None
-        )
-
-    def extract_command_args(self, command: str, text: str) -> str | None:
+    def extract_command_args(
+        self,
+        command: str,
+        text: str | None = None,
+        *,
+        event: (
+            RoomMessageText
+            | RoomMessageNotice
+            | ReactionEvent
+            | RoomMessageEmote
+            | None
+        ) = None,
+    ) -> str | None:
         """
         Extract arguments for ``command`` using the shared Matrix command parser.
 
@@ -949,16 +967,25 @@ class BasePlugin(ABC):
         ``get_matching_matrix_command()`` so command/argument semantics remain
         consistent.
 
-        The provided ``text`` should be the same message body used for command
-        matching. If the command is present with no arguments, returns an empty
-        string.
+        Prefer the ``event=...`` path so argument extraction reuses the exact
+        parse result used for command matching. The ``text`` fallback remains
+        for compatibility with older plugin call sites.
 
         Returns:
             str: Arguments after the command, stripped of surrounding whitespace,
                 or an empty string if no arguments are present; `None` if input
-                is not a string or the command does not match.
+                is invalid or the command does not match.
         """
         from mmrelay.matrix_utils import _parse_matrix_message_command
+
+        if event is not None:
+            parsed = self.get_matching_matrix_command_with_args(event)
+            if parsed is None:
+                return None
+            parsed_command, parsed_args = parsed
+            if parsed_command.casefold() != command.casefold():
+                return None
+            return parsed_args
 
         if not isinstance(text, str):
             return None

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -695,18 +695,20 @@ class BasePlugin(ABC):
         """
         Return the first Matrix command name that matches the given event.
 
-        Uses the plugin's require-mention setting when testing commands.
+        Uses the shared Matrix command parser and this plugin's require-mention
+        policy to resolve one canonical command name and arguments.
 
         Returns:
             The matching command string if a command matches the event, `None` otherwise.
         """
-        from mmrelay.matrix_utils import bot_command
+        from mmrelay.matrix_utils import _parse_matrix_message_command
 
-        require_mention = self.get_require_bot_mention()
-        for command in self.get_matrix_commands():
-            if bot_command(command, event, require_mention=require_mention):
-                return command
-        return None
+        parsed = _parse_matrix_message_command(
+            event,
+            self.get_matrix_commands(),
+            require_mention=self.get_require_bot_mention(),
+        )
+        return parsed.command if parsed is not None else None
 
     async def send_matrix_message(
         self,
@@ -927,35 +929,46 @@ class BasePlugin(ABC):
         Returns:
             `True` if the event invokes one of the plugin's Matrix commands, `False` otherwise.
         """
-        from mmrelay.matrix_utils import bot_command
+        from mmrelay.matrix_utils import _parse_matrix_message_command
 
-        # Determine if bot mentions are required
-        require_mention = self.get_require_bot_mention()
-
-        return any(
-            bot_command(command, event, require_mention=require_mention)
-            for command in self.get_matrix_commands()
+        return (
+            _parse_matrix_message_command(
+                event,
+                self.get_matrix_commands(),
+                require_mention=self.get_require_bot_mention(),
+            )
+            is not None
         )
 
     def extract_command_args(self, command: str, text: str) -> str | None:
         """
-        Extract arguments that follow a bot command in a message, tolerating an optional leading mention prefix and matching the command case-insensitively.
+        Extract arguments for ``command`` using the shared Matrix command parser.
 
-        If the message contains the command (e.g. "!cmd arg1 arg2" or "BotName: !cmd arg1" or "BotName !cmd arg1"), returns the trailing argument string stripped of surrounding whitespace; if the command is present with no arguments returns an empty string; if the input does not match the command pattern or is not a string returns None.
+        This method intentionally does not maintain an independent regex. It
+        reuses the same parser and mention policy as ``matches()`` and
+        ``get_matching_matrix_command()`` so command/argument semantics remain
+        consistent.
+
+        The provided ``text`` should be the same message body used for command
+        matching. If the command is present with no arguments, returns an empty
+        string.
 
         Returns:
-            str: Arguments after the command, stripped of surrounding whitespace, or an empty string if no arguments are present; `None` if the command pattern does not match or input is not a string.
+            str: Arguments after the command, stripped of surrounding whitespace,
+                or an empty string if no arguments are present; `None` if input
+                is not a string or the command does not match.
         """
+        from mmrelay.matrix_utils import _parse_matrix_message_command
+
         if not isinstance(text, str):
             return None
-        pattern = rf"^(?:.+?[,:;]?\s+)?!{re.escape(command)}(?:\s+(.*))?$"
-        match = re.match(pattern, text, flags=re.IGNORECASE)
-        if not match:
-            return None
-        args = match.group(1)
-        if args is None:
-            return ""
-        return args.strip()
+
+        parsed = _parse_matrix_message_command(
+            text,
+            (command,),
+            require_mention=self.get_require_bot_mention(),
+        )
+        return parsed.args if parsed is not None else None
 
     def parse_mesh_bang_command(
         self, text: str, commands: Iterable[str], *, allow_anywhere: bool = False

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -628,7 +628,7 @@ class BasePlugin(ABC):
         description = f"Plugin {self.plugin_name}: {text[:DEFAULT_TEXT_TRUNCATION_LENGTH]}{'...' if len(text) > DEFAULT_TEXT_TRUNCATION_LENGTH else ''}"
 
         if reply_id is not None:
-            from meshtastic.mesh_interface import BROADCAST_NUM
+            from meshtastic import BROADCAST_NUM
 
             from mmrelay.meshtastic.messaging import send_text_reply
 

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -941,14 +941,14 @@ class BasePlugin(ABC):
         """
         Extract arguments that follow a bot command in a message, tolerating an optional leading mention prefix and matching the command case-insensitively.
 
-        If the message contains the command (e.g. "!cmd arg1 arg2" or "@bot: !cmd arg1"), returns the trailing argument string stripped of surrounding whitespace; if the command is present with no arguments returns an empty string; if the input does not match the command pattern or is not a string returns None.
+        If the message contains the command (e.g. "!cmd arg1 arg2" or "BotName: !cmd arg1" or "BotName !cmd arg1"), returns the trailing argument string stripped of surrounding whitespace; if the command is present with no arguments returns an empty string; if the input does not match the command pattern or is not a string returns None.
 
         Returns:
             str: Arguments after the command, stripped of surrounding whitespace, or an empty string if no arguments are present; `None` if the command pattern does not match or input is not a string.
         """
         if not isinstance(text, str):
             return None
-        pattern = rf"^(?:.+?:\s*)?!{re.escape(command)}(?:\s+(.*))?$"
+        pattern = rf"^(?:.+?[,:;]?\s+)?!{re.escape(command)}(?:\s+(.*))?$"
         match = re.match(pattern, text, flags=re.IGNORECASE)
         if not match:
             return None

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -695,8 +695,8 @@ class BasePlugin(ABC):
         """
         Return the first Matrix command name that matches the given event.
 
-        Uses the shared Matrix command parser and this plugin's require-mention
-        policy to resolve one canonical command name and arguments.
+        Delegates to :meth:`get_matching_matrix_command_with_args` and returns
+        only the command name portion.
 
         Returns:
             The matching command string if a command matches the event, `None` otherwise.

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -91,14 +91,16 @@ class Plugin(BasePlugin):
         full_message: str,
     ) -> bool:
         """
-        Provide help for Matrix room messages by replying with either a list of available commands or details for a specific command.
+        Provide help for Matrix room messages by replying with command list/details.
 
-        If the incoming event matches this plugin's Matrix help command, sends a reply to the room: either a comma-separated list of all available Matrix commands from loaded plugins or a description for a requested command.
+        The handler first checks ``matches(event)`` for compatibility, then uses
+        ``get_matching_matrix_command_with_args(event)`` as the authoritative parse
+        result to obtain the matched command and its argument text.
 
         Parameters:
             room (MatrixRoom): Matrix room object; its `room_id` is used to send the reply.
             event (RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote): Incoming Matrix event used to determine whether this plugin should handle the message.
-            full_message (str): Raw message text from the room; used to extract command arguments.
+            full_message (str): Raw message text retained for compatibility/logging.
 
         Returns:
             True if the incoming event matched this plugin and a reply was sent, False otherwise.

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -105,10 +105,10 @@ class Plugin(BasePlugin):
         """
         # Maintain legacy matches() call for tests/compatibility but do not gate handling on it
         self.matches(event)
-        matched_command = self.get_matching_matrix_command(event)
-        if not matched_command:
+        parsed = self.get_matching_matrix_command_with_args(event)
+        if not parsed:
             return False
-        command = self.extract_command_args(matched_command, full_message) or ""
+        _matched_command, command = parsed
 
         plugins = load_plugins()
 

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -93,20 +93,19 @@ class Plugin(BasePlugin):
         """
         Provide help for Matrix room messages by replying with command list/details.
 
-        The handler first checks ``matches(event)`` for compatibility, then uses
-        ``get_matching_matrix_command_with_args(event)`` as the authoritative parse
-        result to obtain the matched command and its argument text.
+        The handler relies on ``get_matching_matrix_command_with_args(event)`` as
+        the authoritative parse result to obtain the matched command and argument
+        text.
 
         Parameters:
             room (MatrixRoom): Matrix room object; its `room_id` is used to send the reply.
             event (RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote): Incoming Matrix event used to determine whether this plugin should handle the message.
-            full_message (str): Raw message text retained for compatibility/logging.
+            full_message (str): Raw message text retained for API compatibility.
 
         Returns:
             True if the incoming event matched this plugin and a reply was sent, False otherwise.
         """
-        # Maintain legacy matches() call for tests/compatibility but do not gate handling on it
-        self.matches(event)
+        _ = full_message
         parsed = self.get_matching_matrix_command_with_args(event)
         if not parsed:
             return False

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -15,7 +15,6 @@ from nio import (
     RoomMessageText,
 )
 from PIL import Image as PILImage
-from PIL import ImageDraw as _PILImageDraw
 from PIL import ImageFont
 
 from mmrelay.constants.formats import (
@@ -110,26 +109,6 @@ async def _connect_meshtastic_async() -> object | None:
     from mmrelay.meshtastic_utils import connect_meshtastic
 
     return await asyncio.to_thread(connect_meshtastic)
-
-
-def textsize(
-    self: _PILImageDraw.ImageDraw, text: Any, *args: Any, **kwargs: Any
-) -> tuple[float, float]:
-    """
-    Compute the width and height of `text` as rendered by this ImageDraw instance.
-
-    Parameters:
-        text (Any): The text to measure. Additional rendering options (font, anchor, etc.) may be supplied via `*args` and `**kwargs`.
-
-    Returns:
-        (width, height) (tuple[float, float]): Width and height of the rendered text in pixels.
-    """
-    left, top, right, bottom = self.textbbox((0, 0), text, *args, **kwargs)
-    return right - left, bottom - top
-
-
-# Monkeypatch fix for https://github.com/flopp/py-staticmaps/issues/39
-_PILImageDraw.ImageDraw.textsize = textsize  # type: ignore[attr-defined]
 
 
 class TextLabel(staticmaps.Object):  # type: ignore[misc]

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -496,7 +496,7 @@ class Plugin(BasePlugin):
         Parameters:
             room: The Matrix room where the message was received; used to send responses and the resulting image.
             event: The full Matrix event object; passed to plugin matching logic.
-            full_message: The raw message text to parse for the "!map" command and optional parameters.
+            full_message: The raw message text retained for API compatibility.
 
         Returns:
             `True` if the command was handled and the map image was generated and sent; `False` otherwise.

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -504,9 +504,10 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        args = self.extract_command_args("map", full_message)
-        if args is None:
+        parsed = self.get_matching_matrix_command_with_args(event)
+        if not parsed:
             return False
+        _command, args = parsed
 
         token_pattern = r"(?:\s*(?:zoom=\d+|size=\d+,\s*\d+))*\s*$"
         if args and not re.fullmatch(token_pattern, args, flags=re.IGNORECASE):

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import Any
 
 # matrix-nio is not marked py.typed; keep import-untyped for strict mypy.
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 from nio import (
     MatrixRoom,
     ReactionEvent,

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -166,7 +166,6 @@ class Plugin(BasePlugin):
         event: RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote,
         full_message: str,
     ) -> bool:
-        # Pass the event to matches()
         """
         Handle a Matrix telemetry command and send a generated graph to the room.
 
@@ -179,11 +178,12 @@ class Plugin(BasePlugin):
         Parameters:
             room: Matrix room object where the event originated and where the response will be sent.
             event: Matrix event used to determine whether it matches a supported telemetry command.
-            full_message: Full plaintext message retained for compatibility/logging.
+            full_message: Full plaintext message retained for API compatibility.
 
         Returns:
             `True` if the message matched a telemetry command and a graph was generated and sent or a notice was sent for a node with no data, `False` otherwise.
         """
+        _ = full_message
         if not self.matches(event):
             return False
 

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -183,11 +183,11 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        parsed_command = self.get_matching_matrix_command(event)
-        if not parsed_command:
+        parsed = self.get_matching_matrix_command_with_args(event)
+        if not parsed:
             return False
 
-        args = self.extract_command_args(parsed_command, full_message) or ""
+        parsed_command, args = parsed
         telemetry_option = parsed_command
         node = args or None
 

--- a/src/mmrelay/plugins/telemetry_plugin.py
+++ b/src/mmrelay/plugins/telemetry_plugin.py
@@ -168,14 +168,18 @@ class Plugin(BasePlugin):
     ) -> bool:
         # Pass the event to matches()
         """
-        Handle a Matrix message that requests a telemetry graph and send the generated image to the originating room.
+        Handle a Matrix telemetry command and send a generated graph to the room.
 
-        Parses a telemetry command (one of `batteryLevel`, `voltage`, `airUtilTx`) optionally followed by a node identifier, computes hourly averages for the last 12 hours for that node or for the whole network, renders a line plot of those averages, and uploads the image to the originating room. If a specified node has no telemetry data, a notice is sent instead of an image.
+        Matching is determined by ``matches(event)``, and command parsing comes from
+        ``get_matching_matrix_command_with_args(event)``. The parsed tuple provides
+        ``parsed_command`` (one of ``batteryLevel``, ``voltage``, ``airUtilTx``) and
+        optional args (node identifier). The handler then computes hourly averages,
+        renders a graph, and uploads it or sends an error notice.
 
         Parameters:
             room: Matrix room object where the event originated and where the response will be sent.
             event: Matrix event used to determine whether it matches a supported telemetry command.
-            full_message: Full plaintext message content used to parse the command and optional node identifier.
+            full_message: Full plaintext message retained for compatibility/logging.
 
         Returns:
             `True` if the message matched a telemetry command and a graph was generated and sent or a notice was sent for a node with no data, `False` otherwise.

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -931,11 +931,12 @@ class Plugin(BasePlugin):
         Parameters:
             room: The Matrix room object where the event originated.
             event: The Matrix event object to evaluate for a plugin match.
-            full_message (str): The raw message text retained for compatibility/logging.
+            full_message (str): The raw message text retained for API compatibility.
 
         Returns:
             bool: `True` if the event matched the plugin and was handled (a response was sent or attempted), `False` if the event did not match and was not handled.
         """
+        _ = full_message
         if not self.matches(event):
             return False
 

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -936,11 +936,11 @@ class Plugin(BasePlugin):
         if not self.matches(event):
             return False
 
-        parsed_command = self.get_matching_matrix_command(event)
-        if not parsed_command:
+        parsed = self.get_matching_matrix_command_with_args(event)
+        if not parsed:
             return False
+        parsed_command, args_text = parsed
         mode = self._normalize_mode(parsed_command)
-        args_text = self.extract_command_args(parsed_command, full_message) or ""
 
         try:
             coords = await self._resolve_location_from_args(args_text)

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -921,14 +921,17 @@ class Plugin(BasePlugin):
         full_message: str,
     ) -> bool:
         """
-        Handle a Matrix room message invoking the weather plugin and post a forecast to the room.
+        Handle a Matrix weather command and post a forecast to the room.
 
-        Parses the room message for a supported weather command, resolves coordinates from command arguments, mesh-derived location, or geocoding, generates a forecast for the resolved coordinates, and sends the forecast back to the Matrix room. If a location cannot be determined, posts "Cannot determine location" to the room.
+        The handler uses ``matches(event)`` for command gating and
+        ``get_matching_matrix_command_with_args(event)`` for authoritative parsing.
+        The parsed tuple yields ``parsed_command`` and ``args_text`` used to choose
+        forecast mode and resolve coordinates.
 
         Parameters:
             room: The Matrix room object where the event originated.
             event: The Matrix event object to evaluate for a plugin match.
-            full_message (str): The raw message text used to extract command arguments.
+            full_message (str): The raw message text retained for compatibility/logging.
 
         Returns:
             bool: `True` if the event matched the plugin and was handled (a response was sent or attempted), `False` if the event did not match and was not handled.

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any
 
 import requests
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 from nio import (
     MatrixRoom,
     ReactionEvent,

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -26,6 +26,7 @@ import schedule
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+from mmrelay.constants.config import CONFIG_KEY_REQUIRE_BOT_MENTION
 from mmrelay.constants.database import DEFAULT_MAX_DATA_ROWS_PER_NODE_BASE
 from mmrelay.constants.domain import MATRIX_EVENT_TYPE_ROOM_MESSAGE
 from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
@@ -642,23 +643,27 @@ class TestBasePlugin(unittest.TestCase):
             result = plugin.is_channel_enabled(0, is_direct_message=True)
             self.assertTrue(result)
 
-    @patch("mmrelay.matrix_utils.bot_command")
-    def test_matches_method(self, mock_bot_command):
-        """
-        Test that the plugin's matches method correctly identifies Matrix events as matching or not based on the bot_command utility.
-
-        Verifies that the matches method returns True when the event matches a command and False otherwise.
-        """
-        plugin = MockPlugin()
+    def test_matches_method_accepts_supported_mxid_mention(self):
+        """matches() should accept MXID mention + command when mentions are required."""
+        plugin = CoreMockPlugin()
         event = MagicMock()
+        event.body = "@testbot:example.org: !test_plugin"
+        event.source = {"content": {"formatted_body": ""}}
 
-        mock_bot_command.return_value = True
-        result = plugin.matches(event)
-        self.assertTrue(result)
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+            result = plugin.matches(event)
+            self.assertTrue(result)
 
-        mock_bot_command.return_value = False
-        result = plugin.matches(event)
-        self.assertFalse(result)
+    def test_matches_method_rejects_display_name_prefix_when_mentions_required(self):
+        """matches() should not treat display-name prefixes as bot mentions."""
+        plugin = CoreMockPlugin()
+        event = MagicMock()
+        event.body = "ForxRelay: !test_plugin"
+        event.source = {"content": {"formatted_body": ""}}
+
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+            result = plugin.matches(event)
+            self.assertFalse(result)
 
     @patch("mmrelay.matrix_utils.connect_matrix")
     def test_send_matrix_message(self, mock_connect_matrix):
@@ -1554,8 +1559,9 @@ class TestBasePlugin(unittest.TestCase):
             plugin = MultiCmdPlugin()
 
         mock_event = MagicMock()
-        with patch("mmrelay.matrix_utils.bot_command") as mock_bc:
-            mock_bc.side_effect = lambda cmd, *_, **__: cmd == "cmd2"
+        mock_event.body = "@testbot:example.org: !cmd2 value"
+        mock_event.source = {"content": {"formatted_body": ""}}
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
             result = plugin.get_matching_matrix_command(mock_event)
             self.assertEqual(result, "cmd2")
 
@@ -1581,30 +1587,37 @@ class TestBasePlugin(unittest.TestCase):
             plugin = MultiCmdPlugin2()
 
         mock_event = MagicMock()
-        with patch("mmrelay.matrix_utils.bot_command", return_value=False):
+        mock_event.body = "!cmd1"
+        mock_event.source = {"content": {"formatted_body": ""}}
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
             result = plugin.get_matching_matrix_command(mock_event)
             self.assertIsNone(result)
 
     def test_extract_command_args_with_match(self):
-        """extract_command_args should extract args from full message."""
-        plugin = MockPlugin()
-        with patch(
-            "mmrelay.matrix_utils.bot_command",
-            side_effect=lambda cmd, msg, *_, **__: cmd == "test_plugin",
-        ):
-            MagicMock()
+        """extract_command_args should use shared parser semantics for args extraction."""
+        plugin = CoreMockPlugin()
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
             result = plugin.extract_command_args(
-                "test_plugin", "!test_plugin arg1 arg2"
+                "test_plugin",
+                "@testbot:example.org: !test_plugin arg1 arg2",
             )
             self.assertEqual(result, "arg1 arg2")
 
     def test_extract_command_args_no_match(self):
         """extract_command_args should return None when command doesn't match."""
-        plugin = MockPlugin()
-        with patch("mmrelay.matrix_utils.bot_command", return_value=False):
-            MagicMock()
-            result = plugin.extract_command_args("test_plugin", "!other_cmd")
+        plugin = CoreMockPlugin()
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+            result = plugin.extract_command_args(
+                "test_plugin", "ForxRelay: !test_plugin"
+            )
             self.assertIsNone(result)
+
+    def test_extract_command_args_allows_bare_command_when_mentions_disabled(self):
+        """Non-core plugins should keep bare-command parsing when mentions are disabled."""
+        plugin = MockPlugin()
+        plugin.config[CONFIG_KEY_REQUIRE_BOT_MENTION] = False
+        result = plugin.extract_command_args("test_plugin", "!test_plugin alpha beta")
+        self.assertEqual(result, "alpha beta")
 
     def test_parse_mesh_bang_command_with_args(self):
         """parse_mesh_bang_command should parse command and trailing args."""

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -660,7 +660,7 @@ class TestBasePlugin(unittest.TestCase):
         """matches() should reject display-name prefixes that do not match the configured name."""
         plugin = CoreMockPlugin()
         event = MagicMock()
-        event.body = "ForxRelay: !test_plugin"
+        event.body = "TestRelay: !test_plugin"
         event.source = {"content": {"formatted_body": ""}}
 
         with (
@@ -1625,7 +1625,7 @@ class TestBasePlugin(unittest.TestCase):
             "content": {
                 "formatted_body": (
                     '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
-                    "ForxRelay</a>: !cmd2 value"
+                    "TestRelay</a>: !cmd2 value"
                 )
             }
         }
@@ -1687,7 +1687,7 @@ class TestBasePlugin(unittest.TestCase):
             "content": {
                 "formatted_body": (
                     '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
-                    "ForxRelay</a>: !test_plugin alpha beta"
+                    "TestRelay</a>: !test_plugin alpha beta"
                 )
             }
         }
@@ -1701,7 +1701,7 @@ class TestBasePlugin(unittest.TestCase):
         plugin = CoreMockPlugin()
         with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
             result = plugin.extract_command_args(
-                "test_plugin", "ForxRelay: !test_plugin"
+                "test_plugin", "TestRelay: !test_plugin"
             )
             self.assertIsNone(result)
 

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1545,14 +1545,20 @@ class TestBasePlugin(unittest.TestCase):
             is_core_plugin = True
 
             async def handle_meshtastic_message(
-                self, packet, formatted_message, longname, meshnet_name
+                self,
+                _packet: object,
+                _formatted_message: object,
+                _longname: object,
+                _meshnet_name: object,
             ) -> bool:
                 return False
 
-            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+            async def handle_room_message(
+                self, _room: object, _event: object, _full_message: object
+            ) -> bool:
                 return False
 
-            def get_matrix_commands(self):
+            def get_matrix_commands(self) -> list[str]:
                 return ["cmd1", "cmd2"]
 
         with patch("mmrelay.plugins.base_plugin.config", {"plugins": {}}):
@@ -1573,14 +1579,20 @@ class TestBasePlugin(unittest.TestCase):
             is_core_plugin = True
 
             async def handle_meshtastic_message(
-                self, packet, formatted_message, longname, meshnet_name
+                self,
+                _packet: object,
+                _formatted_message: object,
+                _longname: object,
+                _meshnet_name: object,
             ) -> bool:
                 return False
 
-            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+            async def handle_room_message(
+                self, _room: object, _event: object, _full_message: object
+            ) -> bool:
                 return False
 
-            def get_matrix_commands(self):
+            def get_matrix_commands(self) -> list[str]:
                 return ["cmd1", "cmd2"]
 
         with patch("mmrelay.plugins.base_plugin.config", {"plugins": {}}):
@@ -1609,14 +1621,20 @@ class TestBasePlugin(unittest.TestCase):
             is_core_plugin = True
 
             async def handle_meshtastic_message(
-                self, packet, formatted_message, longname, meshnet_name
+                self,
+                _packet: object,
+                _formatted_message: object,
+                _longname: object,
+                _meshnet_name: object,
             ) -> bool:
                 return False
 
-            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+            async def handle_room_message(
+                self, _room: object, _event: object, _full_message: object
+            ) -> bool:
                 return False
 
-            def get_matrix_commands(self):
+            def get_matrix_commands(self) -> list[str]:
                 return ["cmd1"]
 
         with patch("mmrelay.plugins.base_plugin.config", {"plugins": {}}):

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -654,16 +654,37 @@ class TestBasePlugin(unittest.TestCase):
             result = plugin.matches(event)
             self.assertTrue(result)
 
-    def test_matches_method_rejects_display_name_prefix_when_mentions_required(self):
-        """matches() should not treat display-name prefixes as bot mentions."""
+    def test_matches_method_rejects_non_matching_display_name_prefix_when_mentions_required(
+        self,
+    ):
+        """matches() should reject display-name prefixes that do not match the configured name."""
         plugin = CoreMockPlugin()
         event = MagicMock()
         event.body = "ForxRelay: !test_plugin"
         event.source = {"content": {"formatted_body": ""}}
 
-        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "OtherBot"),
+        ):
             result = plugin.matches(event)
             self.assertFalse(result)
+
+    def test_matches_method_accepts_matching_display_name_prefix_when_mentions_required(
+        self,
+    ):
+        """matches() should accept display-name prefix that matches the configured name."""
+        plugin = CoreMockPlugin()
+        event = MagicMock()
+        event.body = "TestBot: !test_plugin"
+        event.source = {"content": {"formatted_body": ""}}
+
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
+        ):
+            result = plugin.matches(event)
+            self.assertTrue(result)
 
     @patch("mmrelay.matrix_utils.connect_matrix")
     def test_send_matrix_message(self, mock_connect_matrix):
@@ -1727,6 +1748,55 @@ class TestBasePlugin(unittest.TestCase):
         plugin = MockPlugin()
         self.assertIsNone(plugin.parse_mesh_bang_command(12345, ("weather",)))
         self.assertIsNone(plugin.parse_mesh_bang_command("!weather", ()))
+
+    def test_get_matching_matrix_command_display_name_fallback(self):
+        """get_matching_matrix_command should match display-name prefix as fallback."""
+        plugin = CoreMockPlugin()
+        mock_event = MagicMock()
+        mock_event.body = "TestBot: !test_plugin"
+        mock_event.source = {"content": {"formatted_body": ""}}
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
+        ):
+            result = plugin.get_matching_matrix_command(mock_event)
+        self.assertEqual(result, "test_plugin")
+
+    def test_get_matching_matrix_command_display_name_whitespace_separator(self):
+        """get_matching_matrix_command should match display-name with whitespace separator."""
+        plugin = CoreMockPlugin()
+        mock_event = MagicMock()
+        mock_event.body = "TestBot !test_plugin"
+        mock_event.source = {"content": {"formatted_body": ""}}
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
+        ):
+            result = plugin.get_matching_matrix_command_with_args(mock_event)
+        self.assertEqual(result, ("test_plugin", ""))
+
+    def test_get_matching_matrix_command_mxid_takes_precedence_over_display_name(self):
+        """MXID mention should take precedence over display-name fallback."""
+        plugin = CoreMockPlugin()
+        mock_event = MagicMock()
+        mock_event.body = "@testbot:example.org: !test_plugin"
+        mock_event.source = {"content": {"formatted_body": ""}}
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
+        ):
+            result = plugin.get_matching_matrix_command_with_args(mock_event)
+        self.assertEqual(result, ("test_plugin", ""))
+
+    def test_extract_command_args_display_name_no_match_without_name_configured(self):
+        """extract_command_args should not match display name when bot_user_name is None."""
+        plugin = CoreMockPlugin()
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", None),
+        ):
+            result = plugin.extract_command_args("test_plugin", "TestBot: !test_plugin")
+        self.assertIsNone(result)
 
     @patch("mmrelay.matrix_utils.connect_matrix")
     def test_send_matrix_reaction_success(self, mock_connect):

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1565,6 +1565,42 @@ class TestBasePlugin(unittest.TestCase):
             result = plugin.get_matching_matrix_command(mock_event)
             self.assertEqual(result, "cmd2")
 
+    def test_get_matching_matrix_command_with_args_matches_formatted_mention_pill(self):
+        """get_matching_matrix_command_with_args should parse command+args from formatted mention pills."""
+
+        class MultiCmdPlugin(BasePlugin):
+            plugin_name = "multi"
+            is_core_plugin = True
+
+            async def handle_meshtastic_message(
+                self, packet, formatted_message, longname, meshnet_name
+            ) -> bool:
+                return False
+
+            async def handle_room_message(self, _room, _event, _full_message) -> bool:
+                return False
+
+            def get_matrix_commands(self):
+                return ["cmd1", "cmd2"]
+
+        with patch("mmrelay.plugins.base_plugin.config", {"plugins": {}}):
+            plugin = MultiCmdPlugin()
+
+        mock_event = MagicMock()
+        mock_event.body = "not a command"
+        mock_event.source = {
+            "content": {
+                "formatted_body": (
+                    '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
+                    "ForxRelay</a>: !cmd2 value"
+                )
+            }
+        }
+
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+            result = plugin.get_matching_matrix_command_with_args(mock_event)
+            self.assertEqual(result, ("cmd2", "value"))
+
     def test_get_matching_matrix_command_no_match(self):
         """get_matching_matrix_command should return None when nothing matches."""
 
@@ -1602,6 +1638,24 @@ class TestBasePlugin(unittest.TestCase):
                 "@testbot:example.org: !test_plugin arg1 arg2",
             )
             self.assertEqual(result, "arg1 arg2")
+
+    def test_extract_command_args_from_event_uses_shared_parse_result(self):
+        """event-based extraction should reuse shared parsing when plain body is not command text."""
+        plugin = CoreMockPlugin()
+        event = MagicMock()
+        event.body = "not a command"
+        event.source = {
+            "content": {
+                "formatted_body": (
+                    '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
+                    "ForxRelay</a>: !test_plugin alpha beta"
+                )
+            }
+        }
+
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+            result = plugin.extract_command_args("test_plugin", event=event)
+            self.assertEqual(result, "alpha beta")
 
     def test_extract_command_args_no_match(self):
         """extract_command_args should return None when command doesn't match."""

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -153,7 +153,10 @@ class TestHelpPlugin(unittest.TestCase):
         event.body = "@testbot:example.org: !help"
         event.source = {"content": {"formatted_body": ""}}
 
-        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestRelay"),
+        ):
 
             async def run_test() -> None:
                 result = await self.plugin.handle_room_message(room, event, event.body)
@@ -184,12 +187,15 @@ class TestHelpPlugin(unittest.TestCase):
             "content": {
                 "formatted_body": (
                     '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
-                    "ForxRelay</a>: !help weather"
+                    "TestRelay</a>: !help weather"
                 )
             }
         }
 
-        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestRelay"),
+        ):
 
             async def run_test() -> None:
                 result = await self.plugin.handle_room_message(room, event, event.body)
@@ -220,12 +226,15 @@ class TestHelpPlugin(unittest.TestCase):
             "content": {
                 "formatted_body": (
                     '<a href="https://matrix.to/#/%40relay%3Aexample.com">'
-                    "ForxRelay</a>: !help"
+                    "TestRelay</a>: !help"
                 )
             }
         }
 
-        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestRelay"),
+        ):
 
             async def run_test() -> None:
                 result = await self.plugin.handle_room_message(room, event, event.body)
@@ -235,19 +244,22 @@ class TestHelpPlugin(unittest.TestCase):
 
             asyncio.run(run_test())
 
-    def test_handle_room_message_rejects_display_name_prefix_when_mentions_required(
+    def test_handle_room_message_rejects_non_matching_display_name_prefix_when_mentions_required(
         self,
     ):
-        """Display-name prefixes should not be claimed when mention policy is strict."""
+        """Mismatched display-name prefixes should not be claimed when mentions are required."""
         self.plugin.get_require_bot_mention = MagicMock(return_value=True)
 
         room = MagicMock()
         room.room_id = "!test:example.org"
         event = MagicMock()
-        event.body = "ForxRelay: !help"
+        event.body = "OtherRelay: !help"
         event.source = {"content": {"formatted_body": ""}}
 
-        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+        with (
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestRelay"),
+        ):
 
             async def run_test() -> None:
                 result = await self.plugin.handle_room_message(room, event, event.body)
@@ -269,7 +281,6 @@ class TestHelpPlugin(unittest.TestCase):
             self.mock_plugin2,
             self.mock_plugin3,
         ]
-        self.plugin.matches = MagicMock(return_value=True)
 
         room = MagicMock()
         room.room_id = "!test:matrix.org"
@@ -282,12 +293,11 @@ class TestHelpPlugin(unittest.TestCase):
             """
             Run assertions that handling a general "!help" room message results in a command list being sent.
 
-            Verifies that handle_room_message reports success, that matches() is called with the event, that send_matrix_message() is called once for the target room, and that the sent message contains "Available commands:" and the expected commands "nodes", "health", "weather", and "help".
+            Verifies that handle_room_message reports success, that send_matrix_message() is called once for the target room, and that the sent message contains "Available commands:" and the expected commands "nodes", "health", "weather", and "help".
             """
             result = await self.plugin.handle_room_message(room, event, full_message)
 
             self.assertTrue(result)
-            self.plugin.matches.assert_called_once_with(event)
             self.plugin.send_matrix_message.assert_called_once()
             self.plugin.send_matrix_reaction.assert_called_once_with(
                 "!test:matrix.org", event.event_id, "✅"

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -165,6 +165,76 @@ class TestHelpPlugin(unittest.TestCase):
 
             asyncio.run(run_test())
 
+    @patch("mmrelay.plugins.help_plugin.load_plugins")
+    def test_handle_room_message_accepts_formatted_mention_pill_with_display_text(
+        self, mock_load_plugins
+    ):
+        """
+        Formatted mention pills should match by MXID href even when visible text is a display name.
+        """
+        mock_load_plugins.return_value = [self.mock_plugin2, self.mock_plugin3]
+        self.plugin.get_require_bot_mention = MagicMock(return_value=True)
+
+        room = MagicMock()
+        room.room_id = "!test:example.org"
+        event = MagicMock()
+        event.event_id = "$evt-pill"
+        event.body = "not a command"
+        event.source = {
+            "content": {
+                "formatted_body": (
+                    '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
+                    "ForxRelay</a>: !help weather"
+                )
+            }
+        }
+
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+
+            async def run_test() -> None:
+                result = await self.plugin.handle_room_message(room, event, event.body)
+                self.assertTrue(result)
+                self.plugin.send_matrix_message.assert_called_once()
+                sent = self.plugin.send_matrix_message.call_args.args[1]
+                self.assertEqual(
+                    sent,
+                    MSG_COMMAND_HELP.format(
+                        command="weather", description=self.mock_plugin2.description
+                    ),
+                )
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!test:example.org", "$evt-pill", "✅"
+                )
+
+            asyncio.run(run_test())
+
+    def test_handle_room_message_rejects_formatted_link_without_bot_mxid_target(self):
+        """Formatted links that do not target the bot MXID should not be claimed."""
+        self.plugin.get_require_bot_mention = MagicMock(return_value=True)
+
+        room = MagicMock()
+        room.room_id = "!test:example.org"
+        event = MagicMock()
+        event.body = "not a command"
+        event.source = {
+            "content": {
+                "formatted_body": (
+                    '<a href="https://matrix.to/#/%40relay%3Aexample.com">'
+                    "ForxRelay</a>: !help"
+                )
+            }
+        }
+
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+
+            async def run_test() -> None:
+                result = await self.plugin.handle_room_message(room, event, event.body)
+                self.assertFalse(result)
+                self.plugin.send_matrix_message.assert_not_called()
+                self.plugin.send_matrix_reaction.assert_not_called()
+
+            asyncio.run(run_test())
+
     def test_handle_room_message_rejects_display_name_prefix_when_mentions_required(
         self,
     ):

--- a/tests/test_help_plugin.py
+++ b/tests/test_help_plugin.py
@@ -117,8 +117,8 @@ class TestHelpPlugin(unittest.TestCase):
         event.source = {"content": {"formatted_body": ""}}
 
         with (
-            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
-            patch("mmrelay.matrix_utils.bot_user_name", "TestBot"),
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestRelay"),
         ):
 
             async def run_test() -> None:
@@ -132,6 +132,55 @@ class TestHelpPlugin(unittest.TestCase):
                 result = await self.plugin.handle_room_message(
                     room, event, "full_message"
                 )
+                self.assertFalse(result)
+                self.plugin.send_matrix_message.assert_not_called()
+                self.plugin.send_matrix_reaction.assert_not_called()
+
+            asyncio.run(run_test())
+
+    @patch("mmrelay.plugins.help_plugin.load_plugins")
+    def test_handle_room_message_accepts_supported_mxid_mention_end_to_end(
+        self, mock_load_plugins
+    ):
+        """Supported MXID mention form should be parsed and handled end-to-end."""
+        mock_load_plugins.return_value = [self.mock_plugin3]
+        self.plugin.get_require_bot_mention = MagicMock(return_value=True)
+
+        room = MagicMock()
+        room.room_id = "!test:example.org"
+        event = MagicMock()
+        event.event_id = "$evt1"
+        event.body = "@testbot:example.org: !help"
+        event.source = {"content": {"formatted_body": ""}}
+
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+
+            async def run_test() -> None:
+                result = await self.plugin.handle_room_message(room, event, event.body)
+                self.assertTrue(result)
+                self.plugin.send_matrix_message.assert_called_once()
+                self.plugin.send_matrix_reaction.assert_called_once_with(
+                    "!test:example.org", "$evt1", "✅"
+                )
+
+            asyncio.run(run_test())
+
+    def test_handle_room_message_rejects_display_name_prefix_when_mentions_required(
+        self,
+    ):
+        """Display-name prefixes should not be claimed when mention policy is strict."""
+        self.plugin.get_require_bot_mention = MagicMock(return_value=True)
+
+        room = MagicMock()
+        room.room_id = "!test:example.org"
+        event = MagicMock()
+        event.body = "ForxRelay: !help"
+        event.source = {"content": {"formatted_body": ""}}
+
+        with patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"):
+
+            async def run_test() -> None:
+                result = await self.plugin.handle_room_message(room, event, event.body)
                 self.assertFalse(result)
                 self.plugin.send_matrix_message.assert_not_called()
                 self.plugin.send_matrix_reaction.assert_not_called()

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -34,7 +34,6 @@ from mmrelay.plugins.map_plugin import (
     TextLabel,
     get_map,
     precision_bits_to_meters,
-    textsize,
 )
 from tests.constants import TEST_LAT_SF, TEST_LON_SF
 
@@ -148,23 +147,6 @@ class TestTextLabel(unittest.TestCase):
         mock_drawing.path.assert_called_once()
         mock_drawing.text.assert_called_once()
         self.assertEqual(mock_group.add.call_count, 2)
-
-
-class TestTextSizeFunction(unittest.TestCase):
-    """Test cases for textsize function."""
-
-    def test_textsize(self):
-        """
-        Tests that the textsize function returns the correct width and height based on the drawing context's text bounding box.
-        """
-        mock_draw = MagicMock()
-        mock_draw.textbbox.return_value = (0, 0, 100, 20)
-
-        width, height = textsize(mock_draw, "Test text")
-
-        self.assertEqual(width, 100)
-        self.assertEqual(height, 20)
-        mock_draw.textbbox.assert_called_once_with((0, 0), "Test text")
 
 
 class TestGetMap(unittest.TestCase):

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -1014,12 +1014,14 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
 
         asyncio.run(run_test())
 
-    def test_handle_room_message_extract_args_returns_none(self):
-        """Test that extract_command_args returning None causes early return (lines 529-530)."""
+    def test_handle_room_message_no_parsed_command_returns_false(self):
+        """Should return False when no command/args tuple is parsed."""
 
         async def run_test() -> None:
             self.plugin.matches = MagicMock(return_value=True)
-            self.plugin.extract_command_args = MagicMock(return_value=None)
+            self.plugin.get_matching_matrix_command_with_args = MagicMock(
+                return_value=None
+            )
 
             mock_room = MagicMock()
             mock_room.room_id = "!test:example.com"

--- a/tests/test_map_plugin.py
+++ b/tests/test_map_plugin.py
@@ -326,6 +326,7 @@ class TestMapPlugin(unittest.TestCase):
         """
         self.plugin = Plugin()
         self.plugin.send_matrix_reaction = AsyncMock()
+        self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.config = {
             "zoom": 10,
             "image_width": 800,
@@ -440,7 +441,7 @@ class TestMapPlugin(unittest.TestCase):
             # Mock the matches method to return True
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map"
+                    mock_room, mock_event, "!map"
                 )
 
             self.assertTrue(result)
@@ -509,7 +510,7 @@ class TestMapPlugin(unittest.TestCase):
 
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map zoom=15"
+                    mock_room, mock_event, "!map zoom=15"
                 )
 
             self.assertTrue(result)
@@ -572,7 +573,7 @@ class TestMapPlugin(unittest.TestCase):
 
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map size=500,400"
+                    mock_room, mock_event, "!map size=500,400"
                 )
 
             self.assertTrue(result)
@@ -660,7 +661,7 @@ class TestMapPlugin(unittest.TestCase):
 
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map zoom=50"
+                    mock_room, mock_event, "!map zoom=50"
                 )
 
             self.assertTrue(result)
@@ -711,7 +712,7 @@ class TestMapPlugin(unittest.TestCase):
 
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map"
+                    mock_room, mock_event, "!map"
                 )
 
             self.assertTrue(result)
@@ -771,7 +772,7 @@ class TestMapPlugin(unittest.TestCase):
 
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map size=2000,1500"
+                    mock_room, mock_event, "!map size=2000,1500"
                 )
 
             self.assertTrue(result)
@@ -873,7 +874,7 @@ class TestMapPlugin(unittest.TestCase):
 
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map"
+                    mock_room, mock_event, "!map"
                 )
 
             self.assertTrue(result)
@@ -987,6 +988,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
     def setUp(self):
         self.plugin = Plugin()
         self.plugin.send_matrix_reaction = AsyncMock()
+        self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.config = {
             "zoom": 10,
             "image_width": 800,
@@ -1006,7 +1008,7 @@ class TestMapPluginHandleRoomMessage(unittest.TestCase):
 
             with patch.object(self.plugin, "matches", return_value=True):
                 result = await self.plugin.handle_room_message(
-                    mock_room, mock_event, "user: !map bogus=xyz"
+                    mock_room, mock_event, "!map bogus=xyz"
                 )
             self.assertFalse(result)
 

--- a/tests/test_matrix_utils_bot.py
+++ b/tests/test_matrix_utils_bot.py
@@ -104,6 +104,30 @@ class TestMatrixCommandParser:
         assert parsed.command == "map"
         assert parsed.args == "now"
 
+    def test_parser_prefers_real_href_over_data_href(self):
+        event = _make_event(
+            "not a command",
+            formatted_body=(
+                '<a class="mention" data-href="https://matrix.to/#/%40relay%3Aexample.com" '
+                'href="https://matrix.to/#/%40testbot%3Aexample.org">ForxRelay</a>: !map'
+            ),
+        )
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == ""
+
+    def test_parser_rejects_formatted_body_with_only_data_href(self):
+        event = _make_event(
+            "not a command",
+            formatted_body=(
+                '<a class="mention" data-href="https://matrix.to/#/%40testbot%3Aexample.org">'
+                "ForxRelay</a>: !map"
+            ),
+        )
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
+
     def test_parser_rejects_formatted_body_link_not_targeting_bot_mxid(self):
         event = _make_event(
             "not a command",
@@ -131,7 +155,7 @@ class TestMatrixCommandParser:
         """Broken bot MXID stringification should fail closed."""
 
         class BadIdent:
-            def __str__(self):
+            def __str__(self) -> str:
                 raise ValueError("boom")
 
         event = _make_event("!help")

--- a/tests/test_matrix_utils_bot.py
+++ b/tests/test_matrix_utils_bot.py
@@ -105,18 +105,28 @@ class TestMatrixCommandParser:
         assert parsed is not None
         assert parsed.command == "map"
 
-    def test_formatted_body_mxid_wins_over_display_name_in_body(self):
+    def test_formatted_body_mxid_wins_over_plain_body_display_name_fallback(self):
         event = _make_event(
-            "ForxRelay !map",
+            "ForxRelay !map 123",
             formatted_body=(
                 '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
-                "ForxRelay</a>: !map"
+                "ForxRelay</a>: !map 456"
             ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is not None
         assert parsed.command == "map"
-        assert parsed.args == ""
+        assert parsed.args == "456"
+
+    def test_plain_body_mxid_wins_over_formatted_body_display_name_fallback(self):
+        event = _make_event(
+            f"{BOT_MXID}: !map 999",
+            formatted_body="<span>ForxRelay !map 321</span>",
+        )
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == "999"
 
     def test_display_name_fallback_skipped_when_name_not_configured(self):
         event = _make_event("ForxRelay !map")
@@ -132,6 +142,19 @@ class TestMatrixCommandParser:
         assert parsed is not None
         assert parsed.command == "map"
         assert parsed.args == "42"
+
+    def test_unrelated_formatted_body_link_keeps_display_name_fallback(self):
+        event = _make_event(
+            "ForxRelay !map 55",
+            formatted_body=(
+                '<a href="https://matrix.to/#/%40relay%3Aexample.com">'
+                "ForxRelay</a>: !map 777"
+            ),
+        )
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == "55"
 
     def test_parser_requires_mxid_mention_when_enabled(self):
         event = _make_event("!map")

--- a/tests/test_matrix_utils_bot.py
+++ b/tests/test_matrix_utils_bot.py
@@ -2,204 +2,126 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from mmrelay.matrix_utils import bot_command
+from mmrelay.matrix_utils import _parse_matrix_message_command, bot_command
+
+BOT_MXID = "@testbot:example.org"
+OTHER_MXID = "@relay:example.com"
 
 
-class TestBotCommand:
-    """Test class for bot command detection functionality."""
+def _make_event(body: str, formatted_body: str | None = None) -> MagicMock:
+    """Create a Matrix event-shaped mock with optional formatted_body."""
+    event = MagicMock()
+    event.body = body
+    content: dict[str, str] = {}
+    if formatted_body is not None:
+        content["formatted_body"] = formatted_body
+    event.source = {"content": content}
+    return event
+
+
+class TestMatrixCommandParser:
+    """Command parser tests intentionally use non-real MXIDs."""
 
     @pytest.fixture(autouse=True)
-    def mock_bot_globals(self):
-        """
-        Provide a pytest fixture that patches the module-level bot identifiers for tests in this class.
-
-        Patches mmrelay.matrix_utils.bot_user_id to "@bot:matrix.org" and
-        mmrelay.matrix_utils.bot_user_name to "Bot" for the duration of each test, then yields
-        control to the test. Intended for use as an autouse fixture within the test class.
-        """
+    def patch_bot_identity(self):
         with (
-            patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
-            patch("mmrelay.matrix_utils.bot_user_name", "Bot"),
+            patch("mmrelay.matrix_utils.bot_user_id", BOT_MXID),
+            patch("mmrelay.matrix_utils.bot_user_name", "ForxRelay"),
         ):
             yield
 
-    def test_direct_mention(self):
-        """
-        Tests that a message starting with the bot command triggers correct command detection.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "!help"
-        mock_event.source = {"content": {"formatted_body": "!help"}}
+    def test_parser_matches_supported_mxid_with_whitespace_separator(self):
+        event = _make_event(f"{BOT_MXID} !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == ""
 
-        result = bot_command("help", mock_event)
-        assert result
+    def test_parser_matches_supported_mxid_with_colon_separator(self):
+        event = _make_event(f"{BOT_MXID}: !map 42")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == "42"
 
-    def test_direct_mention_require_mention_false(self):
-        """
-        Tests that a message starting with the bot command works when require_mention=False.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "!help"
-        mock_event.source = {"content": {"formatted_body": "!help"}}
+    def test_parser_rejects_spaced_semicolon_prefix(self):
+        event = _make_event(f"{BOT_MXID} ; !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
 
-        result = bot_command("help", mock_event, require_mention=False)
-        assert result
+    def test_parser_rejects_compact_mxid_and_command(self):
+        event = _make_event(f"{BOT_MXID}!map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
 
-    def test_direct_mention_require_mention_true(self):
-        """
-        Verifies that a plain command without a bot mention is not recognized when mentions are required.
+    def test_parser_rejects_display_name_prefix(self):
+        event = _make_event("ForxRelay !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
 
-        This test constructs a mock event with a command-like body and asserts that bot_command returns falsy when require_mention is enabled.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "!help"
-        mock_event.source = {"content": {"formatted_body": "!help"}}
+    def test_parser_rejects_display_name_colon_prefix(self):
+        event = _make_event("ForxRelay: !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
 
-        result = bot_command("help", mock_event, require_mention=True)
-        assert not result
+    def test_parser_rejects_arbitrary_prose_before_command(self):
+        event = _make_event("I like !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=False)
+        assert parsed is None
 
-    def test_no_match(self):
-        """
-        Test that a non-command message does not trigger bot command detection.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "regular message"
-        mock_event.source = {"content": {"formatted_body": "regular message"}}
+    def test_parser_requires_mxid_mention_when_enabled(self):
+        event = _make_event("!map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
 
-        result = bot_command("help", mock_event)
-        assert not result
+    def test_parser_allows_bare_command_when_mentions_not_required(self):
+        event = _make_event("!map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=False)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == ""
 
-    def test_no_match_require_mention_true(self):
-        """
-        Test that a non-command message does not trigger bot command detection when require_mention=True.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "regular message"
-        mock_event.source = {"content": {"formatted_body": "regular message"}}
+    def test_parser_rejects_other_mxid_when_mentions_required(self):
+        event = _make_event(f"{OTHER_MXID}: !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
 
-        result = bot_command("help", mock_event, require_mention=True)
-        assert not result
+    def test_parser_checks_normalized_formatted_body(self):
+        event = _make_event(
+            "not a command",
+            formatted_body=f"<a>{BOT_MXID}</a>: <strong>!MaP</strong> now",
+        )
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == "now"
 
-    def test_case_insensitive(self):
-        """
-        Test that bot command detection is case-insensitive by verifying a command matches regardless of letter case.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "!HELP"
-        mock_event.source = {"content": {"formatted_body": "!HELP"}}
+    def test_bot_command_wrapper_matches_supported_mxid(self):
+        event = _make_event(f"{BOT_MXID}: !HELP")
+        assert bot_command("help", event, require_mention=True)
 
-        result = bot_command("HELP", mock_event)  # Command should match case
-        assert result
+    def test_bot_command_wrapper_rejects_display_name(self):
+        event = _make_event("ForxRelay: !help")
+        assert not bot_command("help", event, require_mention=True)
 
-    def test_case_insensitive_require_mention_true(self):
-        """
-        Test that bot command detection fails when require_mention=True even with case-insensitive match.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "!HELP"
-        mock_event.source = {"content": {"formatted_body": "!HELP"}}
+    def test_bot_command_empty_command_returns_false(self):
+        event = _make_event("!help")
+        assert bot_command("", event) is False
 
-        result = bot_command("HELP", mock_event, require_mention=True)
-        assert not result
-
-    def test_with_args(self):
-        """
-        Test that the bot command is correctly detected when followed by additional arguments.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "!help me please"
-        mock_event.source = {"content": {"formatted_body": "!help me please"}}
-
-        result = bot_command("help", mock_event)
-        assert result
-
-    def test_with_args_require_mention_true(self):
-        """
-        Test that the bot command fails when require_mention=True even with arguments.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "!help me please"
-        mock_event.source = {"content": {"formatted_body": "!help me please"}}
-
-        result = bot_command("help", mock_event, require_mention=True)
-        assert not result
-
-    def test_bot_mention_require_mention_true(self):
-        """
-        Test that a message with bot mention works when require_mention=True.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "@bot:matrix.org: !help"
-        mock_event.source = {"content": {"formatted_body": "@bot:matrix.org: !help"}}
-
-        result = bot_command("help", mock_event, require_mention=True)
-        assert result
-
-    def test_bot_mention_with_name_require_mention_true(self):
-        """
-        Test that a message with bot display name works when require_mention=True.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "Bot: !help"
-        mock_event.source = {"content": {"formatted_body": "Bot: !help"}}
-
-        result = bot_command("help", mock_event, require_mention=True)
-        assert result
-
-    def test_non_bot_mention_require_mention_true(self):
-        """
-        Test that a message mentioning another user does not trigger when require_mention=True.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "@someuser: !help"
-        mock_event.source = {"content": {"formatted_body": "@someuser: !help"}}
-
-        result = bot_command("help", mock_event, require_mention=True)
-        assert not result
-
-    def test_bot_mention_require_mention_false(self):
-        """
-        Test that a message with bot mention works when require_mention=False.
-        """
-        mock_event = MagicMock()
-        mock_event.body = "@bot:matrix.org: !help"
-        mock_event.source = {"content": {"formatted_body": "@bot:matrix.org: !help"}}
-
-        result = bot_command("help", mock_event, require_mention=False)
-        assert result
-
-    def test_empty_command_returns_false(self):
-        """Empty commands should never match."""
-        mock_event = MagicMock()
-        mock_event.body = "!help"
-        mock_event.source = {"content": {"formatted_body": "!help"}}
-
-        result = bot_command("", mock_event)
-        assert result is False
-
-    def test_bad_identifier_skips_mention_parts(self):
-        """Bad bot identifiers should be ignored when building mention patterns."""
+    def test_bad_mxid_identifier_is_ignored(self):
+        """Broken bot MXID stringification should fail closed."""
 
         class BadIdent:
             def __str__(self):
-                """
-                Raise a ValueError with message "boom".
-
-                Raises:
-                    ValueError: Always raised when attempting to produce the string representation.
-                """
                 raise ValueError("boom")
 
-        mock_event = MagicMock()
-        mock_event.body = "hello"
-        mock_event.source = {"content": {"formatted_body": "hello"}}
-
+        event = _make_event("!help")
         with (
             patch("mmrelay.matrix_utils.bot_user_id", BadIdent()),
-            patch("mmrelay.matrix_utils.bot_user_name", None),
             patch("mmrelay.matrix_utils.logger") as mock_logger,
         ):
-            result = bot_command("help", mock_event, require_mention=True)
-
-        assert result is False
+            parsed = _parse_matrix_message_command(
+                event, ("help",), require_mention=True
+            )
+        assert parsed is None
         mock_logger.debug.assert_called()

--- a/tests/test_matrix_utils_bot.py
+++ b/tests/test_matrix_utils_bot.py
@@ -59,20 +59,79 @@ class TestMatrixCommandParser:
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is None
 
-    def test_parser_rejects_display_name_prefix(self):
+    def test_parser_accepts_display_name_prefix(self):
         event = _make_event("ForxRelay !map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
-        assert parsed is None
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == ""
 
-    def test_parser_rejects_display_name_colon_prefix(self):
+    def test_parser_accepts_display_name_colon_prefix(self):
         event = _make_event("ForxRelay: !map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
-        assert parsed is None
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == ""
 
     def test_parser_rejects_arbitrary_prose_before_command(self):
         event = _make_event("I like !map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=False)
         assert parsed is None
+
+    def test_parser_rejects_display_name_without_separator(self):
+        event = _make_event("ForxRelay!map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
+
+    def test_parser_rejects_display_name_not_at_start(self):
+        event = _make_event("Hello ForxRelay !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
+
+    def test_parser_rejects_partial_display_name_match(self):
+        event = _make_event("Forx !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
+
+    def test_display_name_case_insensitive(self):
+        event = _make_event("forxrelay !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+
+    def test_mxid_mention_takes_precedence_over_display_name(self):
+        event = _make_event(f"{BOT_MXID}: !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+
+    def test_formatted_body_mxid_wins_over_display_name_in_body(self):
+        event = _make_event(
+            "ForxRelay !map",
+            formatted_body=(
+                '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
+                "ForxRelay</a>: !map"
+            ),
+        )
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == ""
+
+    def test_display_name_fallback_skipped_when_name_not_configured(self):
+        event = _make_event("ForxRelay !map")
+        with patch("mmrelay.matrix_utils.bot_user_name", None):
+            parsed = _parse_matrix_message_command(
+                event, ("map",), require_mention=True
+            )
+        assert parsed is None
+
+    def test_display_name_fallback_with_args(self):
+        event = _make_event("ForxRelay: !map 42")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is not None
+        assert parsed.command == "map"
+        assert parsed.args == "42"
 
     def test_parser_requires_mxid_mention_when_enabled(self):
         event = _make_event("!map")
@@ -143,9 +202,9 @@ class TestMatrixCommandParser:
         event = _make_event(f"{BOT_MXID}: !HELP")
         assert bot_command("help", event, require_mention=True)
 
-    def test_bot_command_wrapper_rejects_display_name(self):
+    def test_bot_command_wrapper_accepts_display_name(self):
         event = _make_event("ForxRelay: !help")
-        assert not bot_command("help", event, require_mention=True)
+        assert bot_command("help", event, require_mention=True)
 
     def test_bot_command_empty_command_returns_false(self):
         event = _make_event("!help")

--- a/tests/test_matrix_utils_bot.py
+++ b/tests/test_matrix_utils_bot.py
@@ -26,7 +26,7 @@ class TestMatrixCommandParser:
     def patch_bot_identity(self):
         with (
             patch("mmrelay.matrix_utils.bot_user_id", BOT_MXID),
-            patch("mmrelay.matrix_utils.bot_user_name", "ForxRelay"),
+            patch("mmrelay.matrix_utils.bot_user_name", "TestRelay"),
         ):
             yield
 
@@ -60,14 +60,14 @@ class TestMatrixCommandParser:
         assert parsed is None
 
     def test_parser_accepts_display_name_prefix(self):
-        event = _make_event("ForxRelay !map")
+        event = _make_event("TestRelay !map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is not None
         assert parsed.command == "map"
         assert parsed.args == ""
 
     def test_parser_accepts_display_name_colon_prefix(self):
-        event = _make_event("ForxRelay: !map")
+        event = _make_event("TestRelay: !map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is not None
         assert parsed.command == "map"
@@ -79,12 +79,12 @@ class TestMatrixCommandParser:
         assert parsed is None
 
     def test_parser_rejects_display_name_without_separator(self):
-        event = _make_event("ForxRelay!map")
+        event = _make_event("TestRelay!map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is None
 
     def test_parser_rejects_display_name_not_at_start(self):
-        event = _make_event("Hello ForxRelay !map")
+        event = _make_event("Hello TestRelay !map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is None
 
@@ -94,7 +94,7 @@ class TestMatrixCommandParser:
         assert parsed is None
 
     def test_display_name_case_insensitive(self):
-        event = _make_event("forxrelay !map")
+        event = _make_event("testrelay !map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is not None
         assert parsed.command == "map"
@@ -107,10 +107,10 @@ class TestMatrixCommandParser:
 
     def test_formatted_body_mxid_wins_over_plain_body_display_name_fallback(self):
         event = _make_event(
-            "ForxRelay !map 123",
+            "TestRelay !map 123",
             formatted_body=(
                 '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
-                "ForxRelay</a>: !map 456"
+                "TestRelay</a>: !map 456"
             ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
@@ -121,7 +121,7 @@ class TestMatrixCommandParser:
     def test_plain_body_mxid_wins_over_formatted_body_display_name_fallback(self):
         event = _make_event(
             f"{BOT_MXID}: !map 999",
-            formatted_body="<span>ForxRelay !map 321</span>",
+            formatted_body="<span>TestRelay !map 321</span>",
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is not None
@@ -129,7 +129,7 @@ class TestMatrixCommandParser:
         assert parsed.args == "999"
 
     def test_display_name_fallback_skipped_when_name_not_configured(self):
-        event = _make_event("ForxRelay !map")
+        event = _make_event("TestRelay !map")
         with patch("mmrelay.matrix_utils.bot_user_name", None):
             parsed = _parse_matrix_message_command(
                 event, ("map",), require_mention=True
@@ -137,7 +137,7 @@ class TestMatrixCommandParser:
         assert parsed is None
 
     def test_display_name_fallback_with_args(self):
-        event = _make_event("ForxRelay: !map 42")
+        event = _make_event("TestRelay: !map 42")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is not None
         assert parsed.command == "map"
@@ -145,10 +145,10 @@ class TestMatrixCommandParser:
 
     def test_unrelated_formatted_body_link_keeps_display_name_fallback(self):
         event = _make_event(
-            "ForxRelay !map 55",
+            "TestRelay !map 55",
             formatted_body=(
                 '<a href="https://matrix.to/#/%40relay%3Aexample.com">'
-                "ForxRelay</a>: !map 777"
+                "TestRelay</a>: !map 777"
             ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
@@ -178,7 +178,7 @@ class TestMatrixCommandParser:
             "not a command",
             formatted_body=(
                 '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
-                "ForxRelay</a>: <strong>!MaP</strong> now"
+                "TestRelay</a>: <strong>!MaP</strong> now"
             ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
@@ -191,7 +191,7 @@ class TestMatrixCommandParser:
             "not a command",
             formatted_body=(
                 '<a class="mention" data-href="https://matrix.to/#/%40relay%3Aexample.com" '
-                'href="https://matrix.to/#/%40testbot%3Aexample.org">ForxRelay</a>: !map'
+                'href="https://matrix.to/#/%40testbot%3Aexample.org">TestRelay</a>: !map'
             ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
@@ -204,7 +204,7 @@ class TestMatrixCommandParser:
             "not a command",
             formatted_body=(
                 '<a class="mention" data-href="https://matrix.to/#/%40testbot%3Aexample.org">'
-                "ForxRelay</a>: !map"
+                "TestRelay</a>: !map"
             ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
@@ -215,7 +215,7 @@ class TestMatrixCommandParser:
             "not a command",
             formatted_body=(
                 '<a href="https://matrix.to/#/%40relay%3Aexample.com">'
-                "ForxRelay</a>: !map"
+                "TestRelay</a>: !map"
             ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
@@ -226,7 +226,7 @@ class TestMatrixCommandParser:
         assert bot_command("help", event, require_mention=True)
 
     def test_bot_command_wrapper_accepts_display_name(self):
-        event = _make_event("ForxRelay: !help")
+        event = _make_event("TestRelay: !help")
         assert bot_command("help", event, require_mention=True)
 
     def test_bot_command_empty_command_returns_false(self):

--- a/tests/test_matrix_utils_bot.py
+++ b/tests/test_matrix_utils_bot.py
@@ -49,6 +49,11 @@ class TestMatrixCommandParser:
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is None
 
+    def test_parser_rejects_comma_prefix(self):
+        event = _make_event(f"{BOT_MXID}, !map")
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
+
     def test_parser_rejects_compact_mxid_and_command(self):
         event = _make_event(f"{BOT_MXID}!map")
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
@@ -86,15 +91,29 @@ class TestMatrixCommandParser:
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is None
 
-    def test_parser_checks_normalized_formatted_body(self):
+    def test_parser_accepts_formatted_body_mention_pill_targeting_bot_mxid(self):
         event = _make_event(
             "not a command",
-            formatted_body=f"<a>{BOT_MXID}</a>: <strong>!MaP</strong> now",
+            formatted_body=(
+                '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
+                "ForxRelay</a>: <strong>!MaP</strong> now"
+            ),
         )
         parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
         assert parsed is not None
         assert parsed.command == "map"
         assert parsed.args == "now"
+
+    def test_parser_rejects_formatted_body_link_not_targeting_bot_mxid(self):
+        event = _make_event(
+            "not a command",
+            formatted_body=(
+                '<a href="https://matrix.to/#/%40relay%3Aexample.com">'
+                "ForxRelay</a>: !map"
+            ),
+        )
+        parsed = _parse_matrix_message_command(event, ("map",), require_mention=True)
+        assert parsed is None
 
     def test_bot_command_wrapper_matches_supported_mxid(self):
         event = _make_event(f"{BOT_MXID}: !HELP")

--- a/tests/test_meshtastic_utils.py
+++ b/tests/test_meshtastic_utils.py
@@ -24,7 +24,7 @@ from typing import Any, NoReturn
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, mock_open, patch
 
 import pytest
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/tests/test_meshtastic_utils_edge_cases.py
+++ b/tests/test_meshtastic_utils_edge_cases.py
@@ -21,7 +21,7 @@ from concurrent.futures import TimeoutError as ConcurrentTimeoutError
 from typing import NoReturn
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))

--- a/tests/test_meshtastic_utils_message_paths.py
+++ b/tests/test_meshtastic_utils_message_paths.py
@@ -4,7 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 
 import mmrelay.meshtastic_utils as mu
 from mmrelay.constants.config import CONFIG_KEY_MESHNET_NAME

--- a/tests/test_performance_stress.py
+++ b/tests/test_performance_stress.py
@@ -27,7 +27,7 @@ import pytest
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 
 from mmrelay.constants.formats import TEXT_MESSAGE_APP
 from mmrelay.constants.messages import PORTNUM_TEXT_MESSAGE_APP

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 
 from mmrelay.constants.formats import DEFAULT_CHANNEL, TEXT_MESSAGE_APP
 from mmrelay.constants.messages import PING_RESPONSE

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -432,37 +432,31 @@ class TestTelemetryPlugin(unittest.TestCase):
 
         asyncio.run(run_test())
 
-    @patch("mmrelay.matrix_utils.bot_command")
-    def test_matches_with_valid_command(self, mock_bot_command):
+    def test_matches_with_valid_command(self):
         """
         Test that the matches method returns True when a valid telemetry command is present in the event.
 
-        Verifies that the method checks all available commands and returns True upon finding a match.
+        Verifies that a valid leading telemetry command matches.
         """
-        mock_bot_command.side_effect = lambda cmd, *_, **__: cmd == "batteryLevel"
-
         event = MagicMock()
+        event.body = "!batteryLevel"
+        event.source = {"content": {"formatted_body": ""}}
         result = self.plugin.matches(event)
 
         self.assertTrue(result)
-        # Should check all commands until it finds a match
-        self.assertTrue(mock_bot_command.called)
 
-    @patch("mmrelay.matrix_utils.bot_command")
-    def test_matches_with_no_command(self, mock_bot_command):
+    def test_matches_with_no_command(self):
         """
         Test that the matches method returns False when no commands match the event.
 
-        Verifies that all available commands are checked when there is no match.
+        Verifies that non-command text does not match.
         """
-        mock_bot_command.return_value = False
-
         event = MagicMock()
+        event.body = "hello there"
+        event.source = {"content": {"formatted_body": ""}}
         result = self.plugin.matches(event)
 
         self.assertFalse(result)
-        # Should check all commands
-        self.assertEqual(mock_bot_command.call_count, 3)
 
     def test_handle_room_message_no_match(self):
         """

--- a/tests/test_telemetry_plugin.py
+++ b/tests/test_telemetry_plugin.py
@@ -662,7 +662,9 @@ class TestTelemetryPlugin(unittest.TestCase):
 
     def test_handle_room_message_matrix_unavailable(self):
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("batteryLevel", "")
+        )
 
         with (
             patch("mmrelay.matrix_utils.bot_user_id", "@bot:matrix.org"),
@@ -688,7 +690,9 @@ class TestTelemetryPlugin(unittest.TestCase):
     @patch("mmrelay.matrix_utils.send_image")
     def test_handle_room_message_node_no_data(self, _mock_send, mock_connect):
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("batteryLevel", "NodeX")
+        )
         self.plugin.get_node_data.return_value = None
         self.plugin.send_matrix_message = AsyncMock()
 
@@ -727,7 +731,9 @@ class TestTelemetryPlugin(unittest.TestCase):
         import json
 
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("batteryLevel", "")
+        )
         now_ts = datetime.now(timezone.utc).timestamp()
         self.plugin.get_data.return_value = [
             (json.dumps([{"time": now_ts, "batteryLevel": 80}]),)
@@ -775,7 +781,9 @@ class TestTelemetryPlugin(unittest.TestCase):
         from mmrelay.matrix_utils import ImageUploadError
 
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("batteryLevel", "")
+        )
         self.plugin.get_data.return_value = []
 
         mock_matrix_client = MagicMock()
@@ -828,7 +836,9 @@ class TestTelemetryPlugin(unittest.TestCase):
         import json
 
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("batteryLevel", "")
+        )
 
         now_ts = datetime.now(timezone.utc).timestamp()
         self.plugin.get_data.return_value = [
@@ -880,7 +890,9 @@ class TestTelemetryPlugin(unittest.TestCase):
         import json
 
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("batteryLevel", "")
+        )
 
         self.plugin.get_data.return_value = [
             (
@@ -932,7 +944,9 @@ class TestTelemetryPlugin(unittest.TestCase):
     @patch("mmrelay.matrix_utils.send_image")
     def test_handle_room_message_generic_exception(self, _mock_send, mock_connect):
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="batteryLevel")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("batteryLevel", "")
+        )
         self.plugin.get_data.side_effect = RuntimeError("unexpected error")
 
         mock_matrix_client = MagicMock()

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -24,7 +24,7 @@ import pytest
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from meshtastic.mesh_interface import BROADCAST_NUM
+from meshtastic import BROADCAST_NUM
 
 from mmrelay.constants.messages import PORTNUM_TEXT_MESSAGE_APP
 from mmrelay.constants.plugins import WEATHER_UNITS_IMPERIAL, WEATHER_UNITS_METRIC
@@ -1579,10 +1579,6 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     async def test_handle_room_message_no_coords_no_mesh(self):
         """Should send 'Cannot determine location' when no coords available."""
-        self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command_with_args = MagicMock(
-            return_value=("weather", "")
-        )
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.send_matrix_reaction = AsyncMock()
@@ -1593,7 +1589,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
         with patch("mmrelay.meshtastic_utils.connect_meshtastic", return_value=None):
             result = await self.plugin.handle_room_message(
-                MagicMock(room_id="!r"), mock_event, "!weather"
+                MagicMock(room_id="!r"), mock_event, mock_event.body
             )
         self.assertTrue(result)
         self.assertIn(
@@ -1603,10 +1599,6 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     async def test_handle_room_message_mesh_location_fallback(self):
         """Should use mesh location when no coords in args."""
-        self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command_with_args = MagicMock(
-            return_value=("weather", "")
-        )
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
@@ -1624,7 +1616,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
             "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
         ):
             result = await self.plugin.handle_room_message(
-                MagicMock(room_id="!r"), mock_event, "!weather"
+                MagicMock(room_id="!r"), mock_event, mock_event.body
             )
         self.assertTrue(result)
         self.plugin.generate_forecast.assert_called_once()
@@ -1646,10 +1638,7 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     async def test_handle_room_message_replies_to_event(self):
         """handle_room_message should send a reaction and not use reply_to_event_id."""
-        self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command_with_args = MagicMock(
-            return_value=("weather", "")
-        )
+        self.plugin.get_require_bot_mention = MagicMock(return_value=True)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.send_matrix_reaction = AsyncMock()
         self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
@@ -1661,14 +1650,24 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
         mock_event = MagicMock()
         mock_event.event_id = "$test_event_123"
-        mock_event.body = "!weather"
-        mock_event.source = {"content": {"formatted_body": ""}}
+        mock_event.body = "not a command"
+        mock_event.source = {
+            "content": {
+                "formatted_body": (
+                    '<a href="https://matrix.to/#/%40testbot%3Aexample.org">'
+                    "TestRelay</a>: !weather"
+                )
+            }
+        }
 
-        with patch(
-            "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+        with (
+            patch(
+                "mmrelay.meshtastic_utils.connect_meshtastic", return_value=mock_client
+            ),
+            patch("mmrelay.matrix_utils.bot_user_id", "@testbot:example.org"),
         ):
             result = await self.plugin.handle_room_message(
-                MagicMock(room_id="!r"), mock_event, "!weather"
+                MagicMock(room_id="!r"), mock_event, mock_event.body
             )
 
         self.assertTrue(result)
@@ -1680,15 +1679,14 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
 
     async def test_handle_room_message_no_parsed_command_returns_false(self):
         """Should return False when command/args parsing yields no match."""
-        self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command_with_args = MagicMock(return_value=None)
+        self.plugin.get_require_bot_mention = MagicMock(return_value=False)
 
         mock_event = MagicMock()
-        mock_event.body = "!weather"
+        mock_event.body = "hello there"
         mock_event.source = {"content": {"formatted_body": ""}}
 
         result = await self.plugin.handle_room_message(
-            MagicMock(room_id="!r"), mock_event, "!weather"
+            MagicMock(room_id="!r"), mock_event, mock_event.body
         )
         self.assertFalse(result)
 

--- a/tests/test_weather_plugin.py
+++ b/tests/test_weather_plugin.py
@@ -1580,7 +1580,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     async def test_handle_room_message_no_coords_no_mesh(self):
         """Should send 'Cannot determine location' when no coords available."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("weather", "")
+        )
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.send_matrix_reaction = AsyncMock()
@@ -1602,7 +1604,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     async def test_handle_room_message_mesh_location_fallback(self):
         """Should use mesh location when no coords in args."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("weather", "")
+        )
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
@@ -1643,7 +1647,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     async def test_handle_room_message_replies_to_event(self):
         """handle_room_message should send a reaction and not use reply_to_event_id."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("weather", "")
+        )
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.send_matrix_reaction = AsyncMock()
         self.plugin.generate_forecast = MagicMock(return_value="Sunny 25°C")
@@ -1673,9 +1679,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(call_kwargs.get("reply_to_event_id"))
 
     async def test_handle_room_message_no_parsed_command_returns_false(self):
-        """Should return False when get_matching_matrix_command returns None (line 914)."""
+        """Should return False when command/args parsing yields no match."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value=None)
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(return_value=None)
 
         mock_event = MagicMock()
         mock_event.body = "!weather"
@@ -1689,7 +1695,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     async def test_handle_room_message_invalid_units_fallback_to_metric(self):
         """Invalid units in config should fall back to metric (lines 953-954)."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("weather", "")
+        )
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.send_matrix_reaction = AsyncMock()
@@ -1720,7 +1728,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     async def test_handle_room_message_exception_handler(self):
         """Exception in handle_room_message should log and send reaction (lines 973-975)."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("weather", "")
+        )
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.send_matrix_reaction = AsyncMock()
         self.plugin._resolve_location_from_args = AsyncMock(
@@ -1746,7 +1756,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     async def test_handle_room_message_no_location_sends_reaction(self):
         """'Cannot determine location' should still send a reaction."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("weather", "")
+        )
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.send_matrix_reaction = AsyncMock()
 
@@ -2161,7 +2173,9 @@ class TestWeatherPlugin(unittest.IsolatedAsyncioTestCase):
     async def test_handle_room_message_appends_marine_data(self):
         """Matrix handler combines terrestrial and marine forecasts in one message."""
         self.plugin.matches = MagicMock(return_value=True)
-        self.plugin.get_matching_matrix_command = MagicMock(return_value="weather")
+        self.plugin.get_matching_matrix_command_with_args = MagicMock(
+            return_value=("weather", "40.0 -10.0")
+        )
         self.plugin.get_require_bot_mention = MagicMock(return_value=False)
         self.plugin.send_matrix_message = AsyncMock()
         self.plugin.generate_forecast = MagicMock(return_value="Now: ☀️ Clear - 22°C")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR refactors Matrix command parsing to provide centralized, robust handling of command detection and argument extraction. It removes a PIL.ImageDraw monkeypatch that became unnecessary with py-staticmaps 0.5.0, updates imports to align with current meshtastic package structure, and replaces scattered regex-based parsing logic with a dedicated parser that handles mention detection via MXID, display-name fallback, formatted-body normalization, and flexible delimiter handling.

## Key Changes

**Refactoring**
- Centralized Matrix command parsing into a new `_parse_matrix_message_command()` function in `command_bridge.py` that replaces scattered regex logic and provides consistent handling across plugins
- Introduced `ParsedMatrixCommand` data class and associated helper functions to manage command lookup, candidate body extraction, formatted-body normalization (stripping reply blocks, collapsing whitespace, processing anchor tags), and mention detection
- Refactored `BasePlugin.matches()` to delegate to new `get_matching_matrix_command_with_args()` instead of iterating over commands
- Added `BasePlugin.get_matching_matrix_command_with_args()` method that returns `(command, args)` tuple for consolidated command and argument extraction
- Updated `BasePlugin.extract_command_args()` to accept optional event-based parsing (via keyword-only `event` parameter) as an alternative to text-based fallback
- Updated all plugins (`map_plugin.py`, `weather_plugin.py`, `telemetry_plugin.py`, `help_plugin.py`, `ping_plugin.py`) to use new command parsing methods

**Removal**
- Removed `textsize()` monkeypatch from `map_plugin.py` (custom PIL.ImageDraw.textsize wrapper)

**Import Updates**
- Changed `BROADCAST_NUM` imports from `meshtastic.mesh_interface` to top-level `meshtastic` in `events.py`, `base_plugin.py`, `ping_plugin.py`, and `weather_plugin.py`
- Updated `meshtastic/connection.py` to capture BLE interface class reference for indirect instantiation

**Testing**
- Removed `TestTextSizeFunction` test class from `test_map_plugin.py`
- Updated command parsing tests to use new MXID mention handling and `get_matching_matrix_command_with_args()` mocking
- Added coverage for MXID mention detection, display-name fallback, formatted-body parsing with mention pills, and command argument extraction via events
- Refactored `test_matrix_utils_bot.py` to validate internal `_parse_matrix_message_command()` parser behavior across various mention formats and separator rules

## Breaking Changes

- `BasePlugin.extract_command_args()` signature changed from `extract_command_args(command: str, text: str)` to `extract_command_args(command: str, text: str | None = None, *, event: RoomMessageText | RoomMessageNotice | ReactionEvent | RoomMessageEmote | None = None)`
- New required method `get_matching_matrix_command_with_args()` added to `BasePlugin`; subclasses relying on old command detection patterns will need updates to use centralized parsing pipeline
<!-- end of auto-generated comment: release notes by coderabbit.ai -->