### PR TITLE
Raise minimum Python to 3.11 and align CI, tooling, and docs

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -33,8 +33,9 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-pip-
             ${{ runner.os }}-pip-
 
       - name: Install dependencies

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[test]'
+          pip install -e '.[test,e2e]'
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -22,15 +22,15 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: jeremiah-k/meshtastic-matrix-relay
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,3 +1,5 @@
+target-version = "py311"
+
 # Generic, formatter-friendly config.
 select = ["B", "D3", "E", "F"]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 
 - **Imports**: Use isort with black profile (already configured)
 - **Formatting**: Black formatter with 88-character line length
-- **Types**: Use type hints consistently (Python 3.10+)
+- **Types**: Use type hints consistently (Python 3.11+)
 - **Naming**: snake_case for functions/variables, PascalCase for classes
 - **Error handling**: Use specific exceptions, avoid bare except clauses
 - **Logging**: Use structured logging via log_utils.get_logger()

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -158,7 +158,7 @@ session: you need to log in again and re-verify devices.
 
 ## Requirements and platform support
 
-- **Python 3.10 or higher**
+- **Python 3.11 or higher**
 - **Linux or macOS** (E2EE is not supported on Windows due to library
   limitations)
 - **MMRelay v1.2+** with E2EE support:

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # MMRelay Instructions
 
-MMRelay works on Linux, macOS, and Windows and requires Python 3.10+.
+MMRelay works on Linux, macOS, and Windows and requires Python 3.11+.
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,6 @@ docs/
 ## Version Information
 
 - **Current Version**: v1.3+
-- **Python Requirement**: 3.10+
+- **Python Requirement**: 3.11+
 - **Supported Platforms**: Linux, macOS, Windows (E2EE not available on Windows)
 - **Key Features**: Meshtastic ↔ Matrix relay, encrypted Matrix rooms (Matrix E2EE), Docker deployment, Plugin system

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Welcome to the MMRelay documentation! This directory contains comprehensive guid
 
 ## Release-Specific Documents
 
+- **[What's New in 1.4.0](WHATS_NEW_1.4.md)** - Python 3.11 minimum and upgrade guidance
 - **[What's New in 1.3.0](WHATS_NEW_1.3.md)** - Release summary and changes overview
 - **[What's New in 1.2](WHATS_NEW_1.2.md)** - Previous release notes (historical)
 
@@ -41,6 +42,7 @@ docs/
 ├── README.md                 # This file - documentation index
 ├── INSTRUCTIONS.md           # Main installation and setup guide
 ├── MIGRATION_1.3.md         # Migration guide for upgrading from older versions
+├── WHATS_NEW_1.4.md          # 1.4 runtime-support changes
 ├── WHATS_NEW_1.3.md          # 1.3 release summary
 ├── WHATS_NEW_1.2.md          # 1.2 release notes (historical)
 ├── E2EE.md                  # End-to-End Encryption guide
@@ -73,7 +75,7 @@ docs/
 
 ## Version Information
 
-- **Current Version**: v1.3+
-- **Python Requirement**: 3.11+
+- **Next Release**: v1.4.0
+- **Python Requirement (v1.4+)**: 3.11+
 - **Supported Platforms**: Linux, macOS, Windows (E2EE not available on Windows)
 - **Key Features**: Meshtastic ↔ Matrix relay, encrypted Matrix rooms (Matrix E2EE), Docker deployment, Plugin system

--- a/docs/WHATS_NEW_1.4.md
+++ b/docs/WHATS_NEW_1.4.md
@@ -1,0 +1,34 @@
+# What's New in 1.4.0
+
+MMRelay 1.4.0 raises the minimum supported Python version to 3.11.
+
+## Why the Python floor changed
+
+Matplotlib 3.11 requires Python 3.11 or newer. MMRelay uses Matplotlib for
+telemetry graphs, so retaining Python 3.10 in the package metadata would
+advertise an environment that cannot install MMRelay's required dependencies.
+The map plugin is unaffected; it uses py-staticmaps and Pillow rather than
+Matplotlib.
+
+Python 3.10 is also in security-fix-only maintenance and reaches end of life in
+October 2026. Moving the floor now keeps MMRelay aligned with its actively
+maintained dependency stack and removes Python 3.10-only compatibility code.
+
+## Upgrade guidance
+
+Before installing MMRelay 1.4.0 or newer, upgrade the runtime to Python 3.11 or
+newer and recreate the virtual environment or pipx installation so compiled
+packages are installed for the new interpreter.
+
+Python 3.10 systems can remain on the final MMRelay 1.3.x release. Operators who
+need a custom dependency set may continue to install and maintain an older
+source checkout, but that environment is outside the supported 1.4 release
+matrix.
+
+## Maintainer notes
+
+- Package metadata, runtime checks, mypy, Windows guidance, and CI all use the
+  same Python 3.11 minimum.
+- Matplotlib is updated to 3.11.1 after the Python floor change.
+- The Python 3.10 fallback parser in the source-checkout version helper is
+  removed in favor of the Python 3.11 standard-library `tomllib` module.

--- a/docs/dev/TESTING_GUIDE.md
+++ b/docs/dev/TESTING_GUIDE.md
@@ -74,7 +74,7 @@ def test_handle_auth_logout_keyboard_interrupt(self, mock_print, mock_logout):
 
 ### Coroutine Leak Prevention Patterns
 
-Some failures only show up on certain Python versions (commonly 3.10/3.11/3.13+) as:
+Some failures only show up on certain Python versions (commonly 3.11/3.12/3.13+) as:
 
 ```text
 PytestUnraisableExceptionWarning: coroutine ... was never awaited

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 python_version = 3.11
 mypy_path = src
 incremental = False
+follow_imports_for_stubs = True
 
 [mypy-requests.*]
 ignore_missing_imports = True
@@ -32,3 +33,9 @@ ignore_missing_imports = True
 
 [mypy-markdown.*]
 ignore_missing_imports = True
+
+[mypy-matplotlib.*]
+follow_imports = skip
+
+[mypy-numpy.*]
+follow_imports = skip

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.11
 mypy_path = src
 incremental = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,12 @@ name = "mmrelay"
 version = "1.3.8"
 description = "Bridge between Meshtastic mesh networks and Matrix chat rooms"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "GPL-3.0-or-later"
 authors = [{ name = "Geoff Whittington" }, { name = "Jeremiah K." }]
 maintainers = [{ name = "Jeremiah K.", email = "jeremiahk@gmx.com" }]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "Pillow==12.3.0",
   "aiohttp==3.14.3",
   "mindroom-nio==0.31.0",
-  "matplotlib==3.10.9",
+  "matplotlib==3.11.1",
   "requests==2.34.2",
   "markdown==3.10.2",
   "nh3==0.3.6",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,12 +1,7 @@
 {
   "venvPath": ".",
   "venv": "venv",
-  "include": [
-    "src",
-    "scripts"
-  ],
-  "exclude": [
-    "tests"
-  ],
+  "include": ["src", "scripts"],
+  "exclude": ["tests"],
   "pythonVersion": "3.11"
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,6 +1,12 @@
 {
   "venvPath": ".",
   "venv": "venv",
-  "include": ["src", "scripts"],
-  "exclude": ["tests"]
+  "include": [
+    "src",
+    "scripts"
+  ],
+  "exclude": [
+    "tests"
+  ],
+  "pythonVersion": "3.11"
 }

--- a/src/mmrelay/_version.py
+++ b/src/mmrelay/_version.py
@@ -4,7 +4,7 @@ Version helpers with source-checkout fallback support.
 
 from __future__ import annotations
 
-import re
+import tomllib
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as metadata_version
 from pathlib import Path
@@ -12,14 +12,6 @@ from typing import Final
 
 _PACKAGE_NAME: Final[str] = "mmrelay"
 _UNKNOWN_VERSION: Final[str] = "0+unknown"
-_PROJECT_VERSION_RE: Final[re.Pattern[str]] = re.compile(
-    r"""^version\s*=\s*["'](?P<version>[^"']+)["']\s*(?:#.*)?$"""
-)
-
-try:
-    import tomllib  # type: ignore[import-not-found]  # Python 3.11+
-except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback path
-    tomllib = None  # pyright: ignore[reportAssignmentType]
 
 
 def _version_from_metadata() -> str | None:
@@ -53,33 +45,15 @@ def _version_from_pyproject() -> str | None:
         return None
 
     try:
-        if tomllib is not None:
-            with pyproject.open("rb") as handle:
-                data = tomllib.load(handle)
-            project = data.get("project")
-            if not isinstance(project, dict):
-                return None
-            version = project.get("version")
-            if isinstance(version, str):
-                normalized = version.strip()
-                return normalized or None
+        with pyproject.open("rb") as handle:
+            data = tomllib.load(handle)
+        project = data.get("project")
+        if not isinstance(project, dict):
             return None
-
-        # Python 3.10 fallback: parse only [project] version entry.
-        in_project_section = False
-        for line in pyproject.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#"):
-                continue
-            if stripped.startswith("[") and stripped.endswith("]"):
-                in_project_section = stripped == "[project]"
-                continue
-            if not in_project_section:
-                continue
-            match = _PROJECT_VERSION_RE.match(stripped)
-            if match:
-                normalized = match.group("version").strip()
-                return normalized or None
+        version = project.get("version")
+        if isinstance(version, str):
+            normalized = version.strip()
+            return normalized or None
     except (OSError, UnicodeError, ValueError):
         return None
 

--- a/src/mmrelay/constants/app.py
+++ b/src/mmrelay/constants/app.py
@@ -56,7 +56,7 @@ SECURE_FILE_PERMISSIONS: Final[int] = 0o600
 SECURE_DIR_PERMISSIONS: Final[int] = 0o700
 
 # Version requirements
-MIN_PYTHON_VERSION: Final[tuple[int, int]] = (3, 10)
+MIN_PYTHON_VERSION: Final[tuple[int, int]] = (3, 11)
 
 # Windows-specific constants
 WINDOWS_VTP_FLAG: Final[int] = 0x0004  # ENABLE_VIRTUAL_TERMINAL_PROCESSING

--- a/tests/test_main_check_connection.py
+++ b/tests/test_main_check_connection.py
@@ -37,7 +37,7 @@ def _find_check_conn_tasks(
 ) -> tuple[list[Any], list[str]]:
     """Find check_connection tasks from a list of _TaskSpy objects.
 
-    NOTE: Task introspection relies on CPython 3.10+ coroutine internals.
+    NOTE: Task introspection relies on CPython 3.11+ coroutine internals.
     """
     check_conn_tasks = []
     observed_coro_names: list[str] = []
@@ -438,7 +438,7 @@ def test_cancelled_error_cancels_task_and_returns():
 
     async def mock_wait_for(coro, timeout=None):
         if timeout == 5.0:
-            # NOTE: Task introspection relies on CPython 3.10+ coroutine internals.
+            # NOTE: Task introspection relies on CPython 3.11+ coroutine internals.
             # If Python changes these, fallback to checking task names via get_name().
             # Peek inside asyncio wrappers (gather, etc.) to find the
             # target coroutine name using CPython internals with defensive

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -1,3 +1,4 @@
+import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -38,11 +39,6 @@ def _patch_detection(
 
 def _read_pyproject_deps() -> dict[str, object]:
     """Read pyproject.toml and extract dependencies and optional-dependencies."""
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib  # type: ignore[no-redef]
-
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject_path.open("rb") as f:
         data = tomllib.load(f)

--- a/tests/test_python_support_policy.py
+++ b/tests/test_python_support_policy.py
@@ -1,0 +1,49 @@
+"""Regression tests for MMRelay's supported Python runtime contract."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from mmrelay.constants.app import MIN_PYTHON_VERSION
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+TEST_WORKFLOW = ROOT / ".github" / "workflows" / "test-and-coverage.yml"
+
+
+def _project_metadata() -> dict[str, object]:
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    project = data.get("project")
+    assert isinstance(project, dict)
+    return project
+
+
+def test_python_311_floor_is_consistent_across_runtime_and_metadata() -> None:
+    project = _project_metadata()
+
+    assert project["requires-python"] == ">=3.11"
+    assert MIN_PYTHON_VERSION == (3, 11)
+
+    classifiers = project.get("classifiers")
+    assert isinstance(classifiers, list)
+    assert "Programming Language :: Python :: 3.10" not in classifiers
+    for minor in range(11, 15):
+        assert f"Programming Language :: Python :: 3.{minor}" in classifiers
+
+
+def test_supported_ci_matrix_runs_real_e2ee_dependencies() -> None:
+    workflow = TEST_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'python-version: ["3.11", "3.12", "3.13", "3.14"]' in workflow
+    assert 'python-version: ["3.10"' not in workflow
+    assert "pip install -e '.[test,e2e]'" in workflow
+
+
+def test_matplotlib_pin_matches_the_python_311_dependency_line() -> None:
+    project = _project_metadata()
+    dependencies = project.get("dependencies")
+
+    assert isinstance(dependencies, list)
+    assert "matplotlib==3.11.1" in dependencies

--- a/tests/test_python_support_policy.py
+++ b/tests/test_python_support_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tomllib
 from pathlib import Path
 
@@ -10,6 +11,9 @@ from mmrelay.constants.app import MIN_PYTHON_VERSION
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
 TEST_WORKFLOW = ROOT / ".github" / "workflows" / "test-and-coverage.yml"
+MYPY_CONFIG = ROOT / "mypy.ini"
+PYRIGHT_CONFIG = ROOT / "pyrightconfig.json"
+RUFF_CONFIG = ROOT / ".trunk" / "configs" / "ruff.toml"
 
 
 def _project_metadata() -> dict[str, object]:
@@ -39,6 +43,18 @@ def test_supported_ci_matrix_runs_real_e2ee_dependencies() -> None:
     assert 'python-version: ["3.11", "3.12", "3.13", "3.14"]' in workflow
     assert 'python-version: ["3.10"' not in workflow
     assert "pip install -e '.[test,e2e]'" in workflow
+
+    assert "py${{ matrix.python-version }}-pip-" in workflow
+
+
+def test_static_analysis_targets_the_minimum_supported_python() -> None:
+    mypy_config = MYPY_CONFIG.read_text(encoding="utf-8")
+    pyright_config = json.loads(PYRIGHT_CONFIG.read_text(encoding="utf-8"))
+    ruff_config = RUFF_CONFIG.read_text(encoding="utf-8")
+
+    assert "python_version = 3.11" in mypy_config
+    assert pyright_config["pythonVersion"] == "3.11"
+    assert 'target-version = "py311"' in ruff_config
 
 
 def test_matplotlib_pin_matches_the_python_311_dependency_line() -> None:

--- a/tests/test_python_support_policy.py
+++ b/tests/test_python_support_policy.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import configparser
 import json
+import shlex
 import tomllib
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 from mmrelay.constants.app import MIN_PYTHON_VERSION
 
@@ -15,6 +21,9 @@ MYPY_CONFIG = ROOT / "mypy.ini"
 PYRIGHT_CONFIG = ROOT / "pyrightconfig.json"
 RUFF_CONFIG = ROOT / ".trunk" / "configs" / "ruff.toml"
 
+_PYTHON_CLASSIFIER_PREFIX = "Programming Language :: Python :: "
+_MATRIX_EXPRESSION = "${{ matrix.python-version }}"
+
 
 def _project_metadata() -> dict[str, object]:
     with PYPROJECT.open("rb") as handle:
@@ -24,37 +33,162 @@ def _project_metadata() -> dict[str, object]:
     return project
 
 
-def test_python_311_floor_is_consistent_across_runtime_and_metadata() -> None:
-    project = _project_metadata()
+def _test_job() -> dict[str, Any]:
+    workflow = yaml.safe_load(TEST_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get("test")
+    assert isinstance(job, dict)
+    return job
 
-    assert project["requires-python"] == ">=3.11"
-    assert MIN_PYTHON_VERSION == (3, 11)
 
+def _python_classifiers(project: Mapping[str, object]) -> tuple[tuple[int, int], ...]:
     classifiers = project.get("classifiers")
     assert isinstance(classifiers, list)
-    assert "Programming Language :: Python :: 3.10" not in classifiers
-    for minor in range(11, 15):
-        assert f"Programming Language :: Python :: 3.{minor}" in classifiers
+
+    versions: list[tuple[int, int]] = []
+    for classifier in classifiers:
+        if not isinstance(classifier, str):
+            continue
+        value = classifier.removeprefix(_PYTHON_CLASSIFIER_PREFIX)
+        if value == classifier:
+            continue
+        components = value.split(".")
+        if len(components) != 2 or not all(part.isdigit() for part in components):
+            continue
+        versions.append((int(components[0]), int(components[1])))
+
+    assert versions, "No minor-version Python classifiers are declared"
+    assert len(versions) == len(set(versions)), "Duplicate Python classifiers"
+    return tuple(sorted(versions))
 
 
-def test_supported_ci_matrix_runs_real_e2ee_dependencies() -> None:
-    workflow = TEST_WORKFLOW.read_text(encoding="utf-8")
+def _matrix_python_versions(job: Mapping[str, object]) -> tuple[tuple[int, int], ...]:
+    strategy = job.get("strategy")
+    assert isinstance(strategy, dict)
+    matrix = strategy.get("matrix")
+    assert isinstance(matrix, dict)
+    raw_versions = matrix.get("python-version")
+    assert isinstance(raw_versions, list)
 
-    assert 'python-version: ["3.11", "3.12", "3.13", "3.14"]' in workflow
-    assert 'python-version: ["3.10"' not in workflow
-    assert "pip install -e '.[test,e2e]'" in workflow
+    versions: list[tuple[int, int]] = []
+    for raw_version in raw_versions:
+        major, separator, minor = str(raw_version).partition(".")
+        assert separator and major.isdigit() and minor.isdigit(), raw_version
+        versions.append((int(major), int(minor)))
+    assert len(versions) == len(set(versions)), "Duplicate Python versions in CI matrix"
+    return tuple(sorted(versions))
 
-    assert "py${{ matrix.python-version }}-pip-" in workflow
+
+def _workflow_steps(job: Mapping[str, object]) -> tuple[dict[str, Any], ...]:
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    parsed_steps = tuple(step for step in steps if isinstance(step, dict))
+    assert len(parsed_steps) == len(steps), "Every workflow step must be a mapping"
+    return parsed_steps
+
+
+def _step_using(job: Mapping[str, object], action: str) -> dict[str, Any]:
+    matches = [
+        step
+        for step in _workflow_steps(job)
+        if str(step.get("uses", "")).startswith(f"{action}@")
+    ]
+    assert len(matches) == 1, f"Expected exactly one workflow step using {action}"
+    return matches[0]
+
+
+def _cache_step(job: Mapping[str, object], path: str) -> dict[str, Any]:
+    matches: list[dict[str, Any]] = []
+    for step in _workflow_steps(job):
+        if not str(step.get("uses", "")).startswith("actions/cache@"):
+            continue
+        options = step.get("with")
+        if isinstance(options, dict) and options.get("path") == path:
+            matches.append(step)
+    assert len(matches) == 1, f"Expected exactly one cache step for {path}"
+    return matches[0]
+
+
+def _editable_install_extras(script: str) -> set[str]:
+    """Return extras requested by the script's editable project install."""
+    for raw_line in script.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        arguments = shlex.split(line)
+        if "install" not in arguments or "-e" not in arguments:
+            continue
+        editable_index = arguments.index("-e")
+        assert editable_index + 1 < len(arguments)
+        target = arguments[editable_index + 1]
+        if not target.startswith(".[") or not target.endswith("]"):
+            continue
+        return {extra.strip() for extra in target[2:-1].split(",") if extra.strip()}
+    return set()
+
+
+def test_python_floor_is_consistent_across_runtime_and_metadata() -> None:
+    project = _project_metadata()
+    floor_text = ".".join(str(component) for component in MIN_PYTHON_VERSION)
+
+    assert project["requires-python"] == f">={floor_text}"
+
+    declared_versions = _python_classifiers(project)
+    assert min(declared_versions) == MIN_PYTHON_VERSION
+    assert all(major == MIN_PYTHON_VERSION[0] for major, _minor in declared_versions)
+
+    highest_minor = max(minor for _major, minor in declared_versions)
+    expected_versions = tuple(
+        (MIN_PYTHON_VERSION[0], minor)
+        for minor in range(MIN_PYTHON_VERSION[1], highest_minor + 1)
+    )
+    assert declared_versions == expected_versions
+
+
+def test_supported_ci_matrix_matches_declared_versions_and_runs_e2ee() -> None:
+    project = _project_metadata()
+    job = _test_job()
+
+    assert _matrix_python_versions(job) == _python_classifiers(project)
+
+    setup_step = _step_using(job, "actions/setup-python")
+    setup_options = setup_step.get("with")
+    assert isinstance(setup_options, dict)
+    assert setup_options.get("python-version") == _MATRIX_EXPRESSION
+
+    assert any(
+        _editable_install_extras(script) >= {"test", "e2e"}
+        for step in _workflow_steps(job)
+        if isinstance((script := step.get("run")), str)
+    )
+
+    cache_step = _cache_step(job, "~/.cache/pip")
+    cache_options = cache_step.get("with")
+    assert isinstance(cache_options, dict)
+    assert _MATRIX_EXPRESSION in str(cache_options.get("key", ""))
+
+    restore_keys = cache_options.get("restore-keys")
+    assert isinstance(restore_keys, str)
+    assert any(
+        _MATRIX_EXPRESSION in line for line in restore_keys.splitlines() if line.strip()
+    )
 
 
 def test_static_analysis_targets_the_minimum_supported_python() -> None:
-    mypy_config = MYPY_CONFIG.read_text(encoding="utf-8")
-    pyright_config = json.loads(PYRIGHT_CONFIG.read_text(encoding="utf-8"))
-    ruff_config = RUFF_CONFIG.read_text(encoding="utf-8")
+    floor_text = ".".join(str(component) for component in MIN_PYTHON_VERSION)
 
-    assert "python_version = 3.11" in mypy_config
-    assert pyright_config["pythonVersion"] == "3.11"
-    assert 'target-version = "py311"' in ruff_config
+    mypy_config = configparser.ConfigParser()
+    assert mypy_config.read(MYPY_CONFIG, encoding="utf-8") == [str(MYPY_CONFIG)]
+    assert mypy_config["mypy"].get("python_version") == floor_text
+
+    pyright_config = json.loads(PYRIGHT_CONFIG.read_text(encoding="utf-8"))
+    assert pyright_config["pythonVersion"] == floor_text
+
+    with RUFF_CONFIG.open("rb") as handle:
+        ruff_config = tomllib.load(handle)
+    assert ruff_config["target-version"] == f"py{floor_text.replace('.', '')}"
 
 
 def test_matplotlib_pin_matches_the_python_311_dependency_line() -> None:

--- a/tests/test_tools_init.py
+++ b/tests/test_tools_init.py
@@ -11,14 +11,14 @@ class TestToolsInit(unittest.TestCase):
     """Test cases for tools/__init__.py functions."""
 
     def test_get_sample_config_path_modern_python(self):
-        """Test get_sample_config_path with modern Python (3.10+)."""
+        """Test get_sample_config_path with modern Python (3.11+)."""
         # This should work on modern Python versions
         path = get_sample_config_path()
         self.assertIsInstance(path, str)
         self.assertIn("sample_config.yaml", path)
 
     def test_get_service_template_path_modern_python(self):
-        """Test get_service_template_path with modern Python (3.10+)."""
+        """Test get_service_template_path with modern Python (3.11+)."""
         # This should work on modern Python versions
         path = get_service_template_path()
         self.assertIsInstance(path, str)

--- a/tests/test_version_helper.py
+++ b/tests/test_version_helper.py
@@ -2,7 +2,7 @@
 Tests for shared version helper behavior.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import mmrelay._version as version_helper
 
@@ -53,62 +53,18 @@ def test_version_from_pyproject_reads_real_toml(tmp_path) -> None:
         assert version_helper._version_from_pyproject() == "4.5.6"
 
 
-def test_version_from_pyproject_regex_fallback_without_tomllib(tmp_path) -> None:
-    """
-    Python 3.10 fallback should parse version when tomllib is unavailable.
-    """
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(
-        '[project]\nname = "mmrelay"\nversion = "7.8.9"\n',
-        encoding="utf-8",
-    )
-    with (
-        patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject),
-        patch.object(version_helper, "tomllib", new=None),
-    ):
-        assert version_helper._version_from_pyproject() == "7.8.9"
-
-
-def test_version_from_pyproject_regex_fallback_allows_inline_comment(tmp_path) -> None:
-    """
-    Python 3.10 fallback should parse version lines with inline comments.
-    """
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(
-        '[project]\nname = "mmrelay"\nversion = "7.8.9"  # comment\n',
-        encoding="utf-8",
-    )
-    with (
-        patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject),
-        patch.object(version_helper, "tomllib", new=None),
-    ):
-        assert version_helper._version_from_pyproject() == "7.8.9"
-
-
-def test_version_from_pyproject_tomllib_missing_version_does_not_fallback(
+def test_version_from_pyproject_returns_none_when_project_version_is_missing(
     tmp_path,
 ) -> None:
     """
-    When tomllib is available and project.version is missing, fallback scanner is not used.
+    A valid project table without a version should return None.
     """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
         '[project]\nname = "mmrelay"\ndynamic = ["version"]\n',
         encoding="utf-8",
     )
-    mock_tomllib = Mock()
-    mock_tomllib.load.return_value = {
-        "project": {"name": "mmrelay", "dynamic": ["version"]}
-    }
-    with (
-        patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject),
-        patch.object(version_helper, "tomllib", new=mock_tomllib),
-        patch.object(
-            type(pyproject),
-            "read_text",
-            side_effect=AssertionError("fallback scanner should not run"),
-        ),
-    ):
+    with patch.object(version_helper, "_find_pyproject_toml", return_value=pyproject):
         assert version_helper._version_from_pyproject() is None
 
 

--- a/tests/test_windows_utils.py
+++ b/tests/test_windows_utils.py
@@ -204,7 +204,7 @@ class TestCheckWindowsRequirements(unittest.TestCase):
         result = check_windows_requirements()
 
         self.assertIsNotNone(result)
-        self.assertIn("Python 3.10+ is required", result)
+        self.assertIn("Python 3.11+ is required", result)
 
     @patch("sys.platform", "win32")
     @patch("sys.version_info", (3, 12, 0))


### PR DESCRIPTION
## Summary by Sourcery

Raise the minimum supported Python version to 3.11 and align runtime checks, dependencies, static analysis, CI configuration, and documentation with the new support floor.

Enhancements:
- Simplify version discovery by relying on the Python 3.11+ standard-library tomllib module and removing Python 3.10-specific fallback parsing logic.
- Update matplotlib dependency to a Python 3.11-compatible release and adjust type-checker configurations (mypy, pyright, ruff) to target Python 3.11.
- Add regression tests to enforce consistency between the declared Python support policy, CI matrix, static analysis configs, and pinned matplotlib version.

CI:
- Update the test-and-coverage workflow matrix to drop Python 3.10, ensure all supported versions run with the full test and e2e extras, and improve pip cache keying by including the Python version.

Documentation:
- Document the Python 3.11 minimum and upgrade guidance in a new What's New in 1.4.0 note and update existing docs, testing guides, and contributor guidance to reflect the new runtime requirement.

Tests:
- Adjust existing tests to reflect Python 3.11+ assumptions and add a dedicated test module that validates the Python 3.11 floor and dependency alignment across project metadata, CI, and tooling.

Chores:
- Update runtime constants and Windows checks to enforce the new Python 3.11 minimum requirement across the application.