### PR TITLE
Add optional hop count display to ping replies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ src/mmrelay.egg-info/
 .commandcode/
 .sisyphus/
 coderabbit_actionable_items.md
+.omo/
 
 # Build and test outputs
 /build/

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -164,9 +164,12 @@ class Plugin(BasePlugin):
 
         # Append hop count suffix if enabled
         if self.config.get("display_hops", False):
-            hops = packet.get("hopStart", 0) - packet.get("hopLimit", 0)
-            if hops > 0:
-                reply_message = f"{reply_message} {hops} 🦘"
+            hop_start = packet.get("hopStart")
+            hop_limit = packet.get("hopLimit")
+            if hop_start is not None and hop_limit is not None:
+                hops = hop_start - hop_limit
+                if hops > 0:
+                    reply_message += f" {hops} 🦘"
 
         await asyncio.sleep(self.get_response_delay())
 

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -168,8 +168,12 @@ class Plugin(BasePlugin):
             hop_limit = packet.get("hopLimit")
             if hop_start is not None and hop_limit is not None:
                 hops = hop_start - hop_limit
-                if hops > 0:
-                    reply_message += f" {hops} 🦘"
+                suffix = (
+                    f" ({hops} hop{'s' if hops > 1 else ''} 🦘)"
+                    if hops > 0
+                    else " (0 hops 🦘)"
+                )
+                reply_message += suffix
 
         await asyncio.sleep(self.get_response_delay())
 

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -162,6 +162,12 @@ class Plugin(BasePlugin):
             self.plugin_name,
         )
 
+        # Append hop count suffix if enabled
+        if self.config.get("display_hops", False):
+            hops = packet.get("hopStart", 0) - packet.get("hopLimit", 0)
+            if hops > 0:
+                reply_message = f"{reply_message} {hops} 🦘"
+
         await asyncio.sleep(self.get_response_delay())
 
         reply_id = packet.get("id")
@@ -175,6 +181,7 @@ class Plugin(BasePlugin):
             )
         else:
             self.send_message(text=reply_message, channel=channel, reply_id=reply_id)
+
         return True
 
     def get_matrix_commands(self) -> list[str]:

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -119,6 +119,9 @@ plugins:
     # When false (default): responds only to explicit !ping.
     # When true: responds to bare mesh-side "ping" messages with "pong".
     #mimic_mode: false
+    # When true (default: false): appends the hop count to mesh ping responses (e.g., "Pong?!? 2 🦘").
+    # Only visible when the ping came from the LoRa network; direct and MQTT messages are unaffected.
+    #display_hops: false
   weather:
     active: true
     #require_bot_mention: true  # Override global setting for this plugin only

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -119,7 +119,7 @@ plugins:
     # When false (default): responds only to explicit !ping.
     # When true: responds to bare mesh-side "ping" messages with "pong".
     #mimic_mode: false
-    # When true (default: false): appends the hop count to mesh ping responses (e.g., "Pong?!? 2 🦘").
+    # When true (default: false): appends the hop count to mesh ping responses (e.g., "Pong?!? (2 hops 🦘)").
     # Only visible when the ping came from the LoRa network; direct and MQTT messages are unaffected.
     #display_hops: false
   weather:

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -1034,7 +1034,7 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="pong! 2 🦘", channel=0, reply_id=None
+                text="pong! (2 hops 🦘)", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -1065,7 +1065,7 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="pong! 3 🦘",
+                text="pong! (3 hops 🦘)",
                 channel=1,
                 destination_id="!12345678",
                 reply_id=None,
@@ -1075,8 +1075,10 @@ class TestDisplayHops(unittest.TestCase):
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_display_hops_enabled_zero_hops_no_suffix(self, mock_sleep, mock_connect):
-        """Direct connection (hopStart==hopLimit) produces 0 hops — no suffix."""
+    def test_display_hops_enabled_zero_hops_shows_direct(
+        self, mock_sleep, mock_connect
+    ):
+        """Direct connection (hopStart==hopLimit) produces 0 hops — shows "0 hops 🦘"."""
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -1097,7 +1099,7 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="pong!", channel=0, reply_id=None
+                text="pong! (0 hops 🦘)", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -1243,7 +1245,7 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="PoNg!?! 2 🦘", channel=0, reply_id=None
+                text="PoNg!?! (2 hops 🦘)", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -1272,7 +1274,7 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="Pong... 2 🦘", channel=0, reply_id=None
+                text="Pong... (2 hops 🦘)", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -1301,7 +1303,7 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="pong! 7 🦘", channel=0, reply_id=None
+                text="pong! (7 hops 🦘)", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
@@ -1330,17 +1332,17 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="pong! 1 🦘", channel=0, reply_id=None
+                text="pong! (1 hop 🦘)", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())
 
     @patch("mmrelay.meshtastic_utils.connect_meshtastic")
     @patch("asyncio.sleep")
-    def test_display_hops_hoplimit_greater_than_hopstart_no_suffix(
+    def test_display_hops_hoplimit_greater_than_hopstart(
         self, mock_sleep, mock_connect
     ):
-        """Malformed packet (hopLimit > hopStart) produces negative → no suffix."""
+        """Malformed packet (hopLimit > hopStart) produces negative → shows (0 hops 🦘)."""
         mock_client = MagicMock()
         mock_client.myInfo.my_node_num = 123456789
         mock_connect.return_value = mock_client
@@ -1361,7 +1363,7 @@ class TestDisplayHops(unittest.TestCase):
             )
             self.assertTrue(result)
             self.plugin.send_message.assert_called_once_with(
-                text="pong!", channel=0, reply_id=None
+                text="pong! (0 hops 🦘)", channel=0, reply_id=None
             )
 
         asyncio.run(run_test())

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -1000,6 +1000,373 @@ class TestPingPluginMatrixHandling(unittest.TestCase):
         asyncio.run(run_test())
 
 
+class TestDisplayHops(unittest.TestCase):
+    """Tests for the display_hops config option (lines 165-169)."""
+
+    def setUp(self):
+        self.plugin = Plugin()
+        self.plugin.logger = MagicMock()
+        self.plugin.is_channel_enabled = MagicMock(return_value=True)
+        self.plugin.get_response_delay = MagicMock(return_value=1.0)
+        self.plugin.send_message = MagicMock()
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_enabled_broadcast_with_hops(self, mock_sleep, mock_connect):
+        """display_hops=True appends hop count to broadcast pong."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 3,
+            "hopLimit": 1,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong! 2 🦘", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_enabled_direct_message_with_hops(
+        self, mock_sleep, mock_connect
+    ):
+        """display_hops=True appends hop count to DM pong."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 1,
+            "fromId": "!12345678",
+            "to": 123456789,
+            "hopStart": 5,
+            "hopLimit": 2,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong! 3 🦘",
+                channel=1,
+                destination_id="!12345678",
+                reply_id=None,
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_enabled_zero_hops_no_suffix(self, mock_sleep, mock_connect):
+        """Direct connection (hopStart==hopLimit) produces 0 hops — no suffix."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 3,
+            "hopLimit": 3,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong!", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_enabled_negative_hops_no_suffix(
+        self, mock_sleep, mock_connect
+    ):
+        """Pre-2.3 firmware: hopStart missing → 0 - hopLimit = negative → no suffix."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopLimit": 2,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong!", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_enabled_both_fields_missing_no_suffix(
+        self, mock_sleep, mock_connect
+    ):
+        """Neither hopStart nor hopLimit present → 0 - 0 = 0 → no suffix."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong!", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_disabled_no_suffix(self, mock_sleep, mock_connect):
+        """display_hops=False (explicit) does not append suffix."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": False}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 3,
+            "hopLimit": 1,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong!", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_absent_config_no_suffix(self, mock_sleep, mock_connect):
+        """display_hops not in config → defaults to False → no suffix."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 3,
+            "hopLimit": 1,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong!", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_with_mimic_mode(self, mock_sleep, mock_connect):
+        """display_hops works with mimic_mode — suffix appended to mimic response."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"mimic_mode": True, "display_hops": True}
+
+        packet = {
+            "decoded": {"text": "PiNg!?!"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 4,
+            "hopLimit": 2,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="PoNg!?! 2 🦘", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_with_fallback_response(self, mock_sleep, mock_connect):
+        """display_hops appends to fallback response (Pong...) when punctuation exceeds max."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"mimic_mode": True, "display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!!!!!!PING?"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 3,
+            "hopLimit": 1,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="Pong... 2 🦘", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_max_hops(self, mock_sleep, mock_connect):
+        """display_hops with maximum possible hops (7 - 0 = 7)."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 7,
+            "hopLimit": 0,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong! 7 🦘", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_one_hop(self, mock_sleep, mock_connect):
+        """display_hops with exactly 1 hop (hopStart=2, hopLimit=1)."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 2,
+            "hopLimit": 1,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong! 1 🦘", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_hoplimit_greater_than_hopstart_no_suffix(
+        self, mock_sleep, mock_connect
+    ):
+        """Malformed packet (hopLimit > hopStart) produces negative → no suffix."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 1,
+            "hopLimit": 3,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong!", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
+
 class TestPingPluginEdgeCases(unittest.TestCase):
     def setUp(self):
         self.plugin = Plugin()

--- a/tests/test_ping_plugin.py
+++ b/tests/test_ping_plugin.py
@@ -1366,6 +1366,36 @@ class TestDisplayHops(unittest.TestCase):
 
         asyncio.run(run_test())
 
+    @patch("mmrelay.meshtastic_utils.connect_meshtastic")
+    @patch("asyncio.sleep")
+    def test_display_hops_hopstart_present_hoplimit_missing_no_suffix(
+        self, mock_sleep, mock_connect
+    ):
+        """hopStart present but hopLimit missing → guarded, no suffix."""
+        mock_client = MagicMock()
+        mock_client.myInfo.my_node_num = 123456789
+        mock_connect.return_value = mock_client
+        self.plugin.config = {"display_hops": True}
+
+        packet = {
+            "decoded": {"text": "!ping"},
+            "channel": 0,
+            "fromId": "!12345678",
+            "to": BROADCAST_NUM,
+            "hopStart": 3,
+        }
+
+        async def run_test() -> None:
+            result = await self.plugin.handle_meshtastic_message(
+                packet, "formatted_message", "TestNode", "TestMesh"
+            )
+            self.assertTrue(result)
+            self.plugin.send_message.assert_called_once_with(
+                text="pong!", channel=0, reply_id=None
+            )
+
+        asyncio.run(run_test())
+
 
 class TestPingPluginEdgeCases(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary by Sourcery

Add an optional hop count suffix to ping replies and document the new configuration flag.

New Features:
- Add a configurable option to append hop count information to ping responses when enabled.

Documentation:
- Document the new ping plugin display_hops configuration option in the sample configuration file.