### PR TITLE
Add per-BLE-connection generation tracking and timeout diagnostics

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,10 +18,10 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.136.1
+    - renovate@43.139.6
     - shellcheck@0.11.0
     - shfmt@3.6.0
-    - mypy@1.20.1
+    - mypy@1.20.2
     - pyright@1.1.409
     - dotenv-linter@4.0.0
     - hadolint@2.14.0
@@ -36,7 +36,7 @@ lint:
     - osv-scanner@2.3.5
     - prettier@3.8.3
     - ruff@0.15.11
-    - trufflehog@3.94.3
+    - trufflehog@3.95.2
     - yamllint@1.38.0
   definitions:
     - name: bandit

--- a/src/mmrelay/matrix/command_bridge.py
+++ b/src/mmrelay/matrix/command_bridge.py
@@ -352,6 +352,8 @@ def _parse_matrix_message_command(
         return None
 
     if require_mention:
+        if bot_mxid is None:
+            return None
         # Pass 1: require exact MXID mention semantics across all body variants.
         # This tier includes plain-body MXID prefixes and formatted-body mention
         # pills that normalize to MXID prefixes.

--- a/src/mmrelay/meshtastic/async_utils.py
+++ b/src/mmrelay/meshtastic/async_utils.py
@@ -356,13 +356,17 @@ def _run_blocking_with_timeout(
         if not callable(resolve_teardown_timeout):
             return
 
+        resolve_teardown_timeout_fn = cast(
+            Callable[[str, int], tuple[int, bool]],
+            resolve_teardown_timeout,
+        )
         with teardown_timeout_resolution_lock:
             if teardown_timeout_resolved_event.is_set():
                 return
             (
                 resolved_remaining_unresolved,
                 resolved_stale_generation,
-            ) = resolve_teardown_timeout(
+            ) = resolve_teardown_timeout_fn(
                 ble_address,
                 ble_generation,
             )
@@ -447,11 +451,16 @@ def _run_blocking_with_timeout(
                 None,
             )
             if callable(record_teardown_timeout):
-                unresolved_generation_workers = record_teardown_timeout(
+                record_teardown_timeout_fn = cast(
+                    Callable[[str, int], int],
+                    record_teardown_timeout,
+                )
+                recorded_unresolved_count = record_teardown_timeout_fn(
                     ble_address,
                     ble_generation,
                 )
-                if unresolved_generation_workers > 0:
+                unresolved_generation_workers = recorded_unresolved_count
+                if recorded_unresolved_count > 0:
                     teardown_timeout_recorded_event.set()
         timed_out_event.set()
         if done_event.is_set():

--- a/src/mmrelay/meshtastic/async_utils.py
+++ b/src/mmrelay/meshtastic/async_utils.py
@@ -324,8 +324,49 @@ def _run_blocking_with_timeout(
     """
     done_event = threading.Event()
     timed_out_event = threading.Event()
+    teardown_timeout_recorded_event = threading.Event()
+    teardown_timeout_resolved_event = threading.Event()
+    teardown_timeout_resolution_lock = threading.Lock()
     action_error: Exception | None = None
     worker_started_at = facade.time.monotonic()
+    resolved_stale_generation: bool | None = None
+    resolved_remaining_unresolved: int | None = None
+
+    def _resolve_recorded_teardown_timeout_once() -> None:
+        """
+        Resolve a previously-recorded teardown timeout at most once.
+
+        Worker and caller timeout paths can both attempt to resolve. Guard with a
+        lock+event so unresolved teardown bookkeeping remains consistent.
+        """
+
+        nonlocal resolved_stale_generation
+        nonlocal resolved_remaining_unresolved
+
+        if not teardown_timeout_recorded_event.is_set():
+            return
+        if not (ble_address and ble_generation is not None and ble_generation > 0):
+            return
+
+        resolve_teardown_timeout = getattr(
+            facade,
+            "_resolve_ble_teardown_timeout",
+            None,
+        )
+        if not callable(resolve_teardown_timeout):
+            return
+
+        with teardown_timeout_resolution_lock:
+            if teardown_timeout_resolved_event.is_set():
+                return
+            (
+                resolved_remaining_unresolved,
+                resolved_stale_generation,
+            ) = resolve_teardown_timeout(
+                ble_address,
+                ble_generation,
+            )
+            teardown_timeout_resolved_event.set()
 
     def _runner() -> None:
         """
@@ -341,31 +382,24 @@ def _run_blocking_with_timeout(
         finally:
             done_event.set()
             if timed_out_event.is_set():
-                stale_generation: bool | None = None
-                remaining_unresolved: int | None = None
-                if ble_address and ble_generation is not None and ble_generation > 0:
-                    resolve_teardown_timeout = getattr(
+                _resolve_recorded_teardown_timeout_once()
+                stale_generation_for_log = resolved_stale_generation
+                remaining_unresolved_for_log = resolved_remaining_unresolved
+                if (
+                    stale_generation_for_log is None
+                    and ble_address
+                    and ble_generation is not None
+                    and ble_generation > 0
+                ):
+                    is_generation_stale = getattr(
                         facade,
-                        "_resolve_ble_teardown_timeout",
+                        "_is_ble_generation_stale",
                         None,
                     )
-                    if callable(resolve_teardown_timeout):
-                        remaining_unresolved, stale_generation = (
-                            resolve_teardown_timeout(
-                                ble_address,
-                                ble_generation,
-                            )
+                    if callable(is_generation_stale):
+                        stale_generation_for_log = bool(
+                            is_generation_stale(ble_address, ble_generation)
                         )
-                    else:
-                        is_generation_stale = getattr(
-                            facade,
-                            "_is_ble_generation_stale",
-                            None,
-                        )
-                        if callable(is_generation_stale):
-                            stale_generation = bool(
-                                is_generation_stale(ble_address, ble_generation)
-                            )
                 worker_elapsed = max(
                     0.0,
                     facade.time.monotonic() - worker_started_at,
@@ -381,8 +415,8 @@ def _run_blocking_with_timeout(
                     ble_generation,
                     iface_id,
                     client_id,
-                    stale_generation,
-                    remaining_unresolved,
+                    stale_generation_for_log,
+                    remaining_unresolved_for_log,
                 )
 
     thread = threading.Thread(
@@ -404,7 +438,6 @@ def _run_blocking_with_timeout(
     )
     thread.start()
     if not done_event.wait(timeout=timeout):
-        timed_out_event.set()
         elapsed = max(0.0, facade.time.monotonic() - worker_started_at)
         unresolved_generation_workers: int | None = None
         if ble_address and ble_generation is not None and ble_generation > 0:
@@ -418,6 +451,13 @@ def _run_blocking_with_timeout(
                     ble_address,
                     ble_generation,
                 )
+                if unresolved_generation_workers > 0:
+                    teardown_timeout_recorded_event.set()
+        timed_out_event.set()
+        if done_event.is_set():
+            # Worker can finish after timeout expiry but before timeout signaling.
+            # Resolve now so we don't leave a stale unresolved teardown entry.
+            _resolve_recorded_teardown_timeout_once()
         if timeout_log_level is not None:
             facade.logger.log(
                 timeout_log_level,

--- a/src/mmrelay/meshtastic/async_utils.py
+++ b/src/mmrelay/meshtastic/async_utils.py
@@ -299,6 +299,11 @@ def _run_blocking_with_timeout(
     timeout: float,
     label: str,
     timeout_log_level: int | None = logging.WARNING,
+    *,
+    ble_address: str | None = None,
+    ble_generation: int | None = None,
+    iface_id: int | None = None,
+    client_id: int | None = None,
 ) -> None:
     """
     Run a blocking callable in a daemon thread with a timeout to avoid hangs.
@@ -318,7 +323,9 @@ def _run_blocking_with_timeout(
         Exception: Any exception raised by the action is re-raised.
     """
     done_event = threading.Event()
+    timed_out_event = threading.Event()
     action_error: Exception | None = None
+    worker_started_at = facade.time.monotonic()
 
     def _runner() -> None:
         """
@@ -333,17 +340,99 @@ def _run_blocking_with_timeout(
             action_error = exc
         finally:
             done_event.set()
+            if timed_out_event.is_set():
+                stale_generation: bool | None = None
+                remaining_unresolved: int | None = None
+                if ble_address and ble_generation is not None and ble_generation > 0:
+                    resolve_teardown_timeout = getattr(
+                        facade,
+                        "_resolve_ble_teardown_timeout",
+                        None,
+                    )
+                    if callable(resolve_teardown_timeout):
+                        remaining_unresolved, stale_generation = (
+                            resolve_teardown_timeout(
+                                ble_address,
+                                ble_generation,
+                            )
+                        )
+                    else:
+                        is_generation_stale = getattr(
+                            facade,
+                            "_is_ble_generation_stale",
+                            None,
+                        )
+                        if callable(is_generation_stale):
+                            stale_generation = bool(
+                                is_generation_stale(ble_address, ble_generation)
+                            )
+                worker_elapsed = max(
+                    0.0,
+                    facade.time.monotonic() - worker_started_at,
+                )
+                facade.logger.warning(
+                    "Blocking worker completed after caller timeout: label=%s "
+                    "thread=%s elapsed=%.3fs address=%s generation=%s iface_id=%s "
+                    "client_id=%s stale_generation=%s remaining_unresolved=%s",
+                    label,
+                    threading.current_thread().name,
+                    worker_elapsed,
+                    ble_address,
+                    ble_generation,
+                    iface_id,
+                    client_id,
+                    stale_generation,
+                    remaining_unresolved,
+                )
 
     thread = threading.Thread(
         target=_runner,
         name=f"mmrelay-blocking-{label}",
         daemon=True,
     )
+    facade.logger.debug(
+        "Starting blocking worker label=%s thread=%s timeout=%.1fs address=%s "
+        "generation=%s iface_id=%s client_id=%s start_monotonic=%.6f",
+        label,
+        thread.name,
+        timeout,
+        ble_address,
+        ble_generation,
+        iface_id,
+        client_id,
+        worker_started_at,
+    )
     thread.start()
     if not done_event.wait(timeout=timeout):
+        timed_out_event.set()
+        elapsed = max(0.0, facade.time.monotonic() - worker_started_at)
+        unresolved_generation_workers: int | None = None
+        if ble_address and ble_generation is not None and ble_generation > 0:
+            record_teardown_timeout = getattr(
+                facade,
+                "_record_ble_teardown_timeout",
+                None,
+            )
+            if callable(record_teardown_timeout):
+                unresolved_generation_workers = record_teardown_timeout(
+                    ble_address,
+                    ble_generation,
+                )
         if timeout_log_level is not None:
             facade.logger.log(
-                timeout_log_level, "%s timed out after %.1fs", label, timeout
+                timeout_log_level,
+                "%s timed out after %.1fs (thread=%s elapsed=%.3fs address=%s "
+                "generation=%s iface_id=%s client_id=%s "
+                "unresolved_generation_workers=%s)",
+                label,
+                timeout,
+                thread.name,
+                elapsed,
+                ble_address,
+                ble_generation,
+                iface_id,
+                client_id,
+                unresolved_generation_workers,
             )
         raise TimeoutError(f"{label} timed out after {timeout:.1f}s")
     if action_error is not None:

--- a/src/mmrelay/meshtastic/ble.py
+++ b/src/mmrelay/meshtastic/ble.py
@@ -118,6 +118,7 @@ def _attach_late_ble_interface_disposer(
             fallback_address=ble_address,
         )
         log_address = late_address or ble_address
+        late_client_obj = getattr(late_iface, "client", None)
 
         facade.logger.warning(
             "Cleaning up late BLE interface completion for %s (%s) "
@@ -126,11 +127,7 @@ def _attach_late_ble_interface_disposer(
             reason,
             late_generation,
             id(late_iface),
-            (
-                id(getattr(late_iface, "client", None))
-                if getattr(late_iface, "client", None) is not None
-                else None
-            ),
+            (id(late_client_obj) if late_client_obj is not None else None),
         )
         try:
             facade._disconnect_ble_interface(
@@ -1016,6 +1013,7 @@ def _disconnect_ble_interface(
                 if inspect.isawaitable(result):
                     facade._wait_for_result(result, timeout=5.0)
 
+            iface_client_obj = getattr(iface, "client", None)
             facade._run_blocking_with_timeout(
                 _close_sync,
                 timeout=5.0,
@@ -1025,9 +1023,7 @@ def _disconnect_ble_interface(
                 ble_generation=generation,
                 iface_id=iface_id,
                 client_id=(
-                    id(getattr(iface, "client", None))
-                    if getattr(iface, "client", None) is not None
-                    else client_id
+                    id(iface_client_obj) if iface_client_obj is not None else client_id
                 ),
             )
     except TimeoutError as exc:

--- a/src/mmrelay/meshtastic/ble.py
+++ b/src/mmrelay/meshtastic/ble.py
@@ -81,6 +81,7 @@ def _attach_late_ble_interface_disposer(
     reason: str,
     *,
     fallback_iface: Any | None = None,
+    generation: int | None = None,
 ) -> None:
     """
     Dispose interfaces created by abandoned BLE futures that complete late.
@@ -117,6 +118,8 @@ def _attach_late_ble_interface_disposer(
             late_iface,
             fallback_address=ble_address,
         )
+        if late_generation is None:
+            late_generation = generation
         log_address = late_address or ble_address
         late_client_obj = getattr(late_iface, "client", None)
 

--- a/src/mmrelay/meshtastic/ble.py
+++ b/src/mmrelay/meshtastic/ble.py
@@ -8,11 +8,21 @@ from typing import Any, Awaitable, Callable, Coroutine, cast
 import mmrelay.meshtastic_utils as facade
 
 __all__ = [
+    "_advance_ble_generation",
     "_attach_late_ble_interface_disposer",
+    "_discard_ble_iface_generation",
     "_disconnect_ble_by_address",
     "_disconnect_ble_interface",
+    "_extract_ble_address_from_interface",
+    "_get_ble_generation",
+    "_get_ble_iface_generation",
+    "_get_ble_unresolved_teardown_generations",
     "_is_ble_discovery_error",
     "_is_ble_duplicate_connect_suppressed_error",
+    "_is_ble_generation_stale",
+    "_record_ble_teardown_timeout",
+    "_register_ble_iface_generation",
+    "_resolve_ble_teardown_timeout",
     "_reset_ble_connection_gate_state",
     "_sanitize_ble_address",
     "_scan_for_ble_address",
@@ -103,20 +113,36 @@ def _attach_late_ble_interface_disposer(
         if active_iface is late_iface:
             return
 
+        late_address, late_generation = facade._get_ble_iface_generation(
+            late_iface,
+            fallback_address=ble_address,
+        )
+        log_address = late_address or ble_address
+
         facade.logger.warning(
-            "Cleaning up late BLE interface completion for %s (%s)",
-            ble_address,
+            "Cleaning up late BLE interface completion for %s (%s) "
+            "(generation=%s iface_id=%s client_id=%s)",
+            log_address,
             reason,
+            late_generation,
+            id(late_iface),
+            (
+                id(getattr(late_iface, "client", None))
+                if getattr(late_iface, "client", None) is not None
+                else None
+            ),
         )
         try:
             facade._disconnect_ble_interface(
                 late_iface,
                 reason=f"late completion after {reason}",
+                ble_address=late_address,
+                generation=late_generation,
             )
         except Exception:  # noqa: BLE001 - cleanup must not propagate
             facade.logger.debug(
                 "Late BLE interface cleanup failed for %s (%s)",
-                ble_address,
+                log_address,
                 reason,
                 exc_info=True,
             )
@@ -278,6 +304,190 @@ def _sanitize_ble_address(address: str) -> str:
     if not address:
         return address
     return address.replace("-", "").replace("_", "").replace(":", "").lower()
+
+
+def _extract_ble_address_from_interface(iface: Any) -> str | None:
+    """Best-effort extraction of a BLE address from an interface/client shape."""
+    if iface is None:
+        return None
+
+    candidates: list[str | None] = []
+    iface_address = getattr(iface, "address", None)
+    if isinstance(iface_address, str):
+        candidates.append(iface_address)
+
+    client_obj = getattr(iface, "client", None)
+    if client_obj is not None:
+        client_address = getattr(client_obj, "address", None)
+        if isinstance(client_address, str):
+            candidates.append(client_address)
+        bleak_client = getattr(client_obj, "bleak_client", None)
+        if bleak_client is not None:
+            bleak_address = getattr(bleak_client, "address", None)
+            if isinstance(bleak_address, str):
+                candidates.append(bleak_address)
+
+    for candidate in candidates:
+        sanitized = _sanitize_ble_address(candidate or "")
+        if sanitized:
+            return sanitized
+    return None
+
+
+def _advance_ble_generation(ble_address: str, *, transition: str) -> int:
+    """Increment and return the lifecycle generation for a BLE address."""
+    address_key = _sanitize_ble_address(ble_address)
+    if not address_key:
+        return 0
+
+    with facade._ble_lifecycle_lock:
+        generation = facade._ble_generation_by_address.get(address_key, 0) + 1
+        facade._ble_generation_by_address[address_key] = generation
+
+    facade.logger.debug(
+        "Advanced BLE lifecycle generation for %s to %s (%s)",
+        ble_address,
+        generation,
+        transition,
+    )
+    return generation
+
+
+def _get_ble_generation(ble_address: str) -> int:
+    """Return the current lifecycle generation for a BLE address."""
+    address_key = _sanitize_ble_address(ble_address)
+    if not address_key:
+        return 0
+    with facade._ble_lifecycle_lock:
+        return facade._ble_generation_by_address.get(address_key, 0)
+
+
+def _is_ble_generation_stale(ble_address: str, generation: int) -> bool:
+    """Return whether a generation token is stale for a BLE address."""
+    address_key = _sanitize_ble_address(ble_address)
+    if not address_key:
+        return False
+    with facade._ble_lifecycle_lock:
+        current_generation = facade._ble_generation_by_address.get(address_key, 0)
+    return current_generation != generation
+
+
+def _register_ble_iface_generation(
+    iface: Any,
+    ble_address: str,
+    generation: int,
+) -> None:
+    """Associate an interface object identity with BLE address/generation ownership."""
+    if iface is None:
+        return
+    address_key = _sanitize_ble_address(ble_address)
+    if not address_key or generation <= 0:
+        return
+    with facade._ble_lifecycle_lock:
+        facade._ble_iface_generation_by_id[id(iface)] = (address_key, generation)
+
+
+def _get_ble_iface_generation(
+    iface: Any,
+    *,
+    fallback_address: str | None = None,
+) -> tuple[str | None, int | None]:
+    """
+    Return the best-known (address, generation) ownership metadata for an interface.
+    """
+    iface_id = id(iface) if iface is not None else None
+    fallback_key = _sanitize_ble_address(fallback_address or "")
+
+    with facade._ble_lifecycle_lock:
+        if iface_id is not None:
+            mapped = facade._ble_iface_generation_by_id.get(iface_id)
+            if mapped is not None:
+                return mapped
+        if fallback_key:
+            return fallback_key, facade._ble_generation_by_address.get(fallback_key)
+
+    extracted = _extract_ble_address_from_interface(iface)
+    if not extracted:
+        return (fallback_key or None), None
+
+    with facade._ble_lifecycle_lock:
+        return extracted, facade._ble_generation_by_address.get(extracted)
+
+
+def _discard_ble_iface_generation(iface: Any) -> tuple[str | None, int | None]:
+    """Drop interface ownership metadata once that interface is no longer active."""
+    if iface is None:
+        return None, None
+    with facade._ble_lifecycle_lock:
+        res = facade._ble_iface_generation_by_id.pop(id(iface), None)
+    if res is None:
+        return None, None
+    return res
+
+
+def _record_ble_teardown_timeout(ble_address: str, generation: int) -> int:
+    """Record a timed-out teardown worker for address/generation ownership."""
+    address_key = _sanitize_ble_address(ble_address)
+    if not address_key or generation <= 0:
+        return 0
+    with facade._ble_lifecycle_lock:
+        key = (address_key, generation)
+        count = facade._ble_teardown_unresolved_by_generation.get(key, 0) + 1
+        facade._ble_teardown_unresolved_by_generation[key] = count
+    return count
+
+
+def _resolve_ble_teardown_timeout(
+    ble_address: str,
+    generation: int,
+) -> tuple[int, bool]:
+    """
+    Resolve one timed-out teardown worker and report remaining unresolved workers.
+    """
+    address_key = _sanitize_ble_address(ble_address)
+    if not address_key or generation <= 0:
+        return 0, False
+
+    remaining_for_address = 0
+    with facade._ble_lifecycle_lock:
+        key = (address_key, generation)
+        previous = facade._ble_teardown_unresolved_by_generation.get(key, 0)
+        if previous <= 1:
+            facade._ble_teardown_unresolved_by_generation.pop(key, None)
+        else:
+            facade._ble_teardown_unresolved_by_generation[key] = previous - 1
+
+        current_generation = facade._ble_generation_by_address.get(address_key, 0)
+        stale_generation = current_generation != generation
+
+        for (
+            entry_address,
+            _,
+        ), count in facade._ble_teardown_unresolved_by_generation.items():
+            if entry_address == address_key:
+                remaining_for_address += count
+
+    return remaining_for_address, stale_generation
+
+
+def _get_ble_unresolved_teardown_generations(
+    ble_address: str,
+) -> list[tuple[int, int]]:
+    """Return unresolved teardown worker counts as (generation, count)."""
+    address_key = _sanitize_ble_address(ble_address)
+    if not address_key:
+        return []
+    with facade._ble_lifecycle_lock:
+        pending = [
+            (generation, count)
+            for (
+                entry_address,
+                generation,
+            ), count in facade._ble_teardown_unresolved_by_generation.items()
+            if entry_address == address_key and count > 0
+        ]
+    pending.sort(key=lambda item: item[0])
+    return pending
 
 
 def _validate_ble_connection_address(interface: Any, expected_address: str) -> bool:
@@ -593,7 +803,13 @@ def _disconnect_ble_by_address(address: str) -> None:
         )
 
 
-def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
+def _disconnect_ble_interface(
+    iface: Any,
+    reason: str = "disconnect",
+    *,
+    ble_address: str | None = None,
+    generation: int | None = None,
+) -> None:
     """
     Tear down a BLE interface and release its underlying Bluetooth resources.
 
@@ -606,6 +822,27 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
     """
     if iface is None:
         return
+
+    iface_id = id(iface)
+    resolved_address, mapped_generation = facade._get_ble_iface_generation(
+        iface,
+        fallback_address=ble_address,
+    )
+    if generation is None:
+        generation = mapped_generation
+    if generation is None and resolved_address is not None:
+        generation = facade._get_ble_generation(resolved_address)
+
+    client_obj = getattr(iface, "client", None)
+    client_id = id(client_obj) if client_obj is not None else None
+    facade.logger.debug(
+        "Starting BLE teardown reason=%s address=%s generation=%s iface_id=%s client_id=%s",
+        reason,
+        resolved_address,
+        generation,
+        iface_id,
+        client_id,
+    )
 
     # Pre-disconnect delay to allow pending notifications to complete
     # This helps prevent "Unexpected EOF on notification file handle" errors
@@ -656,6 +893,10 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
                             timeout=3.0,
                             label=f"ble-interface-disconnect-{reason}",
                             timeout_log_level=timeout_log_level,
+                            ble_address=resolved_address,
+                            ble_generation=generation,
+                            iface_id=iface_id,
+                            client_id=client_id,
                         )
                     # Give the adapter time to complete the disconnect
                     facade.time.sleep(1.0)
@@ -732,6 +973,12 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
                             timeout=2.0,
                             label=f"ble-client-disconnect-{reason}",
                             timeout_log_level=timeout_log_level,
+                            ble_address=resolved_address,
+                            ble_generation=generation,
+                            iface_id=iface_id,
+                            client_id=(
+                                id(client_obj) if client_obj is not None else client_id
+                            ),
                         )
                     facade.time.sleep(1.0)
                     facade.logger.debug(
@@ -774,11 +1021,20 @@ def _disconnect_ble_interface(iface: Any, reason: str = "disconnect") -> None:
                 timeout=5.0,
                 label=f"ble-interface-close-{reason}",
                 timeout_log_level=timeout_log_level,
+                ble_address=resolved_address,
+                ble_generation=generation,
+                iface_id=iface_id,
+                client_id=(
+                    id(getattr(iface, "client", None))
+                    if getattr(iface, "client", None) is not None
+                    else client_id
+                ),
             )
     except TimeoutError as exc:
         facade.logger.debug("BLE interface %s timed out: %s", reason, exc)
     except Exception as e:  # noqa: BLE001 - cleanup must not block shutdown
         facade.logger.debug(f"Error during BLE interface {reason}", exc_info=e)
     finally:
+        facade._discard_ble_iface_generation(iface)
         # Small delay to ensure the adapter has fully released the connection
         facade.time.sleep(0.5)

--- a/src/mmrelay/meshtastic/ble.py
+++ b/src/mmrelay/meshtastic/ble.py
@@ -116,10 +116,11 @@ def _attach_late_ble_interface_disposer(
 
         late_address, late_generation = facade._get_ble_iface_generation(
             late_iface,
-            fallback_address=ble_address,
         )
         if late_generation is None:
             late_generation = generation
+        if late_address is None:
+            late_address = facade._extract_ble_address_from_interface(late_iface)
         log_address = late_address or ble_address
         late_client_obj = getattr(late_iface, "client", None)
 

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1056,6 +1056,11 @@ def _connect_meshtastic_impl(
                                 connect_generation,
                                 unresolved_teardown,
                             )
+                            # This barrier can trigger after publishing the interface
+                            # singleton but before connect(). Hand ownership to the
+                            # shared rollback path so teardown always clears the
+                            # published interface and generation registration.
+                            client = iface
                             raise TimeoutError(
                                 f"BLE teardown still unresolved for {ble_address}; waiting before connect()."
                             )

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1064,14 +1064,15 @@ def _connect_meshtastic_impl(
                             raise TimeoutError(
                                 f"BLE teardown still unresolved for {ble_address}; waiting before connect()."
                             )
+                        iface_client_obj = getattr(iface, "client", None)
                         facade.logger.info(
                             "Initiating BLE connection to %s (sequential mode, generation=%s, iface_id=%s, client_id=%s)",
                             ble_address,
                             connect_generation,
                             id(iface),
                             (
-                                id(getattr(iface, "client", None))
-                                if getattr(iface, "client", None) is not None
+                                id(iface_client_obj)
+                                if iface_client_obj is not None
                                 else None
                             ),
                         )
@@ -1145,14 +1146,15 @@ def _connect_meshtastic_impl(
                                 connect_future,
                                 timeout_seconds=facade.BLE_CONNECT_TIMEOUT_SECS,
                             )
+                            connected_client_obj = getattr(iface, "client", None)
                             facade.logger.info(
                                 "BLE connection established to %s (generation=%s iface_id=%s client_id=%s)",
                                 ble_address,
                                 connect_generation,
                                 id(iface),
                                 (
-                                    id(getattr(iface, "client", None))
-                                    if getattr(iface, "client", None) is not None
+                                    id(connected_client_obj)
+                                    if connected_client_obj is not None
                                     else None
                                 ),
                             )

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -965,6 +965,7 @@ def _connect_meshtastic_impl(
                                             future,
                                             ble_address,
                                             reason="interface creation shutdown cancellation",
+                                            generation=connect_generation,
                                         )
                                     facade.meshtastic_iface = None
                                 raise
@@ -1033,6 +1034,7 @@ def _connect_meshtastic_impl(
                             late_creation_disposer_future,
                             ble_address,
                             reason="interface creation timeout",
+                            generation=connect_generation,
                         )
 
                     # Connect outside singleton-creation lock to avoid blocking other threads.
@@ -1187,6 +1189,7 @@ def _connect_meshtastic_impl(
                                         ble_address,
                                         reason="connect shutdown cancellation",
                                         fallback_iface=shutdown_iface,
+                                        generation=connect_generation,
                                     )
                                 iface = None
                                 facade.meshtastic_iface = None
@@ -1229,6 +1232,7 @@ def _connect_meshtastic_impl(
                                         ble_address,
                                         reason="connect timeout",
                                         fallback_iface=timed_out_iface,
+                                        generation=connect_generation,
                                     )
                                     timeout_count = facade._record_ble_timeout(
                                         ble_address

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -591,6 +591,7 @@ def _connect_meshtastic_impl(
     ):
         # Initialize before try block to avoid unbound variable errors
         ble_address: str | None = None
+        connect_generation: int | None = None
         supports_auto_reconnect = False
         fallback_to_compat_mode = False
         ble_connect_timeout_logged_for_attempt = False
@@ -628,7 +629,16 @@ def _connect_meshtastic_impl(
                 # BLE connection
                 ble_address = facade.config["meshtastic"].get(CONFIG_KEY_BLE_ADDRESS)
                 if ble_address:
+                    connect_generation = facade._advance_ble_generation(
+                        ble_address,
+                        transition="connect-attempt",
+                    )
                     facade.logger.info(f"Connecting to BLE address {ble_address}")
+                    facade.logger.debug(
+                        "BLE connect attempt generation=%s address=%s",
+                        connect_generation,
+                        ble_address,
+                    )
 
                     iface = None
                     supports_auto_reconnect = False
@@ -655,6 +665,24 @@ def _connect_meshtastic_impl(
                             facade.meshtastic_iface = None
 
                         if facade.meshtastic_iface is None:
+                            unresolved_teardown = (
+                                facade._get_ble_unresolved_teardown_generations(
+                                    ble_address
+                                )
+                            )
+                            if unresolved_teardown:
+                                facade.logger.warning(
+                                    "Blocking BLE interface creation for %s generation=%s "
+                                    "due to unresolved teardown workers=%s",
+                                    ble_address,
+                                    connect_generation,
+                                    unresolved_teardown,
+                                )
+                                raise TimeoutError(
+                                    "BLE teardown still unresolved for "
+                                    f"{ble_address}; waiting before new interface creation."
+                                )
+
                             # Disconnect any stale BlueZ connection before creating new interface
                             facade._disconnect_ble_by_address(ble_address)
 
@@ -839,8 +867,34 @@ def _connect_meshtastic_impl(
                                         raise RuntimeError(
                                             "BLE interface creation returned no interface"
                                         )
+                                    if connect_generation is not None:
+                                        facade._register_ble_iface_generation(
+                                            facade.meshtastic_iface,
+                                            ble_address,
+                                            connect_generation,
+                                        )
                                     facade.logger.debug(
-                                        f"BLE interface created successfully for {ble_address}"
+                                        "BLE interface created successfully for %s "
+                                        "(generation=%s iface_id=%s client_id=%s)",
+                                        ble_address,
+                                        connect_generation,
+                                        id(facade.meshtastic_iface),
+                                        (
+                                            id(
+                                                getattr(
+                                                    facade.meshtastic_iface,
+                                                    "client",
+                                                    None,
+                                                )
+                                            )
+                                            if getattr(
+                                                facade.meshtastic_iface,
+                                                "client",
+                                                None,
+                                            )
+                                            is not None
+                                            else None
+                                        ),
                                     )
                                     if not fallback_to_compat_mode and hasattr(
                                         facade.meshtastic_iface, "auto_reconnect"
@@ -963,6 +1017,16 @@ def _connect_meshtastic_impl(
                                 )
 
                         iface = facade.meshtastic_iface
+                        if (
+                            iface is not None
+                            and connect_generation is not None
+                            and ble_address is not None
+                        ):
+                            facade._register_ble_iface_generation(
+                                iface,
+                                ble_address,
+                                connect_generation,
+                            )
 
                     if late_creation_disposer_future is not None:
                         facade._attach_late_ble_interface_disposer(
@@ -979,8 +1043,32 @@ def _connect_meshtastic_impl(
                         and supports_auto_reconnect
                         and hasattr(iface, "connect")
                     ):
+                        unresolved_teardown = (
+                            facade._get_ble_unresolved_teardown_generations(ble_address)
+                            if ble_address is not None
+                            else []
+                        )
+                        if unresolved_teardown:
+                            facade.logger.warning(
+                                "Blocking BLE connect() for %s generation=%s due to "
+                                "unresolved teardown workers=%s",
+                                ble_address,
+                                connect_generation,
+                                unresolved_teardown,
+                            )
+                            raise TimeoutError(
+                                f"BLE teardown still unresolved for {ble_address}; waiting before connect()."
+                            )
                         facade.logger.info(
-                            f"Initiating BLE connection to {ble_address} (sequential mode)"
+                            "Initiating BLE connection to %s (sequential mode, generation=%s, iface_id=%s, client_id=%s)",
+                            ble_address,
+                            connect_generation,
+                            id(iface),
+                            (
+                                id(getattr(iface, "client", None))
+                                if getattr(iface, "client", None) is not None
+                                else None
+                            ),
                         )
 
                         # Add timeout protection for connect() call to prevent indefinite hangs
@@ -1053,7 +1141,15 @@ def _connect_meshtastic_impl(
                                 timeout_seconds=facade.BLE_CONNECT_TIMEOUT_SECS,
                             )
                             facade.logger.info(
-                                f"BLE connection established to {ble_address}"
+                                "BLE connection established to %s (generation=%s iface_id=%s client_id=%s)",
+                                ble_address,
+                                connect_generation,
+                                id(iface),
+                                (
+                                    id(getattr(iface, "client", None))
+                                    if getattr(iface, "client", None) is not None
+                                    else None
+                                ),
                             )
                             facade.reset_executor_degraded_state(
                                 ble_address=ble_address

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -937,7 +937,13 @@ def _connect_meshtastic_impl(
                                             ble_address,
                                             reason="interface creation timeout",
                                         )
-                                        late_creation_disposer_future = future
+                                        facade._attach_late_ble_interface_disposer(
+                                            future,
+                                            ble_address,
+                                            reason="interface creation timeout",
+                                            generation=connect_generation,
+                                        )
+                                        late_creation_disposer_future = None
                                         timeout_count = facade._record_ble_timeout(
                                             ble_address
                                         )

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -602,7 +602,7 @@ def _connect_meshtastic_impl(
         signal_startup_drain_complete_for_this_connect = False
         client_assigned_for_this_connect = False
 
-        client = None
+        client: Any | None = None
         try:
             if connection_type == CONNECTION_TYPE_SERIAL:
                 # Serial connection

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -92,6 +92,11 @@ def _tear_down_meshtastic_client_for_disconnect(detection_source: str) -> None:
                 ble_address,
                 transition=f"disconnect:{detection_source}",
             )
+            facade._register_ble_iface_generation(
+                facade.meshtastic_iface,
+                ble_address,
+                ble_generation,
+            )
         facade.logger.debug("Disconnecting BLE interface due to connection loss")
         facade._disconnect_ble_interface(
             facade.meshtastic_iface,

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -83,10 +83,21 @@ def _tear_down_meshtastic_client_for_disconnect(detection_source: str) -> None:
         return
 
     if facade.meshtastic_client is facade.meshtastic_iface:
+        ble_address = facade._extract_ble_address_from_interface(
+            facade.meshtastic_iface
+        )
+        ble_generation: int | None = None
+        if ble_address is not None:
+            ble_generation = facade._advance_ble_generation(
+                ble_address,
+                transition=f"disconnect:{detection_source}",
+            )
         facade.logger.debug("Disconnecting BLE interface due to connection loss")
         facade._disconnect_ble_interface(
             facade.meshtastic_iface,
             reason=f"connection loss: {detection_source}",
+            ble_address=ble_address,
+            generation=ble_generation,
         )
         facade.meshtastic_iface = None
     else:

--- a/src/mmrelay/meshtastic/executors.py
+++ b/src/mmrelay/meshtastic/executors.py
@@ -50,6 +50,10 @@ def _shutdown_shared_executors() -> None:
             facade._ble_timeout_counts.clear()
             facade._ble_executor_orphaned_workers_by_address.clear()
         facade._ble_executor_degraded_addresses.clear()
+        with facade._ble_lifecycle_lock:
+            facade._ble_generation_by_address.clear()
+            facade._ble_iface_generation_by_id.clear()
+            facade._ble_teardown_unresolved_by_generation.clear()
 
         executor = facade._ble_executor
         facade._ble_executor = None

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -281,6 +281,11 @@ _ble_future_timeout_secs: float | None = None
 _ble_timeout_counts: dict[str, int] = {}
 _ble_executor_orphaned_workers_by_address: dict[str, int] = {}
 _ble_timeout_lock = threading.Lock()
+# BLE lifecycle ownership state (per sanitized BLE address).
+_ble_lifecycle_lock = threading.Lock()
+_ble_generation_by_address: dict[str, int] = {}
+_ble_iface_generation_by_id: dict[int, tuple[str, int]] = {}
+_ble_teardown_unresolved_by_generation: dict[tuple[str, int], int] = {}
 _ble_future_watchdog_secs = BLE_FUTURE_WATCHDOG_SECS
 _ble_timeout_reset_threshold = BLE_TIMEOUT_RESET_THRESHOLD
 _ble_scan_timeout_secs = BLE_SCAN_TIMEOUT_SECS
@@ -324,11 +329,21 @@ from mmrelay.meshtastic.async_utils import (
     _wait_for_result,
 )
 from mmrelay.meshtastic.ble import (
+    _advance_ble_generation,
     _attach_late_ble_interface_disposer,
+    _discard_ble_iface_generation,
     _disconnect_ble_by_address,
     _disconnect_ble_interface,
+    _extract_ble_address_from_interface,
+    _get_ble_generation,
+    _get_ble_iface_generation,
+    _get_ble_unresolved_teardown_generations,
     _is_ble_discovery_error,
     _is_ble_duplicate_connect_suppressed_error,
+    _is_ble_generation_stale,
+    _record_ble_teardown_timeout,
+    _register_ble_iface_generation,
+    _resolve_ble_teardown_timeout,
     _reset_ble_connection_gate_state,
     _sanitize_ble_address,
     _scan_for_ble_address,

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -982,20 +982,20 @@ class BasePlugin(ABC):
             parsed = self.get_matching_matrix_command_with_args(event)
             if parsed is None:
                 return None
-            parsed_command, parsed_args = parsed
-            if parsed_command.casefold() != command.casefold():
+            matched_command, parsed_args = parsed
+            if matched_command.casefold() != command.casefold():
                 return None
             return parsed_args
 
         if not isinstance(text, str):
             return None
 
-        parsed = _parse_matrix_message_command(
+        parsed_message = _parse_matrix_message_command(
             text,
             (command,),
             require_mention=self.get_require_bot_mention(),
         )
-        return parsed.args if parsed is not None else None
+        return parsed_message.args if parsed_message is not None else None
 
     def parse_mesh_bang_command(
         self, text: str, commands: Iterable[str], *, allow_anywhere: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1154,6 +1154,15 @@ def reset_meshtastic_globals():
         "_ble_executor_orphaned_workers_by_address": dict(
             getattr(mu, "_ble_executor_orphaned_workers_by_address", None) or {}
         ),
+        "_ble_generation_by_address": dict(
+            getattr(mu, "_ble_generation_by_address", None) or {}
+        ),
+        "_ble_iface_generation_by_id": dict(
+            getattr(mu, "_ble_iface_generation_by_id", None) or {}
+        ),
+        "_ble_teardown_unresolved_by_generation": dict(
+            getattr(mu, "_ble_teardown_unresolved_by_generation", None) or {}
+        ),
         "_health_probe_request_deadlines": dict(
             getattr(mu, "_health_probe_request_deadlines", {})
         ),
@@ -1223,6 +1232,9 @@ def reset_meshtastic_globals():
     cleanup_ble_future_state(mu)
     mu._ble_timeout_counts = {}
     mu._ble_executor_orphaned_workers_by_address = {}
+    mu._ble_generation_by_address = {}
+    mu._ble_iface_generation_by_id = {}
+    mu._ble_teardown_unresolved_by_generation = {}
     mu._metadata_executor_orphaned_workers = 0
     mu._ble_executor_degraded_addresses = set()
     mu._metadata_executor_degraded = False

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -1,0 +1,1276 @@
+"""
+Tests for specific uncovered lines across ble.py, async_utils.py, events.py,
+and command_bridge.py.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import mmrelay.matrix_utils as matrix_utils
+import mmrelay.meshtastic_utils as mu
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestAttachLateBleInterfaceDisposerCleanup:
+    """Cover ble.py lines 114-143: late BLE interface disposer cleanup path."""
+
+    def test_late_iface_different_from_active_triggers_cleanup(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        late_iface = MagicMock()
+        late_iface.client = MagicMock()
+        late_iface.address = "AA:BB:CC:DD:EE:FF"
+        active_iface = MagicMock()
+
+        mu.meshtastic_iface = active_iface
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+        mock_future.result.return_value = late_iface
+
+        with patch.object(mu, "_disconnect_ble_interface") as mock_disconnect:
+            with patch.object(
+                mu, "_get_ble_iface_generation", return_value=("aabbccddeeff", 1)
+            ):
+                _attach_late_ble_interface_disposer(
+                    mock_future, "AA:BB:CC:DD:EE:FF", reason="test"
+                )
+                callback = mock_future.add_done_callback.call_args[0][0]
+                callback(mock_future)
+
+        mock_disconnect.assert_called_once()
+        mu.meshtastic_iface = None
+
+    def test_cancelled_callback_returns_early(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        mock_future = MagicMock()
+        _attach_late_ble_interface_disposer(mock_future, "AA:BB", reason="test")
+        callback = mock_future.add_done_callback.call_args[0][0]
+
+        cancelled_future = MagicMock()
+        cancelled_future.cancelled.return_value = True
+        callback(cancelled_future)
+
+    def test_active_iface_same_as_late_returns_early(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        late_iface = MagicMock()
+        late_iface.client = MagicMock()
+
+        mu.meshtastic_iface = late_iface
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+        mock_future.result.return_value = late_iface
+
+        _attach_late_ble_interface_disposer(mock_future, "AA:BB", reason="test")
+        callback = mock_future.add_done_callback.call_args[0][0]
+        callback(mock_future)
+        mu.meshtastic_iface = None
+
+    def test_late_generation_fallback_from_generation_param(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        late_iface = MagicMock()
+        late_iface.client = MagicMock()
+        late_iface.address = "AA:BB:CC"
+        active_iface = MagicMock()
+
+        mu.meshtastic_iface = active_iface
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+        mock_future.result.return_value = late_iface
+
+        with patch.object(mu, "_disconnect_ble_interface") as mock_disconnect:
+            with patch.object(
+                mu, "_get_ble_iface_generation", return_value=("aabbcc", None)
+            ):
+                _attach_late_ble_interface_disposer(
+                    mock_future,
+                    "AA:BB:CC",
+                    reason="test",
+                    generation=5,
+                )
+                callback = mock_future.add_done_callback.call_args[0][0]
+                callback(mock_future)
+
+        mock_disconnect.assert_called_once()
+        call_kwargs = mock_disconnect.call_args
+        assert call_kwargs[1]["generation"] == 5
+        mu.meshtastic_iface = None
+
+    def test_late_iface_no_disconnect_method_returns_early(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        late_iface = MagicMock(spec=["__str__"])
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+        mock_future.result.return_value = late_iface
+
+        mu.meshtastic_iface = MagicMock()
+
+        _attach_late_ble_interface_disposer(mock_future, "AA:BB", reason="test")
+        callback = mock_future.add_done_callback.call_args[0][0]
+        callback(mock_future)
+        mu.meshtastic_iface = None
+
+    def test_late_iface_exception_in_result_uses_fallback(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        fallback_iface = MagicMock()
+        fallback_iface.address = "aa:bb:cc:dd:ee:ff"
+        active_iface = MagicMock()
+
+        mu.meshtastic_iface = active_iface
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+        mock_future.result.side_effect = RuntimeError("future failed")
+
+        with patch.object(mu, "_disconnect_ble_interface") as mock_disconnect:
+            with patch.object(
+                mu, "_get_ble_iface_generation", return_value=("aabbccddeeff", 1)
+            ):
+                _attach_late_ble_interface_disposer(
+                    mock_future,
+                    "AA:BB",
+                    reason="test",
+                    fallback_iface=fallback_iface,
+                )
+                callback = mock_future.add_done_callback.call_args[0][0]
+                callback(mock_future)
+
+        mock_disconnect.assert_called_once()
+        mu.meshtastic_iface = None
+
+    def test_late_iface_result_is_none_and_no_fallback_returns_early(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+        mock_future.result.return_value = None
+
+        _attach_late_ble_interface_disposer(
+            mock_future, "AA:BB", reason="test", fallback_iface=None
+        )
+        callback = mock_future.add_done_callback.call_args[0][0]
+        callback(mock_future)
+
+    def test_disconnect_cleanup_exception_suppressed(self):
+        from mmrelay.meshtastic.ble import _attach_late_ble_interface_disposer
+
+        late_iface = MagicMock()
+        late_iface.client = MagicMock()
+        late_iface.address = "AA:BB:CC:DD:EE:FF"
+        active_iface = MagicMock()
+
+        mu.meshtastic_iface = active_iface
+
+        mock_future = MagicMock()
+        mock_future.cancelled.return_value = False
+        mock_future.result.return_value = late_iface
+
+        with patch.object(
+            mu, "_disconnect_ble_interface", side_effect=RuntimeError("cleanup boom")
+        ):
+            with patch.object(
+                mu, "_get_ble_iface_generation", return_value=("aabbccddeeff", 1)
+            ):
+                _attach_late_ble_interface_disposer(
+                    mock_future, "AA:BB:CC:DD:EE:FF", reason="test"
+                )
+                callback = mock_future.add_done_callback.call_args[0][0]
+                callback(mock_future)
+
+        mu.meshtastic_iface = None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestExtractBleAddressFromInterface:
+    """Cover ble.py lines 311-334."""
+
+    def test_none_returns_none(self):
+        from mmrelay.meshtastic.ble import _extract_ble_address_from_interface
+
+        assert _extract_ble_address_from_interface(None) is None
+
+    def test_iface_address_attribute(self):
+        from mmrelay.meshtastic.ble import _extract_ble_address_from_interface
+
+        iface = MagicMock()
+        iface.address = "AA:BB:CC:DD:EE:FF"
+        del iface.client
+        result = _extract_ble_address_from_interface(iface)
+        assert result == "aabbccddeeff"
+
+    def test_client_address_attribute(self):
+        from mmrelay.meshtastic.ble import _extract_ble_address_from_interface
+
+        iface = MagicMock()
+        iface.address = None
+        iface.client.address = "11:22:33:44:55:66"
+        del iface.client.bleak_client
+        result = _extract_ble_address_from_interface(iface)
+        assert result == "112233445566"
+
+    def test_bleak_client_address_attribute(self):
+        from mmrelay.meshtastic.ble import _extract_ble_address_from_interface
+
+        iface = MagicMock()
+        iface.address = None
+        iface.client.address = None
+        iface.client.bleak_client.address = "AA-BB-CC-DD-EE-FF"
+        result = _extract_ble_address_from_interface(iface)
+        assert result == "aabbccddeeff"
+
+    def test_no_valid_candidates_returns_none(self):
+        from mmrelay.meshtastic.ble import _extract_ble_address_from_interface
+
+        iface = MagicMock()
+        iface.address = None
+        iface.client.address = None
+        iface.client.bleak_client.address = None
+        result = _extract_ble_address_from_interface(iface)
+        assert result is None
+
+    def test_iface_address_not_string_ignored(self):
+        from mmrelay.meshtastic.ble import _extract_ble_address_from_interface
+
+        iface = MagicMock()
+        iface.address = 12345
+        del iface.client
+        result = _extract_ble_address_from_interface(iface)
+        assert result is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestAdvanceBleGeneration:
+    """Cover ble.py lines 337-353."""
+
+    def test_empty_address_returns_zero(self):
+        from mmrelay.meshtastic.ble import _advance_ble_generation
+
+        assert _advance_ble_generation("", transition="test") == 0
+
+    def test_first_generation(self):
+        from mmrelay.meshtastic.ble import _advance_ble_generation
+
+        gen = _advance_ble_generation("AA:BB:CC:DD:EE:FF", transition="connect")
+        assert gen == 1
+
+    def test_increments_existing(self):
+        from mmrelay.meshtastic.ble import _advance_ble_generation
+
+        gen1 = _advance_ble_generation("AA:BB:CC:DD:EE:FF", transition="first")
+        gen2 = _advance_ble_generation("AA:BB:CC:DD:EE:FF", transition="second")
+        assert gen2 == gen1 + 1
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetBleGeneration:
+    """Cover ble.py lines 356-362."""
+
+    def test_empty_address_returns_zero(self):
+        from mmrelay.meshtastic.ble import _get_ble_generation
+
+        assert _get_ble_generation("") == 0
+
+    def test_unknown_address_returns_zero(self):
+        from mmrelay.meshtastic.ble import _get_ble_generation
+
+        assert _get_ble_generation("FF:EE:DD:CC:BB:AA") == 0
+
+    def test_returns_current_generation(self):
+        from mmrelay.meshtastic.ble import _advance_ble_generation, _get_ble_generation
+
+        addr = "AA:BB:CC:DD:EE:FF"
+        _advance_ble_generation(addr, transition="test")
+        assert _get_ble_generation(addr) == 1
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestIsBleGenerationStale:
+    """Cover ble.py lines 365-372."""
+
+    def test_empty_address_returns_false(self):
+        from mmrelay.meshtastic.ble import _is_ble_generation_stale
+
+        assert _is_ble_generation_stale("", 1) is False
+
+    def test_matching_generation_not_stale(self):
+        from mmrelay.meshtastic.ble import (
+            _advance_ble_generation,
+            _is_ble_generation_stale,
+        )
+
+        addr = "AA:BB:CC:DD:EE:FF"
+        gen = _advance_ble_generation(addr, transition="test")
+        assert _is_ble_generation_stale(addr, gen) is False
+
+    def test_old_generation_is_stale(self):
+        from mmrelay.meshtastic.ble import (
+            _advance_ble_generation,
+            _is_ble_generation_stale,
+        )
+
+        addr = "AA:BB:CC:DD:EE:FF"
+        gen1 = _advance_ble_generation(addr, transition="first")
+        _advance_ble_generation(addr, transition="second")
+        assert _is_ble_generation_stale(addr, gen1) is True
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRegisterBleIfaceGeneration:
+    """Cover ble.py lines 375-387."""
+
+    def test_none_iface_noop(self):
+        from mmrelay.meshtastic.ble import _register_ble_iface_generation
+
+        _register_ble_iface_generation(None, "AA:BB", 1)
+        assert mu._ble_iface_generation_by_id == {}
+
+    def test_empty_address_noop(self):
+        from mmrelay.meshtastic.ble import _register_ble_iface_generation
+
+        iface = MagicMock()
+        _register_ble_iface_generation(iface, "", 1)
+        assert mu._ble_iface_generation_by_id == {}
+
+    def test_zero_generation_noop(self):
+        from mmrelay.meshtastic.ble import _register_ble_iface_generation
+
+        iface = MagicMock()
+        _register_ble_iface_generation(iface, "AA:BB", 0)
+        assert mu._ble_iface_generation_by_id == {}
+
+    def test_negative_generation_noop(self):
+        from mmrelay.meshtastic.ble import _register_ble_iface_generation
+
+        iface = MagicMock()
+        _register_ble_iface_generation(iface, "AA:BB", -1)
+        assert mu._ble_iface_generation_by_id == {}
+
+    def test_valid_registration(self):
+        from mmrelay.meshtastic.ble import _register_ble_iface_generation
+
+        iface = MagicMock()
+        _register_ble_iface_generation(iface, "AA:BB:CC", 1)
+        assert id(iface) in mu._ble_iface_generation_by_id
+        assert mu._ble_iface_generation_by_id[id(iface)] == ("aabbcc", 1)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetBleIfaceGeneration:
+    """Cover ble.py lines 402-414."""
+
+    def test_none_iface_with_fallback(self):
+        from mmrelay.meshtastic.ble import _get_ble_iface_generation
+
+        addr, gen = _get_ble_iface_generation(None, fallback_address="AA:BB")
+        assert addr == "aabb"
+        assert gen is None
+
+    def test_mapped_iface_returns_registered(self):
+        from mmrelay.meshtastic.ble import (
+            _get_ble_iface_generation,
+            _register_ble_iface_generation,
+        )
+
+        iface = MagicMock()
+        _register_ble_iface_generation(iface, "AA:BB:CC", 3)
+        addr, gen = _get_ble_iface_generation(iface)
+        assert addr == "aabbcc"
+        assert gen == 3
+
+    def test_fallback_key_with_existing_generation(self):
+        from mmrelay.meshtastic.ble import (
+            _advance_ble_generation,
+            _get_ble_iface_generation,
+        )
+
+        addr = "AA:BB:CC"
+        gen = _advance_ble_generation(addr, transition="test")
+        iface = MagicMock()
+        addr_out, gen_out = _get_ble_iface_generation(iface, fallback_address=addr)
+        assert addr_out == "aabbcc"
+        assert gen_out == gen
+
+    def test_no_fallback_extracts_from_iface(self):
+        from mmrelay.meshtastic.ble import (
+            _advance_ble_generation,
+            _get_ble_iface_generation,
+        )
+
+        iface = MagicMock()
+        iface.address = "AA:BB:CC:DD:EE:FF"
+        del iface.client
+
+        _advance_ble_generation("AA:BB:CC:DD:EE:FF", transition="test")
+
+        addr_out, gen_out = _get_ble_iface_generation(iface)
+        assert addr_out == "aabbccddeeff"
+        assert gen_out is not None
+
+    def test_no_match_returns_none_generation(self):
+        from mmrelay.meshtastic.ble import _get_ble_iface_generation
+
+        iface = MagicMock()
+        iface.address = None
+        del iface.client
+        addr_out, gen_out = _get_ble_iface_generation(iface)
+        assert gen_out is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDiscardBleIfaceGeneration:
+    """Cover ble.py lines 417-425."""
+
+    def test_none_iface(self):
+        from mmrelay.meshtastic.ble import _discard_ble_iface_generation
+
+        addr, gen = _discard_ble_iface_generation(None)
+        assert addr is None
+        assert gen is None
+
+    def test_unregistered_iface(self):
+        from mmrelay.meshtastic.ble import _discard_ble_iface_generation
+
+        iface = MagicMock()
+        addr, gen = _discard_ble_iface_generation(iface)
+        assert addr is None
+        assert gen is None
+
+    def test_registered_iface(self):
+        from mmrelay.meshtastic.ble import (
+            _discard_ble_iface_generation,
+            _register_ble_iface_generation,
+        )
+
+        iface = MagicMock()
+        _register_ble_iface_generation(iface, "AA:BB", 2)
+        addr, gen = _discard_ble_iface_generation(iface)
+        assert addr == "aabb"
+        assert gen == 2
+        assert id(iface) not in mu._ble_iface_generation_by_id
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRecordBleTeardownTimeout:
+    """Cover ble.py lines 428-437."""
+
+    def test_empty_address_returns_zero(self):
+        from mmrelay.meshtastic.ble import _record_ble_teardown_timeout
+
+        assert _record_ble_teardown_timeout("", 1) == 0
+
+    def test_zero_generation_returns_zero(self):
+        from mmrelay.meshtastic.ble import _record_ble_teardown_timeout
+
+        assert _record_ble_teardown_timeout("AA:BB", 0) == 0
+
+    def test_records_and_increments(self):
+        from mmrelay.meshtastic.ble import _record_ble_teardown_timeout
+
+        count1 = _record_ble_teardown_timeout("AA:BB:CC", 1)
+        count2 = _record_ble_teardown_timeout("AA:BB:CC", 1)
+        assert count1 == 1
+        assert count2 == 2
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestResolveBleTeardownTimeout:
+    """Cover ble.py lines 440-470."""
+
+    def test_empty_address(self):
+        from mmrelay.meshtastic.ble import _resolve_ble_teardown_timeout
+
+        remaining, stale = _resolve_ble_teardown_timeout("", 1)
+        assert remaining == 0
+        assert stale is False
+
+    def test_zero_generation(self):
+        from mmrelay.meshtastic.ble import _resolve_ble_teardown_timeout
+
+        remaining, stale = _resolve_ble_teardown_timeout("AA:BB", 0)
+        assert remaining == 0
+        assert stale is False
+
+    def test_resolve_single_entry(self):
+        from mmrelay.meshtastic.ble import (
+            _advance_ble_generation,
+            _record_ble_teardown_timeout,
+            _resolve_ble_teardown_timeout,
+        )
+
+        gen = _advance_ble_generation("AA:BB", transition="test")
+        _record_ble_teardown_timeout("AA:BB", gen)
+        remaining, stale = _resolve_ble_teardown_timeout("AA:BB", gen)
+        assert remaining == 0
+        assert stale is False
+
+    def test_resolve_decrements(self):
+        from mmrelay.meshtastic.ble import (
+            _advance_ble_generation,
+            _record_ble_teardown_timeout,
+            _resolve_ble_teardown_timeout,
+        )
+
+        gen = _advance_ble_generation("AA:BB", transition="test")
+        _record_ble_teardown_timeout("AA:BB", gen)
+        _record_ble_teardown_timeout("AA:BB", gen)
+        remaining, stale = _resolve_ble_teardown_timeout("AA:BB", gen)
+        assert remaining == 1
+        assert stale is False
+
+    def test_stale_generation(self):
+        from mmrelay.meshtastic.ble import (
+            _advance_ble_generation,
+            _record_ble_teardown_timeout,
+            _resolve_ble_teardown_timeout,
+        )
+
+        old_gen = _advance_ble_generation("AA:BB", transition="old")
+        _record_ble_teardown_timeout("AA:BB", old_gen)
+        _advance_ble_generation("AA:BB", transition="new")
+        remaining, stale = _resolve_ble_teardown_timeout("AA:BB", old_gen)
+        assert stale is True
+
+    def test_resolve_counts_other_generations_for_same_address(self):
+        from mmrelay.meshtastic.ble import (
+            _record_ble_teardown_timeout,
+            _resolve_ble_teardown_timeout,
+        )
+
+        _record_ble_teardown_timeout("AA:BB", 1)
+        _record_ble_teardown_timeout("AA:BB", 2)
+        remaining, stale = _resolve_ble_teardown_timeout("AA:BB", 1)
+        assert remaining == 1
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestGetBleUnresolvedTeardownGenerations:
+    """Cover ble.py lines 473-490."""
+
+    def test_empty_address(self):
+        from mmrelay.meshtastic.ble import _get_ble_unresolved_teardown_generations
+
+        assert _get_ble_unresolved_teardown_generations("") == []
+
+    def test_no_entries(self):
+        from mmrelay.meshtastic.ble import _get_ble_unresolved_teardown_generations
+
+        assert _get_ble_unresolved_teardown_generations("AA:BB") == []
+
+    def test_returns_sorted_entries(self):
+        from mmrelay.meshtastic.ble import (
+            _get_ble_unresolved_teardown_generations,
+            _record_ble_teardown_timeout,
+        )
+
+        _record_ble_teardown_timeout("AA:BB", 2)
+        _record_ble_teardown_timeout("AA:BB", 1)
+        result = _get_ble_unresolved_teardown_generations("AA:BB")
+        assert result == [(1, 1), (2, 1)]
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleInterfaceGenerationResolution:
+    """Cover ble.py lines 831-834: generation fallback resolution."""
+
+    def test_generation_none_falls_back_to_mapped(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client = None
+        iface.close.return_value = None
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=("aabb", 5)),
+            patch.object(mu.time, "sleep"),
+        ):
+            _disconnect_ble_interface(iface, reason="test", ble_address="AA:BB")
+
+    def test_generation_none_falls_back_to_get_ble_generation(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client = None
+        iface.close.return_value = None
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=("aabb", None)),
+            patch.object(mu, "_get_ble_generation", return_value=7),
+            patch.object(mu.time, "sleep"),
+        ):
+            _disconnect_ble_interface(iface, reason="test", ble_address="AA:BB")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleInterfaceCloseSyncAwaitable:
+    """Cover ble.py lines 1016-1017: _close_sync awaitable path."""
+
+    def test_close_returns_awaitable(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client = None
+
+        async def async_close():
+            return None
+
+        iface.close = async_close
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep"),
+            patch.object(mu, "_run_blocking_with_timeout"),
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleInterfaceTimeoutError:
+    """Cover ble.py line 1033: TimeoutError handler."""
+
+    def test_timeout_error_in_teardown(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.side_effect = TimeoutError("disconnect timed out")
+        iface.client = None
+        iface.close.return_value = None
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep"),
+            patch.object(
+                mu, "_run_blocking_with_timeout", side_effect=TimeoutError("block")
+            ),
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRunBlockingResolveTeardownOnce:
+    """Cover async_utils.py lines 348-349, 356-357, 364-365."""
+
+    def test_resolve_skipped_when_no_recorded_event(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        gen = mu._advance_ble_generation(ble_address, transition="test")
+
+        with pytest.raises(TimeoutError):
+            _run_blocking_with_timeout(
+                lambda: time.sleep(10),
+                timeout=0.05,
+                label="test-no-recorded",
+                ble_address=ble_address,
+                ble_generation=gen,
+            )
+
+    def test_resolve_skipped_when_resolve_not_callable(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "11:22:33:44:55:66"
+        gen = mu._advance_ble_generation(ble_address, transition="test")
+
+        release = threading.Event()
+        done = threading.Event()
+
+        def _block():
+            release.wait(timeout=2.0)
+            done.set()
+
+        with (
+            patch.object(mu, "_resolve_ble_teardown_timeout", None),
+            pytest.raises(TimeoutError),
+        ):
+            _run_blocking_with_timeout(
+                _block,
+                timeout=0.05,
+                label="test-no-resolve",
+                ble_address=ble_address,
+                ble_generation=gen,
+            )
+
+        release.set()
+        done.wait(timeout=1.0)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRunBlockingLateCompletionIsStaleFallback:
+    """Cover async_utils.py lines 392-404: worker late completion stale fallback."""
+
+    def test_stale_generation_fallback_when_resolve_not_called(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "AA:11:BB:22:CC:33"
+        gen = mu._advance_ble_generation(ble_address, transition="test-stale-fallback")
+
+        release = threading.Event()
+        done = threading.Event()
+
+        real_record = mu._record_ble_teardown_timeout
+
+        def _block():
+            release.wait(timeout=2.0)
+            done.set()
+
+        def _record_and_set_release(addr, g):
+            release.set()
+            return real_record(addr, g)
+
+        with (
+            patch.object(
+                mu, "_record_ble_teardown_timeout", side_effect=_record_and_set_release
+            ),
+            patch.object(mu, "_resolve_ble_teardown_timeout", return_value=(0, True)),
+            patch.object(mu, "_is_ble_generation_stale", return_value=True),
+            pytest.raises(TimeoutError),
+        ):
+            _run_blocking_with_timeout(
+                _block,
+                timeout=0.05,
+                label="ble-interface-disconnect-stale-fallback",
+                ble_address=ble_address,
+                ble_generation=gen,
+            )
+
+        done.wait(timeout=1.0)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRunBlockingTimeoutRecordingPath:
+    """Cover async_utils.py lines 453-470: timeout recording path with callable check."""
+
+    def test_record_not_callable_skips(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        gen = mu._advance_ble_generation(ble_address, transition="test")
+
+        with (
+            patch.object(mu, "_record_ble_teardown_timeout", None),
+            pytest.raises(TimeoutError),
+        ):
+            _run_blocking_with_timeout(
+                lambda: time.sleep(10),
+                timeout=0.05,
+                label="test-record-not-callable",
+                ble_address=ble_address,
+                ble_generation=gen,
+            )
+
+    def test_done_set_after_timeout_triggers_resolve(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "FF:EE:DD:CC:BB:AA"
+        gen = mu._advance_ble_generation(ble_address, transition="test-done-after")
+
+        release = threading.Event()
+        done = threading.Event()
+
+        def _block():
+            release.wait(timeout=2.0)
+            done.set()
+
+        with pytest.raises(TimeoutError):
+            _run_blocking_with_timeout(
+                _block,
+                timeout=0.05,
+                label="ble-client-disconnect-test",
+                ble_address=ble_address,
+                ble_generation=gen,
+            )
+
+        release.set()
+        done.wait(timeout=1.0)
+        for _ in range(50):
+            if not mu._get_ble_unresolved_teardown_generations(ble_address):
+                break
+            time.sleep(0.01)
+        assert mu._get_ble_unresolved_teardown_generations(ble_address) == []
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestTearDownMeshtasticClientBleGeneration:
+    """Cover events.py lines 90-95: BLE teardown with generation registration."""
+
+    def test_ble_interface_with_address_registers_generation(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        mock_iface = MagicMock()
+        mock_iface.address = "AA:BB:CC:DD:EE:FF"
+        mock_iface.client.bleak_client.address = "AA:BB:CC:DD:EE:FF"
+
+        mu.meshtastic_client = mock_iface
+        mu.meshtastic_iface = mock_iface
+
+        with patch.object(mu, "_disconnect_ble_interface") as mock_disconnect:
+            _tear_down_meshtastic_client_for_disconnect("connection_loss")
+
+        mock_disconnect.assert_called_once()
+        assert mu.meshtastic_iface is None
+
+    def test_ble_interface_with_no_address_skips_generation(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        mock_iface = MagicMock()
+        mock_iface.address = None
+        del mock_iface.client
+
+        mu.meshtastic_client = mock_iface
+        mu.meshtastic_iface = mock_iface
+
+        with patch.object(mu, "_extract_ble_address_from_interface", return_value=None):
+            with patch.object(mu, "_disconnect_ble_interface") as mock_disconnect:
+                _tear_down_meshtastic_client_for_disconnect("test")
+
+        mock_disconnect.assert_called_once()
+        assert mu.meshtastic_iface is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestParseMatrixMessageCommandRequireMention:
+    """Cover command_bridge.py lines 352-356: require_mention with no bot_mxid."""
+
+    def test_require_mention_no_bot_mxid_returns_none(self):
+        from mmrelay.matrix.command_bridge import _parse_matrix_message_command
+
+        matrix_utils.bot_user_id = None
+        result = _parse_matrix_message_command("!help", ["help"], require_mention=True)
+        assert result is None
+
+    def test_require_mention_with_bot_mxid_and_mxid_prefix(self):
+        from mmrelay.matrix.command_bridge import _parse_matrix_message_command
+
+        matrix_utils.bot_user_id = "@bot:server.com"
+        result = _parse_matrix_message_command(
+            "@bot:server.com !help", ["help"], require_mention=True
+        )
+        assert result is not None
+        assert result.command == "help"
+
+    def test_require_mention_no_match(self):
+        from mmrelay.matrix.command_bridge import _parse_matrix_message_command
+
+        matrix_utils.bot_user_id = "@bot:server.com"
+        result = _parse_matrix_message_command(
+            "just some text", ["help"], require_mention=True
+        )
+        assert result is None
+
+    def test_require_mention_display_name_fallback(self):
+        from mmrelay.matrix.command_bridge import _parse_matrix_message_command
+
+        matrix_utils.bot_user_id = "@bot:server.com"
+        matrix_utils.bot_user_name = "MyBot"
+        result = _parse_matrix_message_command(
+            "MyBot: !help", ["help"], require_mention=True
+        )
+        assert result is not None
+        assert result.command == "help"
+
+    def test_empty_bodies_returns_none(self):
+        from mmrelay.matrix.command_bridge import _parse_matrix_message_command
+
+        matrix_utils.bot_user_id = "@bot:server.com"
+        mock_event = MagicMock()
+        mock_event.body = ""
+        mock_event.source = {}
+        result = _parse_matrix_message_command(
+            mock_event, ["help"], require_mention=True
+        )
+        assert result is None
+
+    def test_require_mention_false_no_mention(self):
+        from mmrelay.matrix.command_bridge import _parse_matrix_message_command
+
+        matrix_utils.bot_user_id = "@bot:server.com"
+        result = _parse_matrix_message_command("!help", ["help"], require_mention=False)
+        assert result is not None
+        assert result.command == "help"
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleInterfaceAsyncDisconnect:
+    """Cover ble.py line 873: iscoroutinefunction disconnect path."""
+
+    def test_async_disconnect_method(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.client = None
+        iface.close.return_value = None
+
+        def make_disconnect():
+            async def _disconnect():
+                return None
+
+            return _disconnect
+
+        iface.disconnect = make_disconnect()
+
+        def _wait_and_close(coro, **kwargs):
+            if hasattr(coro, "close"):
+                coro.close()
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep"),
+            patch.object(mu, "_wait_for_result", side_effect=_wait_and_close),
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleInterfaceSyncAwaitable:
+    """Cover ble.py line 889: awaitable result in sync disconnect."""
+
+    def test_sync_disconnect_returns_awaitable(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = MagicMock()
+        iface.client = None
+        iface.close.return_value = None
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep"),
+            patch.object(mu, "_run_blocking_with_timeout") as mock_blocking,
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+            mock_blocking.assert_called()
+            sync_fn = mock_blocking.call_args[0][0]
+            with patch.object(mu, "_wait_for_result"):
+                sync_fn()
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleNoDisconnectMethod:
+    """Cover ble.py line 918: interface without disconnect()."""
+
+    def test_no_disconnect_method(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock(spec=["close", "client"])
+        iface.client = None
+        iface.close.return_value = None
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep"),
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleCloseSyncAwaitableResult:
+    """Cover ble.py line 1016-1017: _close_sync with awaitable result."""
+
+    def test_close_returns_awaitable_inside_blocking(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        awaitable_future = asyncio.Future()
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        del iface.disconnect
+        iface.client = None
+        iface.close.return_value = awaitable_future
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep"),
+            patch.object(mu, "_run_blocking_with_timeout") as mock_blocking,
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+            mock_blocking.assert_called()
+            close_fn = mock_blocking.call_args[0][0]
+            with patch.object(mu, "_wait_for_result"):
+                close_fn()
+            awaitable_future.cancel()
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleExceptionHandlers:
+    """Cover ble.py lines 1033-1035: exception handlers in _disconnect_ble_interface."""
+
+    def test_generic_exception_in_disconnect(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.side_effect = RuntimeError("unexpected error")
+        iface.client = None
+        iface.close.return_value = None
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep"),
+            patch.object(
+                mu,
+                "_run_blocking_with_timeout",
+                side_effect=RuntimeError("block fail"),
+            ),
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+
+    def test_timeout_error_in_disconnect(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client = None
+        iface.close.return_value = None
+
+        call_count = 0
+
+        def _sleep_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                pass
+            elif call_count > 6:
+                raise TimeoutError("simulated timeout")
+
+        with (
+            patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
+            patch.object(mu.time, "sleep", side_effect=_sleep_side_effect),
+        ):
+            _disconnect_ble_interface(iface, reason="test")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestDisconnectBleGenerationFallbackToAddress:
+    """Cover ble.py line 833: generation fallback to address lookup."""
+
+    def test_generation_none_mapped_none_address_set(self):
+        from mmrelay.meshtastic.ble import _disconnect_ble_interface
+
+        iface = MagicMock()
+        iface._exit_handler = None
+        iface.disconnect.return_value = None
+        iface.client = None
+        iface.close.return_value = None
+
+        with (
+            patch.object(
+                mu, "_get_ble_iface_generation", return_value=("aabbcc", None)
+            ),
+            patch.object(mu, "_get_ble_generation", return_value=3),
+            patch.object(mu.time, "sleep"),
+        ):
+            _disconnect_ble_interface(iface, reason="test", ble_address="AA:BB:CC")
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRunBlockingResolveGuardPaths:
+    """Cover async_utils.py lines 348-349, 356-357, 364-365."""
+
+    def test_resolve_called_with_no_ble_generation(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        release = threading.Event()
+        done = threading.Event()
+
+        def _block():
+            release.wait(timeout=2.0)
+            done.set()
+
+        with (
+            pytest.raises(TimeoutError),
+            patch.object(mu, "_resolve_ble_teardown_timeout"),
+        ):
+            _run_blocking_with_timeout(
+                _block,
+                timeout=0.05,
+                label="test-no-gen",
+                ble_address="AA:BB",
+                ble_generation=None,
+            )
+
+        release.set()
+        done.wait(timeout=1.0)
+
+    def test_resolve_guard_with_zero_generation(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        release = threading.Event()
+        done = threading.Event()
+
+        def _block():
+            release.wait(timeout=2.0)
+            done.set()
+
+        real_record = mu._record_ble_teardown_timeout
+
+        def _record_then_release(addr, gen):
+            release.set()
+            return real_record(addr, gen)
+
+        with (
+            patch.object(
+                mu, "_record_ble_teardown_timeout", side_effect=_record_then_release
+            ),
+            patch.object(mu, "_resolve_ble_teardown_timeout") as mock_resolve,
+            pytest.raises(TimeoutError),
+        ):
+            _run_blocking_with_timeout(
+                _block,
+                timeout=0.05,
+                label="test-zero-gen",
+                ble_address="AA:BB",
+                ble_generation=0,
+            )
+
+        done.wait(timeout=1.0)
+        mock_resolve.assert_not_called()
+
+    def test_resolve_already_resolved_skips(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "CC:DD:EE:FF:00:11"
+        gen = mu._advance_ble_generation(ble_address, transition="test")
+
+        release = threading.Event()
+        done = threading.Event()
+
+        def _block():
+            release.wait(timeout=2.0)
+            done.set()
+
+        real_resolve = mu._resolve_ble_teardown_timeout
+        resolve_count = 0
+
+        def _counting_resolve(addr, g):
+            nonlocal resolve_count
+            resolve_count += 1
+            return real_resolve(addr, g)
+
+        with (
+            patch.object(
+                mu, "_resolve_ble_teardown_timeout", side_effect=_counting_resolve
+            ),
+            pytest.raises(TimeoutError),
+        ):
+            _run_blocking_with_timeout(
+                _block,
+                timeout=0.05,
+                label="ble-interface-disconnect-dup-resolve",
+                ble_address=ble_address,
+                ble_generation=gen,
+            )
+
+        release.set()
+        done.wait(timeout=1.0)
+        for _ in range(50):
+            if not mu._get_ble_unresolved_teardown_generations(ble_address):
+                break
+            time.sleep(0.01)
+        assert mu._get_ble_unresolved_teardown_generations(ble_address) == []
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestRunBlockingStaleGenerationFallback:
+    """Cover async_utils.py lines 398-404: is_generation_stale fallback when resolve not called."""
+
+    def test_stale_check_used_when_resolve_skipped(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "22:33:44:55:66:77"
+        gen = mu._advance_ble_generation(ble_address, transition="test-stale")
+
+        release = threading.Event()
+        done = threading.Event()
+
+        def _block():
+            release.wait(timeout=2.0)
+            done.set()
+
+        real_record = mu._record_ble_teardown_timeout
+
+        def _record_and_release(addr, g):
+            release.set()
+            return real_record(addr, g)
+
+        with (
+            patch.object(
+                mu, "_record_ble_teardown_timeout", side_effect=_record_and_release
+            ),
+            patch.object(
+                mu,
+                "_resolve_ble_teardown_timeout",
+                side_effect=lambda *a, **k: (0, None),
+            ),
+            patch.object(mu, "_is_ble_generation_stale", return_value=True),
+            pytest.raises(TimeoutError),
+        ):
+            _run_blocking_with_timeout(
+                _block,
+                timeout=0.05,
+                label="ble-client-disconnect-stale-check",
+                ble_address=ble_address,
+                ble_generation=gen,
+            )
+
+        done.wait(timeout=1.0)
+        for _ in range(50):
+            if not mu._get_ble_unresolved_teardown_generations(ble_address):
+                break
+            time.sleep(0.01)
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestTearDownNonBleOSError:
+    """Cover events.py lines 113-115: non-BLE client close with non-EBADF OSError."""
+
+    def test_non_ebadf_oserror_logged(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        client = MagicMock()
+        client.close.side_effect = OSError("broken pipe")
+        client.close.side_effect.errno = 32
+
+        mu.meshtastic_client = client
+        mu.meshtastic_iface = None
+
+        _tear_down_meshtastic_client_for_disconnect("test")
+
+    def test_generic_exception_on_close_logged(self):
+        from mmrelay.meshtastic.events import (
+            _tear_down_meshtastic_client_for_disconnect,
+        )
+
+        client = MagicMock()
+        client.close.side_effect = RuntimeError("unexpected")
+
+        mu.meshtastic_client = client
+        mu.meshtastic_iface = None
+
+        _tear_down_meshtastic_client_for_disconnect("test")

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -3,7 +3,7 @@ Tests for specific uncovered lines across ble.py, async_utils.py, events.py,
 and command_bridge.py.
 """
 
-import asyncio
+import errno
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -849,7 +849,7 @@ class TestTearDownMeshtasticClientBleGeneration:
         assert mu.meshtastic_iface is None
 
 
-@pytest.mark.usefixtures("reset_meshtastic_globals")
+@pytest.mark.usefixtures("reset_meshtastic_globals", "reset_matrix_utils_globals")
 class TestParseMatrixMessageCommandRequireMention:
     """Cover command_bridge.py lines 352-356: require_mention with no bot_mxid."""
 
@@ -993,13 +993,13 @@ class TestDisconnectBleCloseSyncAwaitableResult:
     def test_close_returns_awaitable_inside_blocking(self):
         from mmrelay.meshtastic.ble import _disconnect_ble_interface
 
-        awaitable_future = asyncio.Future()
+        mock_awaitable = MagicMock()
 
         iface = MagicMock()
         iface._exit_handler = None
         del iface.disconnect
         iface.client = None
-        iface.close.return_value = awaitable_future
+        iface.close.return_value = mock_awaitable
 
         with (
             patch.object(mu, "_get_ble_iface_generation", return_value=(None, None)),
@@ -1011,7 +1011,6 @@ class TestDisconnectBleCloseSyncAwaitableResult:
             close_fn = mock_blocking.call_args[0][0]
             with patch.object(mu, "_wait_for_result"):
                 close_fn()
-            awaitable_future.cancel()
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
@@ -1254,8 +1253,7 @@ class TestTearDownNonBleOSError:
         )
 
         client = MagicMock()
-        client.close.side_effect = OSError("broken pipe")
-        client.close.side_effect.errno = 32
+        client.close.side_effect = OSError(errno.EPIPE, "broken pipe")
 
         mu.meshtastic_client = client
         mu.meshtastic_iface = None

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -229,6 +229,62 @@ class TestRunBlockingWithTimeout:
             time.sleep(0.01)
         assert mu._get_ble_unresolved_teardown_generations(ble_address) == []
 
+    def test_timeout_recording_race_does_not_leave_stale_unresolved(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "AA:00:BB:11:CC:22"
+        generation = mu._advance_ble_generation(
+            ble_address,
+            transition="test-timeout-record-race",
+        )
+        release_blocker = threading.Event()
+        blocker_done = threading.Event()
+
+        def _blocking_action() -> None:
+            release_blocker.wait(timeout=2.0)
+            blocker_done.set()
+
+        real_record_timeout = mu._record_ble_teardown_timeout
+        real_resolve_timeout = mu._resolve_ble_teardown_timeout
+
+        def _record_timeout_with_worker_finish(address: str, gen: int) -> int:
+            # While caller is still on the timeout path, let the worker finish
+            # before timeout signaling so caller-side immediate resolve is required.
+            release_blocker.set()
+            assert blocker_done.wait(timeout=1.0)
+            return real_record_timeout(address, gen)
+
+        with (
+            patch.object(
+                mu,
+                "_record_ble_teardown_timeout",
+                side_effect=_record_timeout_with_worker_finish,
+            ) as mock_record,
+            patch.object(
+                mu,
+                "_resolve_ble_teardown_timeout",
+                wraps=real_resolve_timeout,
+            ) as mock_resolve,
+        ):
+            with pytest.raises(TimeoutError):
+                _run_blocking_with_timeout(
+                    _blocking_action,
+                    timeout=0.05,
+                    label="ble-interface-disconnect-race",
+                    ble_address=ble_address,
+                    ble_generation=generation,
+                    iface_id=5150,
+                    client_id=6160,
+                )
+
+        assert mock_record.call_count == 1
+        assert mock_resolve.call_count >= 1
+        for _ in range(50):
+            if not mu._get_ble_unresolved_teardown_generations(ble_address):
+                break
+            time.sleep(0.01)
+        assert mu._get_ble_unresolved_teardown_generations(ble_address) == []
+
     def test_late_completion_from_old_generation_is_stale(self):
         from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
 

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from unittest.mock import patch
@@ -190,6 +191,86 @@ class TestRunBlockingWithTimeout:
         from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
 
         _run_blocking_with_timeout(lambda: None, timeout=2.0, label="test-ok")
+
+    def test_timeout_marks_unresolved_then_late_completion_clears(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        generation = mu._advance_ble_generation(
+            ble_address,
+            transition="test-disconnect",
+        )
+        blocker_done = threading.Event()
+        release_blocker = threading.Event()
+
+        def _blocking_action() -> None:
+            release_blocker.wait(timeout=2.0)
+            blocker_done.set()
+
+        with pytest.raises(TimeoutError):
+            _run_blocking_with_timeout(
+                _blocking_action,
+                timeout=0.05,
+                label="ble-interface-disconnect-test",
+                ble_address=ble_address,
+                ble_generation=generation,
+                iface_id=111,
+                client_id=222,
+            )
+
+        unresolved = mu._get_ble_unresolved_teardown_generations(ble_address)
+        assert unresolved == [(generation, 1)]
+
+        release_blocker.set()
+        assert blocker_done.wait(timeout=1.0)
+        for _ in range(50):
+            if not mu._get_ble_unresolved_teardown_generations(ble_address):
+                break
+            time.sleep(0.01)
+        assert mu._get_ble_unresolved_teardown_generations(ble_address) == []
+
+    def test_late_completion_from_old_generation_is_stale(self):
+        from mmrelay.meshtastic.async_utils import _run_blocking_with_timeout
+
+        ble_address = "11:22:33:44:55:66"
+        old_generation = mu._advance_ble_generation(
+            ble_address,
+            transition="test-old-generation",
+        )
+        blocker_done = threading.Event()
+        release_blocker = threading.Event()
+
+        def _blocking_action() -> None:
+            release_blocker.wait(timeout=2.0)
+            blocker_done.set()
+
+        with pytest.raises(TimeoutError):
+            _run_blocking_with_timeout(
+                _blocking_action,
+                timeout=0.05,
+                label="ble-interface-close-test",
+                ble_address=ble_address,
+                ble_generation=old_generation,
+                iface_id=333,
+                client_id=444,
+            )
+
+        new_generation = mu._advance_ble_generation(
+            ble_address,
+            transition="test-new-connect",
+        )
+        assert new_generation > old_generation
+
+        release_blocker.set()
+        assert blocker_done.wait(timeout=1.0)
+        for _ in range(50):
+            if not mu._get_ble_unresolved_teardown_generations(ble_address):
+                break
+            time.sleep(0.01)
+
+        assert mu._get_ble_unresolved_teardown_generations(ble_address) == []
+        assert mu._get_ble_generation(ble_address) == new_generation
+        assert mu._is_ble_generation_stale(ble_address, old_generation) is True
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -265,17 +265,17 @@ class TestRunBlockingWithTimeout:
                 "_resolve_ble_teardown_timeout",
                 wraps=real_resolve_timeout,
             ) as mock_resolve,
+            pytest.raises(TimeoutError),
         ):
-            with pytest.raises(TimeoutError):
-                _run_blocking_with_timeout(
-                    _blocking_action,
-                    timeout=0.05,
-                    label="ble-interface-disconnect-race",
-                    ble_address=ble_address,
-                    ble_generation=generation,
-                    iface_id=5150,
-                    client_id=6160,
-                )
+            _run_blocking_with_timeout(
+                _blocking_action,
+                timeout=0.05,
+                label="ble-interface-disconnect-race",
+                ble_address=ble_address,
+                ble_generation=generation,
+                iface_id=5150,
+                client_id=6160,
+            )
 
         assert mock_record.call_count == 1
         assert mock_resolve.call_count >= 1

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -1,4 +1,7 @@
-from typing import Any
+from __future__ import annotations
+
+from concurrent.futures import Future
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -413,12 +416,10 @@ class TestBleTeardownBarrier:
         assert mock_ble_ctor.call_count >= 1
 
     def test_late_barrier_after_iface_creation_rolls_back_published_iface(self):
-        from concurrent.futures import Future
-
         from mmrelay.meshtastic.connection import _connect_meshtastic_impl
 
         class BleInterfaceWithConnect:
-            def __init__(
+            def __init__(  # noqa: PLR0913
                 self,
                 *,
                 address: str,
@@ -428,6 +429,7 @@ class TestBleTeardownBarrier:
                 timeout: int,
                 auto_reconnect: bool = True,
             ) -> None:
+                _ = (noProto, debugOut, noNodes, timeout)
                 self.address = address
                 self.client = object()
                 self.auto_reconnect = auto_reconnect
@@ -459,8 +461,10 @@ class TestBleTeardownBarrier:
             # Block at the post-creation barrier before connect().
             return [(1, 1)]
 
-        def _sync_submit(fn: Any, *args: Any, **kwargs: Any) -> Future[Any]:
-            future: Future[Any] = Future()
+        def _sync_submit(
+            fn: Callable[..., object], *args: object, **kwargs: object
+        ) -> Future[object]:
+            future: Future[object] = Future()
             try:
                 future.set_result(fn(*args, **kwargs))
             except Exception as exc:  # noqa: BLE001 - test harness helper

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -5,6 +5,10 @@ import pytest
 import mmrelay.meshtastic_utils as mu
 
 
+def _stop_retry_and_mark_shutdown(_seconds: float) -> None:
+    mu.shutting_down = True
+
+
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestGetConnectionRetryWaitTime:
     def test_zero_attempts(self):
@@ -330,12 +334,9 @@ class TestBleTeardownBarrier:
         mu.meshtastic_client = None
         mu.meshtastic_iface = None
 
-        def _stop_retry(_seconds: float) -> None:
-            mu.shutting_down = True
-
         with (
             patch.object(mu, "_disconnect_ble_by_address"),
-            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(mu.time, "sleep", side_effect=_stop_retry_and_mark_shutdown),
             patch.object(mu.meshtastic.ble_interface, "BLEInterface") as mock_ble_ctor,
         ):
             result = _connect_meshtastic_impl()
@@ -359,12 +360,9 @@ class TestBleTeardownBarrier:
         mu.meshtastic_client = None
         mu.meshtastic_iface = None
 
-        def _stop_retry(_seconds: float) -> None:
-            mu.shutting_down = True
-
         with (
             patch.object(mu, "_disconnect_ble_by_address"),
-            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(mu.time, "sleep", side_effect=_stop_retry_and_mark_shutdown),
             patch.object(
                 mu.meshtastic.ble_interface,
                 "BLEInterface",
@@ -399,12 +397,9 @@ class TestBleTeardownBarrier:
         mu.meshtastic_client = None
         mu.meshtastic_iface = None
 
-        def _stop_retry(_seconds: float) -> None:
-            mu.shutting_down = True
-
         with (
             patch.object(mu, "_disconnect_ble_by_address"),
-            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(mu.time, "sleep", side_effect=_stop_retry_and_mark_shutdown),
             patch.object(
                 mu.meshtastic.ble_interface,
                 "BLEInterface",
@@ -468,9 +463,6 @@ class TestBleTeardownBarrier:
                 future.set_exception(exc)
             return future
 
-        def _stop_retry(_seconds: float) -> None:
-            mu.shutting_down = True
-
         mock_executor = MagicMock()
         mock_executor.submit.side_effect = _sync_submit
 
@@ -481,7 +473,7 @@ class TestBleTeardownBarrier:
             patch.object(mu, "_disconnect_ble_by_address"),
             patch.object(mu, "_get_ble_executor", return_value=mock_executor),
             patch.object(mu, "_disconnect_ble_interface") as mock_disconnect_iface,
-            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(mu.time, "sleep", side_effect=_stop_retry_and_mark_shutdown),
             patch.object(
                 mu.meshtastic.ble_interface,
                 "BLEInterface",

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -415,3 +415,91 @@ class TestBleTeardownBarrier:
 
         assert result is None
         assert mock_ble_ctor.call_count >= 1
+
+    def test_late_barrier_after_iface_creation_rolls_back_published_iface(self):
+        from concurrent.futures import Future
+
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        class BleInterfaceWithConnect:
+            def __init__(
+                self,
+                address: str,
+                noProto: bool,  # noqa: N803
+                debugOut,
+                noNodes: bool,  # noqa: N803
+                timeout: int,
+                auto_reconnect: bool = True,
+            ) -> None:
+                self.address = address
+                self.client = object()
+                self.auto_reconnect = auto_reconnect
+                self.connect = MagicMock()
+
+        ble_address = "44:55:66:77:88:99"
+        mu.config = {
+            "meshtastic": {
+                "connection_type": "ble",
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        mu.meshtastic_iface = None
+
+        unresolved_calls = 0
+
+        def _unresolved_teardown_for_late_barrier(_address: str):
+            nonlocal unresolved_calls
+            unresolved_calls += 1
+            if unresolved_calls == 1:
+                # Allow interface creation pre-check.
+                return []
+            # Block at the post-creation barrier before connect().
+            return [(1, 1)]
+
+        def _sync_submit(fn, *args, **kwargs):
+            future = Future()
+            try:
+                future.set_result(fn(*args, **kwargs))
+            except Exception as exc:  # noqa: BLE001 - test harness helper
+                future.set_exception(exc)
+            return future
+
+        def _stop_retry(_seconds: float) -> None:
+            mu.shutting_down = True
+
+        mock_executor = MagicMock()
+        mock_executor.submit.side_effect = _sync_submit
+
+        with (
+            patch.object(
+                mu, "_get_ble_unresolved_teardown_generations"
+            ) as mock_unresolved,
+            patch.object(mu, "_disconnect_ble_by_address"),
+            patch.object(mu, "_get_ble_executor", return_value=mock_executor),
+            patch.object(mu, "_disconnect_ble_interface") as mock_disconnect_iface,
+            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(
+                mu.meshtastic.ble_interface,
+                "BLEInterface",
+                BleInterfaceWithConnect,
+            ),
+        ):
+            mock_unresolved.side_effect = _unresolved_teardown_for_late_barrier
+            result = _connect_meshtastic_impl()
+
+        assert result is None
+        assert unresolved_calls >= 2
+        assert mock_disconnect_iface.call_count == 1
+        disconnected_iface = mock_disconnect_iface.call_args.args[0]
+        assert disconnected_iface is not None
+        assert disconnected_iface.address == ble_address
+        assert (
+            mock_disconnect_iface.call_args.kwargs["reason"] == "connect setup failed"
+        )
+        assert disconnected_iface.connect.call_count == 0
+        assert mu.meshtastic_iface is None
+        assert mu.meshtastic_client is None

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -307,3 +307,111 @@ class TestConnectMeshtastic:
                 "tcp",
             )
             assert mu.meshtastic_client is None
+
+
+@pytest.mark.usefixtures("reset_meshtastic_globals")
+class TestBleTeardownBarrier:
+    def test_blocks_fresh_creation_when_teardown_unresolved(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        address_key = mu._sanitize_ble_address(ble_address)
+        mu._ble_generation_by_address[address_key] = 7
+        mu._ble_teardown_unresolved_by_generation[(address_key, 7)] = 1
+        mu.config = {
+            "meshtastic": {
+                "connection_type": "ble",
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        mu.meshtastic_iface = None
+
+        def _stop_retry(_seconds: float) -> None:
+            mu.shutting_down = True
+
+        with (
+            patch.object(mu, "_disconnect_ble_by_address"),
+            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(mu.meshtastic.ble_interface, "BLEInterface") as mock_ble_ctor,
+        ):
+            result = _connect_meshtastic_impl()
+
+        assert result is None
+        mock_ble_ctor.assert_not_called()
+
+    def test_allows_fresh_creation_after_teardown_resolves(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        ble_address = "11:22:33:44:55:66"
+        mu.config = {
+            "meshtastic": {
+                "connection_type": "ble",
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        mu.meshtastic_iface = None
+
+        def _stop_retry(_seconds: float) -> None:
+            mu.shutting_down = True
+
+        with (
+            patch.object(mu, "_disconnect_ble_by_address"),
+            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(
+                mu.meshtastic.ble_interface,
+                "BLEInterface",
+                side_effect=RuntimeError("creation failed"),
+            ) as mock_ble_ctor,
+        ):
+            result = _connect_meshtastic_impl()
+
+        assert result is None
+        assert mock_ble_ctor.call_count >= 1
+
+    def test_reconnect_proceeds_after_late_worker_resolution(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        ble_address = "22:33:44:55:66:77"
+        address_key = mu._sanitize_ble_address(ble_address)
+        mu._ble_generation_by_address[address_key] = 3
+        mu._ble_teardown_unresolved_by_generation[(address_key, 3)] = 1
+        remaining, stale = mu._resolve_ble_teardown_timeout(ble_address, 3)
+        assert remaining == 0
+        assert stale is False
+
+        mu.config = {
+            "meshtastic": {
+                "connection_type": "ble",
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        mu.meshtastic_iface = None
+
+        def _stop_retry(_seconds: float) -> None:
+            mu.shutting_down = True
+
+        with (
+            patch.object(mu, "_disconnect_ble_by_address"),
+            patch.object(mu.time, "sleep", side_effect=_stop_retry),
+            patch.object(
+                mu.meshtastic.ble_interface,
+                "BLEInterface",
+                side_effect=RuntimeError("creation failed"),
+            ) as mock_ble_ctor,
+        ):
+            result = _connect_meshtastic_impl()
+
+        assert result is None
+        assert mock_ble_ctor.call_count >= 1

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -419,9 +420,10 @@ class TestBleTeardownBarrier:
         class BleInterfaceWithConnect:
             def __init__(
                 self,
+                *,
                 address: str,
                 noProto: bool,  # noqa: N803
-                debugOut,
+                debugOut: object,  # noqa: N803
                 noNodes: bool,  # noqa: N803
                 timeout: int,
                 auto_reconnect: bool = True,
@@ -446,7 +448,9 @@ class TestBleTeardownBarrier:
 
         unresolved_calls = 0
 
-        def _unresolved_teardown_for_late_barrier(_address: str):
+        def _unresolved_teardown_for_late_barrier(
+            _address: str,
+        ) -> list[tuple[int, int]]:
             nonlocal unresolved_calls
             unresolved_calls += 1
             if unresolved_calls == 1:
@@ -455,8 +459,8 @@ class TestBleTeardownBarrier:
             # Block at the post-creation barrier before connect().
             return [(1, 1)]
 
-        def _sync_submit(fn, *args, **kwargs):
-            future = Future()
+        def _sync_submit(fn: Any, *args: Any, **kwargs: Any) -> Future[Any]:
+            future: Future[Any] = Future()
             try:
                 future.set_result(fn(*args, **kwargs))
             except Exception as exc:  # noqa: BLE001 - test harness helper


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR implements per-BLE-connection "generation" tracking and richer teardown diagnostics to reduce race conditions during rapid connect/disconnect cycles. Each connection attempt is assigned a generation identifier so the code can detect and block new connection/interface creation while prior teardown work for the same BLE address remains unresolved, record unresolved teardown timeouts, and produce more detailed logs and diagnostics when teardown or worker timeouts occur.

## Key changes

Features
- Per-address generation lifecycle tracking:
  - New state maps: `_ble_generation_by_address`, `_ble_iface_generation_by_id`, `_ble_teardown_unresolved_by_generation`.
  - New lifecycle lock: `facade._ble_lifecycle_lock` to synchronize generation/ownership mutations.
- Helper APIs (exported via __all__) to manage generation/ownership and teardown timeouts:
  - `_advance_ble_generation`, `_get_ble_generation`, `_is_ble_generation_stale`
  - `_register_ble_iface_generation`, `_get_ble_iface_generation`, `_discard_ble_iface_generation`
  - `_get_ble_unresolved_teardown_generations`, `_record_ble_teardown_timeout`, `_resolve_ble_teardown_timeout`
  - `_extract_ble_address_from_interface`, plus related BLE helpers.
- Connect-time generation propagation and interface registration:
  - `_connect_meshtastic_impl` advances a `connect_generation` per connect attempt, registers interfaces with generation metadata, and logs generation/iface/client ids.
  - Interfaces are registered on creation/reuse and ownership metadata is discarded in teardown.
- Late-completion cleanup enhanced:
  - `_attach_late_ble_interface_disposer` accepts `generation` and resolves ownership metadata for late worker completions to ensure proper disconnect/cleanup.

Fixes / reliability
- Teardown/unresolved-work barrier:
  - Interface creation and sequential-mode connect now check `_get_ble_unresolved_teardown_generations(address)` and block/return early (raise/propagate TimeoutError or return None) when unresolved teardown generations exist for the same address to avoid race conditions.
- Timeout / worker diagnostics & resolution:
  - `_run_blocking_with_timeout` signature extended with keyword-only context params (`ble_address`, `ble_generation`, `iface_id`, `client_id`) to enrich logs and correctly record/resolve teardown timeouts.
  - Timeout path records unresolved teardown generation entries and invokes resolution hooks so a late worker completion resolves pending teardown state once.
  - Worker-completion logging on caller timeout includes elapsed times and unresolved/stale-generation info.
- Disconnect/teardown improvements:
  - `_disconnect_ble_interface` accepts keyword-only `ble_address` and `generation`, resolves missing metadata from ownership maps, forwards generation into timeout-wrapped disconnect/close operations, logs resolved ids, and discards ownership metadata in finally.
- Executor shutdown cleanup:
  - `_shutdown_shared_executors()` now clears BLE lifecycle tracking state so shutdown resets generation/ownership/timeout maps.

Refactors & cleanup
- Meshtastic utils and modules updated to expose and use the new BLE lifecycle helpers; imports adjusted accordingly.
- Late cleanup and event-driven teardown flows updated to include generation/address metadata and to emit richer diagnostic logs including generation/iface/client ids.

Tests & fixtures
- New and extended tests:
  - Tests exercising `_run_blocking_with_timeout` timeout/late-completion semantics and unresolved-teardown recording/resolution.
  - Tests for `_connect_meshtastic_impl` enforcing the unresolved-teardown barrier, rollback behavior when a late barrier occurs, and registration/discarding of interface generations.
  - Large coverage additions validating teardown/generation logic, error handling in disconnect/close paths, and various edge cases.
- Test fixture `reset_meshtastic_globals()` extended to clear and restore the new BLE lifecycle globals between tests to avoid state leakage.

Breaking changes / migration notes
- No public API breaking changes: all changes are internal (module-private, names prefixed with `_`). Existing call sites without the new optional keyword-only parameters remain valid.
- Internal signatures changed (optional keyword-only params added): `_run_blocking_with_timeout(..., *, ble_address, ble_generation, iface_id, client_id)` and `_disconnect_ble_interface(..., *, ble_address, generation)`. These are backward-compatible for callers that don’t provide the new args.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->