### PR TITLE
Migrate HTML sanitization from bleach to nh3

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.8.0
+      ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -18,25 +18,26 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.150.0
+    - pinact@4.0.0
+    - renovate@43.214.4
     - shellcheck@0.11.0
     - shfmt@3.6.0
-    - mypy@2.0.0
-    - pyright@1.1.409
+    - mypy@2.1.0
+    - pyright@1.1.410
     - dotenv-linter@4.0.0
     - hadolint@2.14.0
     - taplo@0.10.0
     - actionlint@1.7.12
     - bandit@1.9.4
-    - black@26.3.1
-    - checkov@3.2.527
+    - black@26.5.1
+    - checkov@3.2.533
     - git-diff-check
     - isort@8.0.1
     - markdownlint@0.48.0
-    - osv-scanner@2.3.6
+    - osv-scanner@2.3.8
     - prettier@3.8.3
-    - ruff@0.15.12
-    - trufflehog@3.95.2
+    - ruff@0.15.16
+    - trufflehog@3.95.5
     - yamllint@1.38.0
   definitions:
     - name: bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "matplotlib==3.10.9",
   "requests==2.34.2",
   "markdown==3.10.2",
-  "bleach==6.4.0",
+  "nh3==0.3.5",
   "haversine==2.9.0",
   "schedule==1.2.2",
   "platformdirs==4.10.0",

--- a/src/mmrelay/matrix/relay.py
+++ b/src/mmrelay/matrix/relay.py
@@ -293,13 +293,13 @@ async def matrix_relay(
 
         if has_markdown or has_html:
             try:
-                import bleach  # type: ignore[import-untyped]
                 import markdown
+                import nh3
 
                 raw_html = markdown.markdown(safe_message)
-                formatted_body = bleach.clean(
+                formatted_body = nh3.clean(
                     raw_html,
-                    tags=[
+                    tags={
                         "b",
                         "strong",
                         "i",
@@ -313,9 +313,8 @@ async def matrix_relay(
                         "ol",
                         "li",
                         "p",
-                    ],
-                    attributes={"a": ["href"]},
-                    strip=True,
+                    },
+                    attributes={"a": {"href"}},
                 )
                 plain_body = message
             except ImportError:

--- a/tests/test_matrix_utils_relay.py
+++ b/tests/test_matrix_utils_relay.py
@@ -340,7 +340,13 @@ async def test_matrix_relay_markdown_processing(
     }
 
     fake_markdown = SimpleNamespace(markdown=lambda _text: "<strong>bold</strong>")
-    fake_nh3 = SimpleNamespace(clean=lambda raw_html, **_kwargs: raw_html)
+    clean_kwargs: dict = {}
+
+    def fake_clean(raw_html, **kwargs):
+        clean_kwargs.update(kwargs)
+        return raw_html
+
+    fake_nh3 = SimpleNamespace(clean=fake_clean)
 
     with (
         patch("mmrelay.matrix_utils.config", config),
@@ -358,15 +364,32 @@ async def test_matrix_relay_markdown_processing(
     content = mock_client.room_send.call_args.kwargs["content"]
     assert content["formatted_body"] == "<strong>bold</strong>"
     assert content["body"] == "**bold**"
+    assert clean_kwargs["tags"] == {
+        "a",
+        "b",
+        "blockquote",
+        "br",
+        "code",
+        "em",
+        "i",
+        "li",
+        "ol",
+        "p",
+        "pre",
+        "strong",
+        "ul",
+    }
+    assert clean_kwargs["attributes"] == {"a": {"href"}}
 
 
+@pytest.mark.parametrize("missing_module", ["markdown", "nh3"])
 @patch("mmrelay.matrix_utils.connect_matrix")
 @patch("mmrelay.matrix_utils.get_interaction_settings")
 @patch("mmrelay.matrix_utils.message_storage_enabled", return_value=False)
 async def test_matrix_relay_importerror_fallback(
-    _mock_storage_enabled, mock_get_interactions, mock_connect_matrix
+    _mock_storage_enabled, mock_get_interactions, mock_connect_matrix, missing_module
 ):
-    """Markdown import errors should fall back to escaped HTML."""
+    """Import errors (either markdown or nh3) should fall back to escaped HTML."""
     mock_get_interactions.return_value = {"reactions": False, "replies": False}
 
     mock_client = MagicMock()
@@ -384,7 +407,7 @@ async def test_matrix_relay_importerror_fallback(
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name in ("markdown", "nh3"):
+        if name == missing_module:
             raise ImportError("missing")
         return real_import(name, *args, **kwargs)
 

--- a/tests/test_matrix_utils_relay.py
+++ b/tests/test_matrix_utils_relay.py
@@ -340,11 +340,11 @@ async def test_matrix_relay_markdown_processing(
     }
 
     fake_markdown = SimpleNamespace(markdown=lambda _text: "<strong>bold</strong>")
-    fake_bleach = SimpleNamespace(clean=lambda raw_html, **_kwargs: raw_html)
+    fake_nh3 = SimpleNamespace(clean=lambda raw_html, **_kwargs: raw_html)
 
     with (
         patch("mmrelay.matrix_utils.config", config),
-        patch.dict("sys.modules", {"markdown": fake_markdown, "bleach": fake_bleach}),
+        patch.dict("sys.modules", {"markdown": fake_markdown, "nh3": fake_nh3}),
     ):
         await matrix_relay(
             room_id="!room:matrix.org",
@@ -384,7 +384,7 @@ async def test_matrix_relay_importerror_fallback(
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name in ("markdown", "bleach"):
+        if name in ("markdown", "nh3"):
             raise ImportError("missing")
         return real_import(name, *args, **kwargs)
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR refactors the HTML sanitization layer in the matrix relay by replacing the `bleach` library (deprecated) with `nh3`. The change maintains the existing functionality while using a lighter-weight and maintained sanitization library.

## Key Changes

**Refactors**
- Updated `pyproject.toml` to replace `bleach==6.4.0` dependency with `nh3==0.3.5`
- Modified `src/mmrelay/matrix/relay.py` to use `nh3.clean()` instead of `bleach.clean()` for HTML sanitization during markdown-to-HTML conversion
- Adjusted the sanitization configuration to use `nh3`'s tag/attribute specification format (e.g., `a[href]` for allowed href attributes)
- Updated test mocks in `tests/test_matrix_utils_relay.py` to mock `nh3` module instead of `bleach`
- Updated the `ImportError` fallback behavior in tests to account for `nh3` import failures instead of `bleach` import failures

## Notes
The fallback behavior (escaping message content and converting newlines to `<br/>`) remains unchanged if the sanitization library is unavailable. The overall message processing logic and relay functionality are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->