### PR TITLE
Update mindroom-nio to 0.34.1 and lock recovery defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "mtjk==2.7.11.post3",
   "Pillow==12.3.0",
   "aiohttp==3.14.3",
-  "mindroom-nio==0.31.0",
+  "mindroom-nio==0.34.1",
   "matplotlib==3.11.1",
   "requests==2.34.2",
   "markdown==3.10.3",
@@ -39,7 +39,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-e2e = ["mindroom-nio[e2e]==0.31.0"]
+e2e = ["mindroom-nio[e2e]==0.34.1"]
 test = [
   "coverage==7.15.3",
   "pytest==9.1.1",

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -42,6 +42,12 @@ TEST_ROOM_ID_2: Final[str] = "!room2:matrix.org"
 # Matrix event IDs
 TEST_EVENT_ID: Final[str] = "$event123"
 
+# Expected mindroom-nio AsyncClientConfig recovery defaults (single source of truth
+# for tests that assert MMRelay leaves limited-timeline recovery disabled).
+# Update here when the pinned provider changes these defaults.
+MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT: Final[bool] = False
+MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT: Final[bool | None] = None
+
 # Test message delay values for message queue testing
 # These are intentionally different from production to test edge cases
 TEST_MESSAGE_DELAY_LOW: Final[float] = (

--- a/tests/test_matrix_client_config.py
+++ b/tests/test_matrix_client_config.py
@@ -8,6 +8,10 @@ import pytest
 
 import mmrelay.matrix.client_config as client_config
 import mmrelay.matrix_utils as matrix_utils
+from tests.constants import (
+    MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT,
+    MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT,
+)
 
 
 @dataclass(frozen=True)
@@ -17,8 +21,8 @@ class _MindroomConfig:
     max_limit_exceeded: int = 10
     max_timeouts: int = 3
     replace_rotated_device_keys: bool = False
-    backfill_limited_timelines: bool = False
-    backfill_persist_recovery: bool | None = None
+    backfill_limited_timelines: bool = MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT
+    backfill_persist_recovery: bool | None = MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT
 
 
 class _MutableNonDataclassConfig:
@@ -68,8 +72,12 @@ def test_e2ee_config_enables_rotated_device_key_recovery(
     assert config.encryption_enabled is True
     assert config.store_sync_tokens is True
     assert config.replace_rotated_device_keys is True
-    assert config.backfill_limited_timelines is False
-    assert config.backfill_persist_recovery is None
+    assert (
+        config.backfill_limited_timelines is MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT
+    )
+    assert (
+        config.backfill_persist_recovery is MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT
+    )
     assert config.max_limit_exceeded == 0
     assert config.max_timeouts == 0
 

--- a/tests/test_matrix_client_config.py
+++ b/tests/test_matrix_client_config.py
@@ -8,10 +8,6 @@ import pytest
 
 import mmrelay.matrix.client_config as client_config
 import mmrelay.matrix_utils as matrix_utils
-from tests.constants import (
-    MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT,
-    MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT,
-)
 
 
 @dataclass(frozen=True)
@@ -21,8 +17,6 @@ class _MindroomConfig:
     max_limit_exceeded: int = 10
     max_timeouts: int = 3
     replace_rotated_device_keys: bool = False
-    backfill_limited_timelines: bool = MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT
-    backfill_persist_recovery: bool | None = MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT
 
 
 class _MutableNonDataclassConfig:
@@ -72,12 +66,6 @@ def test_e2ee_config_enables_rotated_device_key_recovery(
     assert config.encryption_enabled is True
     assert config.store_sync_tokens is True
     assert config.replace_rotated_device_keys is True
-    assert (
-        config.backfill_limited_timelines is MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT
-    )
-    assert (
-        config.backfill_persist_recovery is MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT
-    )
     assert config.max_limit_exceeded == 0
     assert config.max_timeouts == 0
 

--- a/tests/test_matrix_client_config.py
+++ b/tests/test_matrix_client_config.py
@@ -17,6 +17,8 @@ class _MindroomConfig:
     max_limit_exceeded: int = 10
     max_timeouts: int = 3
     replace_rotated_device_keys: bool = False
+    backfill_limited_timelines: bool = False
+    backfill_persist_recovery: bool | None = None
 
 
 class _MutableNonDataclassConfig:
@@ -66,6 +68,8 @@ def test_e2ee_config_enables_rotated_device_key_recovery(
     assert config.encryption_enabled is True
     assert config.store_sync_tokens is True
     assert config.replace_rotated_device_keys is True
+    assert config.backfill_limited_timelines is False
+    assert config.backfill_persist_recovery is None
     assert config.max_limit_exceeded == 0
     assert config.max_timeouts == 0
 

--- a/tests/test_mindroom_nio_runtime_contract.py
+++ b/tests/test_mindroom_nio_runtime_contract.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import subprocess
+import subprocess  # nosec B404 - runs contract check script with hardcoded args in isolated mode
 import sys
 import textwrap
 import tomllib
@@ -10,6 +10,11 @@ from pathlib import Path
 
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
+
+from tests.constants import (
+    MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT,
+    MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = ROOT / "pyproject.toml"
@@ -71,7 +76,6 @@ def _mindroom_pin() -> str:
 
     base_version = _exact_pin(base_requirement)
     e2e_version = _exact_pin(e2e_requirement)
-    assert base_version == "0.34.1"
     assert e2e_version == base_version
     return base_version
 
@@ -106,8 +110,14 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
 
         default_config = AsyncClientConfig()
         assert default_config.replace_rotated_device_keys is False
-        assert default_config.backfill_limited_timelines is False
-        assert default_config.backfill_persist_recovery is None
+        assert (
+            default_config.backfill_limited_timelines
+            is {MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT!r}
+        )
+        assert (
+            default_config.backfill_persist_recovery
+            is {MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT!r}
+        )
         assert default_config.backfill_sliding_seed_rooms == 1000
 
         config = AsyncClientConfig(
@@ -157,6 +167,6 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
         capture_output=True,
         text=True,
         timeout=30,
-    )
+    )  # nosec B603
 
     assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/test_mindroom_nio_runtime_contract.py
+++ b/tests/test_mindroom_nio_runtime_contract.py
@@ -128,6 +128,14 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
         assert config.encryption_enabled is True
         assert config.store_sync_tokens is True
         assert config.replace_rotated_device_keys is True
+        assert (
+            config.backfill_limited_timelines
+            is {MINDROOM_BACKFILL_LIMITED_TIMELINES_DEFAULT!r}
+        )
+        assert (
+            config.backfill_persist_recovery
+            is {MINDROOM_BACKFILL_PERSIST_RECOVERY_DEFAULT!r}
+        )
 
         ensure_parameters = signature(AsyncClient.ensure_cross_signing).parameters
         password = ensure_parameters["password"]

--- a/tests/test_mindroom_nio_runtime_contract.py
+++ b/tests/test_mindroom_nio_runtime_contract.py
@@ -71,7 +71,7 @@ def _mindroom_pin() -> str:
 
     base_version = _exact_pin(base_requirement)
     e2e_version = _exact_pin(e2e_requirement)
-    assert base_version == "0.31.0"
+    assert base_version == "0.34.1"
     assert e2e_version == base_version
     return base_version
 
@@ -82,7 +82,7 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
     expected_version = _mindroom_pin()
     script = textwrap.dedent(f"""
         from importlib import metadata
-        from inspect import Parameter, signature
+        from inspect import Parameter, iscoroutinefunction, signature
 
         import vodozemac
         from nio import AsyncClient, AsyncClientConfig
@@ -102,11 +102,12 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
         assert ENCRYPTION_ENABLED is True
         assert vodozemac.__name__ == "vodozemac"
         assert SqliteStore is not None
-        assert MatrixStore.store_version == 3
+        assert MatrixStore.store_version == 7
 
         default_config = AsyncClientConfig()
         assert default_config.replace_rotated_device_keys is False
         assert default_config.backfill_limited_timelines is False
+        assert default_config.backfill_persist_recovery is None
         assert default_config.backfill_sliding_seed_rooms == 1000
 
         config = AsyncClientConfig(
@@ -128,6 +129,7 @@ def test_installed_mindroom_nio_exposes_mmrelay_e2ee_contract() -> None:
             assert parameter in send_parameters, parameter
 
         assert isinstance(AsyncClient.cross_signing_identity, property)
+        assert iscoroutinefunction(AsyncClient.close)
         for capability in ("ensure_cross_signing", "stop_sync_forever"):
             assert callable(getattr(AsyncClient, capability, None)), capability
 


### PR DESCRIPTION
## Summary by Sourcery

Update mindroom-nio dependency to version 0.34.1 and align runtime and configuration tests with the new defaults.

Enhancements:
- Lock Matrix client recovery-related configuration defaults, including backfill options and store version, to the new mindroom-nio contract.

Build:
- Bump mindroom-nio base and e2e extras dependencies from 0.31.0 to 0.34.1 in project configuration.

Tests:
- Adjust contract and configuration tests to assert the new mindroom-nio version, updated MatrixStore store version, AsyncClient.close being a coroutine, and new backfill recovery defaults.