### PR TITLE
Enable rotated Matrix device-key recovery for E2EE

### DIFF
--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -20,6 +20,11 @@ The legacy `matrix-nio` provider (with `python-olm`) is still technically
 usable if you manually replace mindroom-nio, but upstream matrix-nio is mostly
 inactive and mindroom-nio is recommended for all deployments.
 
+For encrypted sessions, MMRelay also enables mindroom-nio's rotated-device-key
+recovery policy. MMRelay uses trust on first use and never grants interactive
+verification trust to peer devices, so a valid peer identity rotation can
+replace stale Olm keys without preserving trust that the old keys earned.
+
 ### Legacy matrix-nio provider
 
 mindroom-nio is the default and recommended provider. Legacy matrix-nio

--- a/src/mmrelay/matrix/auth.py
+++ b/src/mmrelay/matrix/auth.py
@@ -185,11 +185,10 @@ def _initialize_matrix_client(
     Returns:
         AsyncClient: A configured AsyncClient instance ready for login and synchronization.
     """
-    client_config = facade.AsyncClientConfig(
+    client_config = facade._build_matrix_client_config(
+        e2ee_enabled=e2ee_enabled,
         max_limit_exceeded=0,
         max_timeouts=0,
-        store_sync_tokens=True,
-        encryption_enabled=e2ee_enabled,
     )
 
     if device_id:

--- a/src/mmrelay/matrix/auth.py
+++ b/src/mmrelay/matrix/auth.py
@@ -185,7 +185,7 @@ def _initialize_matrix_client(
     Returns:
         AsyncClient: A configured AsyncClient instance ready for login and synchronization.
     """
-    client_config = facade._build_matrix_client_config(
+    client_config = facade.build_matrix_client_config(
         e2ee_enabled=e2ee_enabled,
         max_limit_exceeded=0,
         max_timeouts=0,

--- a/src/mmrelay/matrix/client_config.py
+++ b/src/mmrelay/matrix/client_config.py
@@ -8,12 +8,12 @@ from nio import AsyncClientConfig
 
 from mmrelay.log_utils import get_logger
 
-__all__ = ["_build_matrix_client_config"]
+__all__ = ["build_matrix_client_config"]
 
 logger = get_logger(name="Matrix")
 
 
-def _build_matrix_client_config(
+def build_matrix_client_config(
     *,
     e2ee_enabled: bool,
     max_limit_exceeded: int | None = None,
@@ -45,10 +45,21 @@ def _build_matrix_client_config(
             encryption_enabled=e2ee_enabled,
         )
 
-    config_fields = getattr(type(config), "__dataclass_fields__", {})
-    if e2ee_enabled and "replace_rotated_device_keys" in config_fields:
+    if e2ee_enabled and hasattr(config, "replace_rotated_device_keys"):
+        try:
+            setattr(config, "replace_rotated_device_keys", True)
+        except (AttributeError, TypeError):
+            # Preserve compatibility with immutable dataclass-style providers
+            # without using dataclass internals as the capability check.
+            try:
+                config = replace(config, replace_rotated_device_keys=True)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Matrix provider exposes rotated device-key recovery but its "
+                    "client configuration could not be updated"
+                )
+                return config
         logger.debug(
             "Enabled rotated Matrix device-key recovery for MMRelay's TOFU E2EE policy"
         )
-        return replace(config, replace_rotated_device_keys=True)
     return config

--- a/src/mmrelay/matrix/client_config.py
+++ b/src/mmrelay/matrix/client_config.py
@@ -1,0 +1,54 @@
+"""Matrix client configuration shared by authentication and startup flows."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from nio import AsyncClientConfig
+
+from mmrelay.log_utils import get_logger
+
+__all__ = ["_build_matrix_client_config"]
+
+logger = get_logger(name="Matrix")
+
+
+def _build_matrix_client_config(
+    *,
+    e2ee_enabled: bool,
+    max_limit_exceeded: int | None = None,
+    max_timeouts: int | None = None,
+) -> AsyncClientConfig:
+    """Build a client config with MMRelay's E2EE trust policy.
+
+    MMRelay never grants interactive verification trust to peer devices. When
+    mindroom-nio exposes its opt-in rotated-device recovery policy, enable it
+    for encrypted sessions so a peer that legitimately recreates its identity
+    under the same device ID does not remain pinned to stale Olm keys.
+
+    Legacy matrix-nio providers do not expose the fork-specific field, so they
+    retain their default behavior.
+    """
+    if (max_limit_exceeded is None) != (max_timeouts is None):
+        raise ValueError("Matrix retry limits must be provided together")
+
+    if max_limit_exceeded is None:
+        config = AsyncClientConfig(
+            store_sync_tokens=True,
+            encryption_enabled=e2ee_enabled,
+        )
+    else:
+        config = AsyncClientConfig(
+            max_limit_exceeded=max_limit_exceeded,
+            max_timeouts=max_timeouts,
+            store_sync_tokens=True,
+            encryption_enabled=e2ee_enabled,
+        )
+
+    config_fields = getattr(type(config), "__dataclass_fields__", {})
+    if e2ee_enabled and "replace_rotated_device_keys" in config_fields:
+        logger.debug(
+            "Enabled rotated Matrix device-key recovery for MMRelay's TOFU E2EE policy"
+        )
+        return replace(config, replace_rotated_device_keys=True)
+    return config

--- a/src/mmrelay/matrix/client_config.py
+++ b/src/mmrelay/matrix/client_config.py
@@ -19,15 +19,20 @@ def build_matrix_client_config(
     max_limit_exceeded: int | None = None,
     max_timeouts: int | None = None,
 ) -> AsyncClientConfig:
-    """Build a client config with MMRelay's E2EE trust policy.
-
-    MMRelay never grants interactive verification trust to peer devices. When
-    mindroom-nio exposes its opt-in rotated-device recovery policy, enable it
-    for encrypted sessions so a peer that legitimately recreates its identity
-    under the same device ID does not remain pinned to stale Olm keys.
-
-    Legacy matrix-nio providers do not expose the fork-specific field, so they
-    retain their default behavior.
+    """
+    Build a Matrix client configuration with MMRelay's E2EE trust policy.
+    
+    Parameters:
+        e2ee_enabled (bool): Whether to enable end-to-end encryption.
+        max_limit_exceeded (int | None): Maximum limit-exceeded retries.
+        max_timeouts (int | None): Maximum timeout retries; must be provided
+            together with max_limit_exceeded.
+    
+    Returns:
+        AsyncClientConfig: The configured Matrix client settings.
+    
+    Raises:
+        ValueError: If only one retry limit is provided.
     """
     if (max_limit_exceeded is None) != (max_timeouts is None):
         raise ValueError("Matrix retry limits must be provided together")

--- a/src/mmrelay/matrix/client_config.py
+++ b/src/mmrelay/matrix/client_config.py
@@ -21,16 +21,16 @@ def build_matrix_client_config(
 ) -> AsyncClientConfig:
     """
     Build a Matrix client configuration with MMRelay's E2EE trust policy.
-    
+
     Parameters:
         e2ee_enabled (bool): Whether to enable end-to-end encryption.
         max_limit_exceeded (int | None): Maximum limit-exceeded retries.
         max_timeouts (int | None): Maximum timeout retries; must be provided
             together with max_limit_exceeded.
-    
+
     Returns:
         AsyncClientConfig: The configured Matrix client settings.
-    
+
     Raises:
         ValueError: If only one retry limit is provided.
     """
@@ -52,7 +52,9 @@ def build_matrix_client_config(
 
     if e2ee_enabled and hasattr(config, "replace_rotated_device_keys"):
         try:
-            setattr(config, "replace_rotated_device_keys", True)
+            # pyright cannot see that the dataclass attribute is read-only;
+            # the defensive try/except preserves PC's TOFU-compat pattern.
+            config.replace_rotated_device_keys = True  # type: ignore[reportAttributeAccessIssue]
         except (AttributeError, TypeError):
             # Preserve compatibility with immutable dataclass-style providers
             # without using dataclass internals as the capability check.

--- a/src/mmrelay/matrix/sync_bootstrap.py
+++ b/src/mmrelay/matrix/sync_bootstrap.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse
 
 from nio import (
     AsyncClient,
-    AsyncClientConfig,
     SyncError,
 )
 
@@ -801,9 +800,7 @@ async def login_matrix_bot(
         else:
             facade.logger.debug("E2EE disabled in configuration, not using store path")
 
-        client_config = AsyncClientConfig(
-            store_sync_tokens=True, encryption_enabled=e2ee_enabled
-        )
+        client_config = facade._build_matrix_client_config(e2ee_enabled=e2ee_enabled)
 
         localpart = facade._extract_localpart_from_mxid(username) or ""
         facade.logger.debug("Creating AsyncClient with:")

--- a/src/mmrelay/matrix/sync_bootstrap.py
+++ b/src/mmrelay/matrix/sync_bootstrap.py
@@ -800,7 +800,7 @@ async def login_matrix_bot(
         else:
             facade.logger.debug("E2EE disabled in configuration, not using store path")
 
-        client_config = facade._build_matrix_client_config(e2ee_enabled=e2ee_enabled)
+        client_config = facade.build_matrix_client_config(e2ee_enabled=e2ee_enabled)
 
         localpart = facade._extract_localpart_from_mxid(username) or ""
         facade.logger.debug("Creating AsyncClient with:")

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -364,7 +364,6 @@ from mmrelay.matrix.credentials import (
     _resolve_and_load_credentials,
     _resolve_credentials_save_path,
 )
-from mmrelay.matrix.client_config import _build_matrix_client_config
 from mmrelay.matrix.auth import (
     _close_matrix_client_after_failure,
     _configure_e2ee,
@@ -372,6 +371,7 @@ from mmrelay.matrix.auth import (
     _maybe_upload_e2ee_keys,
     _perform_matrix_login,
 )
+from mmrelay.matrix.client_config import build_matrix_client_config
 from mmrelay.matrix.sync_bootstrap import (
     _perform_initial_sync,
     _post_sync_setup,

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -364,6 +364,7 @@ from mmrelay.matrix.credentials import (
     _resolve_and_load_credentials,
     _resolve_credentials_save_path,
 )
+from mmrelay.matrix.client_config import _build_matrix_client_config
 from mmrelay.matrix.auth import (
     _close_matrix_client_after_failure,
     _configure_e2ee,

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -24,8 +24,6 @@ matrix:
   #
   e2ee:
     enabled: true
-    # Valid peer identity rotations replace stale keys under MMRelay's
-    # trust-on-first-use policy; interactively verified trust is never granted.
 
   # Message prefix customization (Meshtastic -> Matrix direction)
   #prefix_enabled: true # Enable prefixes on messages from mesh (e.g., "[Alice/MyMesh]: message")

--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -24,6 +24,8 @@ matrix:
   #
   e2ee:
     enabled: true
+    # Valid peer identity rotations replace stale keys under MMRelay's
+    # trust-on-first-use policy; interactively verified trust is never granted.
 
   # Message prefix customization (Meshtastic -> Matrix direction)
   #prefix_enabled: true # Enable prefixes on messages from mesh (e.g., "[Alice/MyMesh]: message")

--- a/tests/test_matrix_client_config.py
+++ b/tests/test_matrix_client_config.py
@@ -19,6 +19,22 @@ class _MindroomConfig:
     replace_rotated_device_keys: bool = False
 
 
+class _MutableNonDataclassConfig:
+    def __init__(
+        self,
+        *,
+        store_sync_tokens: bool = False,
+        encryption_enabled: bool = False,
+        max_limit_exceeded: int = 10,
+        max_timeouts: int = 3,
+    ) -> None:
+        self.store_sync_tokens = store_sync_tokens
+        self.encryption_enabled = encryption_enabled
+        self.max_limit_exceeded = max_limit_exceeded
+        self.max_timeouts = max_timeouts
+        self.replace_rotated_device_keys = False
+
+
 @dataclass(frozen=True)
 class _LegacyConfig:
     store_sync_tokens: bool = False
@@ -32,7 +48,7 @@ def test_e2ee_config_enables_rotated_device_key_recovery(
 ) -> None:
     monkeypatch.setattr(client_config, "AsyncClientConfig", _MindroomConfig)
 
-    config = matrix_utils._build_matrix_client_config(
+    config = matrix_utils.build_matrix_client_config(
         e2ee_enabled=True,
         max_limit_exceeded=0,
         max_timeouts=0,
@@ -45,12 +61,27 @@ def test_e2ee_config_enables_rotated_device_key_recovery(
     assert config.max_timeouts == 0
 
 
+def test_non_dataclass_provider_capability_is_detected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        client_config,
+        "AsyncClientConfig",
+        _MutableNonDataclassConfig,
+    )
+
+    config = matrix_utils.build_matrix_client_config(e2ee_enabled=True)
+
+    assert config.replace_rotated_device_keys is True
+    assert config.encryption_enabled is True
+
+
 def test_plaintext_config_preserves_rotated_device_key_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(client_config, "AsyncClientConfig", _MindroomConfig)
 
-    config = matrix_utils._build_matrix_client_config(e2ee_enabled=False)
+    config = matrix_utils.build_matrix_client_config(e2ee_enabled=False)
 
     assert config.encryption_enabled is False
     assert config.replace_rotated_device_keys is False
@@ -61,7 +92,7 @@ def test_legacy_provider_config_remains_supported(
 ) -> None:
     monkeypatch.setattr(client_config, "AsyncClientConfig", _LegacyConfig)
 
-    config = matrix_utils._build_matrix_client_config(e2ee_enabled=True)
+    config = matrix_utils.build_matrix_client_config(e2ee_enabled=True)
 
     assert config.encryption_enabled is True
     assert config.store_sync_tokens is True
@@ -70,7 +101,7 @@ def test_legacy_provider_config_remains_supported(
 
 def test_retry_limits_must_be_provided_together() -> None:
     with pytest.raises(ValueError, match="retry limits must be provided together"):
-        matrix_utils._build_matrix_client_config(
+        matrix_utils.build_matrix_client_config(
             e2ee_enabled=True,
             max_limit_exceeded=0,
         )

--- a/tests/test_matrix_client_config.py
+++ b/tests/test_matrix_client_config.py
@@ -1,0 +1,76 @@
+"""Tests for Matrix client construction policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+import mmrelay.matrix.client_config as client_config
+import mmrelay.matrix_utils as matrix_utils
+
+
+@dataclass(frozen=True)
+class _MindroomConfig:
+    store_sync_tokens: bool = False
+    encryption_enabled: bool = False
+    max_limit_exceeded: int = 10
+    max_timeouts: int = 3
+    replace_rotated_device_keys: bool = False
+
+
+@dataclass(frozen=True)
+class _LegacyConfig:
+    store_sync_tokens: bool = False
+    encryption_enabled: bool = False
+    max_limit_exceeded: int = 10
+    max_timeouts: int = 3
+
+
+def test_e2ee_config_enables_rotated_device_key_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_config, "AsyncClientConfig", _MindroomConfig)
+
+    config = matrix_utils._build_matrix_client_config(
+        e2ee_enabled=True,
+        max_limit_exceeded=0,
+        max_timeouts=0,
+    )
+
+    assert config.encryption_enabled is True
+    assert config.store_sync_tokens is True
+    assert config.replace_rotated_device_keys is True
+    assert config.max_limit_exceeded == 0
+    assert config.max_timeouts == 0
+
+
+def test_plaintext_config_preserves_rotated_device_key_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_config, "AsyncClientConfig", _MindroomConfig)
+
+    config = matrix_utils._build_matrix_client_config(e2ee_enabled=False)
+
+    assert config.encryption_enabled is False
+    assert config.replace_rotated_device_keys is False
+
+
+def test_legacy_provider_config_remains_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(client_config, "AsyncClientConfig", _LegacyConfig)
+
+    config = matrix_utils._build_matrix_client_config(e2ee_enabled=True)
+
+    assert config.encryption_enabled is True
+    assert config.store_sync_tokens is True
+    assert not hasattr(config, "replace_rotated_device_keys")
+
+
+def test_retry_limits_must_be_provided_together() -> None:
+    with pytest.raises(ValueError, match="retry limits must be provided together"):
+        matrix_utils._build_matrix_client_config(
+            e2ee_enabled=True,
+            max_limit_exceeded=0,
+        )

--- a/tests/test_matrix_client_config.py
+++ b/tests/test_matrix_client_config.py
@@ -30,12 +30,12 @@ class _MutableNonDataclassConfig:
     ) -> None:
         """
         Initialize Matrix client configuration settings.
-        
+
         Parameters:
-        	store_sync_tokens (bool): Whether to persist synchronization tokens.
-        	encryption_enabled (bool): Whether end-to-end encryption is enabled.
-        	max_limit_exceeded (int): Maximum number of rate-limit responses to retry.
-        	max_timeouts (int): Maximum number of timeout responses to retry.
+                store_sync_tokens (bool): Whether to persist synchronization tokens.
+                encryption_enabled (bool): Whether end-to-end encryption is enabled.
+                max_limit_exceeded (int): Maximum number of rate-limit responses to retry.
+                max_timeouts (int): Maximum number of timeout responses to retry.
         """
         self.store_sync_tokens = store_sync_tokens
         self.encryption_enabled = encryption_enabled

--- a/tests/test_matrix_client_config.py
+++ b/tests/test_matrix_client_config.py
@@ -28,6 +28,15 @@ class _MutableNonDataclassConfig:
         max_limit_exceeded: int = 10,
         max_timeouts: int = 3,
     ) -> None:
+        """
+        Initialize Matrix client configuration settings.
+        
+        Parameters:
+        	store_sync_tokens (bool): Whether to persist synchronization tokens.
+        	encryption_enabled (bool): Whether end-to-end encryption is enabled.
+        	max_limit_exceeded (int): Maximum number of rate-limit responses to retry.
+        	max_timeouts (int): Maximum number of timeout responses to retry.
+        """
         self.store_sync_tokens = store_sync_tokens
         self.encryption_enabled = encryption_enabled
         self.max_limit_exceeded = max_limit_exceeded

--- a/tests/test_matrix_utils_auth_e2ee.py
+++ b/tests/test_matrix_utils_auth_e2ee.py
@@ -473,7 +473,7 @@ async def test_connect_matrix_e2ee_windows_disables(monkeypatch):
     monkeypatch.setattr("mmrelay.matrix_utils.matrix_client", None, raising=False)
     config_factory = MagicMock()
     monkeypatch.setattr(
-        "mmrelay.matrix_utils._build_matrix_client_config", config_factory
+        "mmrelay.matrix_utils.build_matrix_client_config", config_factory
     )
     monkeypatch.setattr(
         "mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock(), raising=False

--- a/tests/test_matrix_utils_auth_e2ee.py
+++ b/tests/test_matrix_utils_auth_e2ee.py
@@ -458,8 +458,6 @@ async def test_on_decryption_failure_timeout_on_to_device():
 
 async def test_connect_matrix_e2ee_windows_disables(monkeypatch):
     """E2EE should be disabled on Windows platforms."""
-    import mmrelay.matrix_utils as mx
-
     mock_client = MagicMock()
     mock_client.rooms = {}
     mock_client.sync = AsyncMock(return_value=SimpleNamespace())
@@ -473,7 +471,10 @@ async def test_connect_matrix_e2ee_windows_disables(monkeypatch):
         "mmrelay.config.is_e2ee_enabled", lambda _cfg: True, raising=False
     )
     monkeypatch.setattr("mmrelay.matrix_utils.matrix_client", None, raising=False)
-    monkeypatch.setattr("mmrelay.matrix_utils.AsyncClientConfig", MagicMock())
+    config_factory = MagicMock()
+    monkeypatch.setattr(
+        "mmrelay.matrix_utils._build_matrix_client_config", config_factory
+    )
     monkeypatch.setattr(
         "mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock(), raising=False
     )
@@ -511,8 +512,11 @@ async def test_connect_matrix_e2ee_windows_disables(monkeypatch):
     ):
         await connect_matrix(config)
 
-    _, kwargs = mx.AsyncClientConfig.call_args  # type: ignore[attr-defined]
-    assert kwargs["encryption_enabled"] is False
+    config_factory.assert_called_once_with(
+        e2ee_enabled=False,
+        max_limit_exceeded=0,
+        max_timeouts=0,
+    )
 
 
 async def test_connect_matrix_e2ee_store_path_from_config(monkeypatch):

--- a/tests/test_mindroom_nio_runtime_contract.py
+++ b/tests/test_mindroom_nio_runtime_contract.py
@@ -8,8 +8,38 @@ import textwrap
 import tomllib
 from pathlib import Path
 
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
+
+
+def _single_mindroom_requirement(
+    dependencies: list[str], *, expected_extras: frozenset[str]
+) -> Requirement:
+    """Return the single mindroom-nio requirement for the requested extras."""
+    matches: list[Requirement] = []
+    for dependency in dependencies:
+        requirement = Requirement(dependency)
+        if (
+            canonicalize_name(requirement.name) == "mindroom-nio"
+            and frozenset(requirement.extras) == expected_extras
+        ):
+            matches.append(requirement)
+
+    assert len(matches) == 1, matches
+    return matches[0]
+
+
+def _exact_pin(requirement: Requirement) -> str:
+    """Return an exact version pin and reject ranges or environment markers."""
+    specifiers = list(requirement.specifier)
+    assert requirement.marker is None
+    assert len(specifiers) == 1, specifiers
+    specifier = specifiers[0]
+    assert specifier.operator == "=="
+    return specifier.version
 
 
 def _mindroom_pin() -> str:
@@ -17,27 +47,18 @@ def _mindroom_pin() -> str:
     with PYPROJECT.open("rb") as handle:
         project = tomllib.load(handle)["project"]
 
-    dependencies = project["dependencies"]
-    base_matches = [
-        dependency
-        for dependency in dependencies
-        if isinstance(dependency, str) and dependency.startswith("mindroom-nio==")
-    ]
-    assert base_matches == ["mindroom-nio==0.31.0"]
+    base_requirement = _single_mindroom_requirement(
+        project["dependencies"], expected_extras=frozenset()
+    )
+    e2e_requirement = _single_mindroom_requirement(
+        project["optional-dependencies"]["e2e"],
+        expected_extras=frozenset({"e2e"}),
+    )
 
-    optional_dependencies = project["optional-dependencies"]
-    e2e_dependencies = optional_dependencies["e2e"]
-    e2e_matches = [
-        dependency
-        for dependency in e2e_dependencies
-        if isinstance(dependency, str)
-        and dependency.startswith("mindroom-nio[e2e]==")
-    ]
-    assert e2e_matches == ["mindroom-nio[e2e]==0.31.0"]
-
-    base_version = base_matches[0].partition("==")[2]
-    e2e_version = e2e_matches[0].partition("==")[2]
-    assert base_version == e2e_version
+    base_version = _exact_pin(base_requirement)
+    e2e_version = _exact_pin(e2e_requirement)
+    assert base_version == "0.31.0"
+    assert e2e_version == base_version
     return base_version
 
 
@@ -121,6 +142,7 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
         check=False,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
     assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/test_mindroom_nio_runtime_contract.py
+++ b/tests/test_mindroom_nio_runtime_contract.py
@@ -20,13 +20,13 @@ def _single_mindroom_requirement(
 ) -> Requirement:
     """
     Find the single `mindroom-nio` requirement matching the requested extras.
-    
+
     Parameters:
-    	dependencies (list[str]): Dependency requirement strings to inspect.
-    	expected_extras (frozenset[str]): Extras that the matching requirement must specify.
-    
+        dependencies (list[str]): Dependency requirement strings to inspect.
+        expected_extras (frozenset[str]): Extras that the matching requirement must specify.
+
     Returns:
-    	Requirement: The matching `mindroom-nio` requirement.
+        Requirement: The matching `mindroom-nio` requirement.
     """
     matches: list[Requirement] = []
     for dependency in dependencies:
@@ -54,9 +54,9 @@ def _exact_pin(requirement: Requirement) -> str:
 def _mindroom_pin() -> str:
     """
     Determine the pinned version shared by the base and E2EE `mindroom-nio` dependencies.
-    
+
     Returns:
-    	str: The shared pinned `mindroom-nio` version.
+        str: The shared pinned `mindroom-nio` version.
     """
     with PYPROJECT.open("rb") as handle:
         project = tomllib.load(handle)["project"]
@@ -80,8 +80,7 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
     """Exercise the real provider outside MMRelay's in-process dependency mocks."""
 
     expected_version = _mindroom_pin()
-    script = textwrap.dedent(
-        f"""
+    script = textwrap.dedent(f"""
         from importlib import metadata
         from inspect import Parameter, signature
 
@@ -148,8 +147,7 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
         )
         signature_value = vodozemac.Ed25519Signature.from_base64(signature_b64)
         public_key.verify_signature(message, signature_value)
-        """
-    )
+        """)
 
     result = subprocess.run(
         [sys.executable, "-I", "-c", script],

--- a/tests/test_mindroom_nio_runtime_contract.py
+++ b/tests/test_mindroom_nio_runtime_contract.py
@@ -18,7 +18,16 @@ PYPROJECT = ROOT / "pyproject.toml"
 def _single_mindroom_requirement(
     dependencies: list[str], *, expected_extras: frozenset[str]
 ) -> Requirement:
-    """Return the single mindroom-nio requirement for the requested extras."""
+    """
+    Find the single `mindroom-nio` requirement matching the requested extras.
+    
+    Parameters:
+    	dependencies (list[str]): Dependency requirement strings to inspect.
+    	expected_extras (frozenset[str]): Extras that the matching requirement must specify.
+    
+    Returns:
+    	Requirement: The matching `mindroom-nio` requirement.
+    """
     matches: list[Requirement] = []
     for dependency in dependencies:
         requirement = Requirement(dependency)
@@ -43,7 +52,12 @@ def _exact_pin(requirement: Requirement) -> str:
 
 
 def _mindroom_pin() -> str:
-    """Return the single version used by the base and E2EE dependency sets."""
+    """
+    Determine the pinned version shared by the base and E2EE `mindroom-nio` dependencies.
+    
+    Returns:
+    	str: The shared pinned `mindroom-nio` version.
+    """
     with PYPROJECT.open("rb") as handle:
         project = tomllib.load(handle)["project"]
 


### PR DESCRIPTION
## Overview

This PR enables mindroom-nio's opt-in rotated device-key recovery for encrypted MMRelay clients. MMRelay uses a trust-on-first-use policy and does not grant interactive verification trust, so accepting a validly self-signed replacement identity prevents a reused Matrix device ID from remaining pinned to stale Olm keys.

## Key changes

### Features

* Enable `replace_rotated_device_keys` for encrypted sessions when the active Matrix provider exposes that capability.
* Leave plaintext clients and legacy matrix-nio providers unchanged.

### Refactors

* Centralize Matrix `AsyncClientConfig` creation in the public `build_matrix_client_config` helper used by authentication and startup flows.
* Detect provider support from the constructed configuration object rather than relying on dataclass internals.
* Support mutable non-dataclass and immutable dataclass-style provider configurations while preserving existing retry defaults.

### Tests

* Cover encrypted and plaintext sessions, current and legacy providers, mutable non-dataclass configurations, immutable configurations, retry-limit validation, and Windows E2EE disabling.

## Breaking changes / migration notes

* No public MMRelay API or user configuration is added or removed.
* The policy is enabled only for E2EE and remains tied to MMRelay's existing trust-on-first-use behavior.

## Summary by Sourcery

Enable rotated Matrix device-key recovery for encrypted sessions while centralizing Matrix client configuration construction and preserving compatibility with legacy providers.

New Features:
- Enable mindroom-nio rotated-device-key recovery for E2EE sessions when the Matrix provider supports it.

Enhancements:
- Introduce a shared Matrix client configuration builder used by authentication and startup flows, including retry limit handling and provider capability detection.
- Support both mutable and immutable AsyncClientConfig implementations while maintaining existing defaults and behavior.
- Increase the robustness of dependency contract checks for mindroom-nio versions and extras.

Documentation:
- Document the rotated-device-key recovery behavior and its interaction with MMRelay's trust-on-first-use E2EE policy.

Tests:
- Add tests covering the new client configuration builder across provider types, retry-limit validation, and Windows E2EE behavior.
- Tighten the runtime contract test ensuring consistent mindroom-nio base and E2EE dependency pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds opt-in rotated Matrix device-key recovery for encrypted MMRelay clients using mindroom-nio, while preserving existing behavior for plaintext sessions and legacy providers. Matrix client configuration is centralized, provider capabilities are detected safely, and retry settings remain compatible.

### Key changes

**Features**
- Enable `replace_rotated_device_keys` for encrypted sessions when supported by the configured provider.
- Support both mutable and immutable provider configuration objects.
- Document the E2EE trust policy and rotated-key recovery behavior.

**Refactors**
- Centralize `AsyncClientConfig` creation in `build_matrix_client_config`.
- Use the shared configuration builder during authentication and sync bootstrap.
- Preserve token storage, encryption settings, and retry-limit configuration.
- Detect provider support from the constructed configuration rather than assuming a specific provider implementation.

**Fixes and tests**
- Maintain compatibility with legacy providers that lack rotated-key recovery.
- Preserve defaults for plaintext sessions.
- Validate that retry limits are provided together.
- Update Windows E2EE tests to use the configuration builder.
- Strengthen mindroom-nio version contract checks and add a runtime timeout.

No breaking changes or migration steps are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->